### PR TITLE
feat(github): add account pause controls

### DIFF
--- a/docs/github-commits.md
+++ b/docs/github-commits.md
@@ -31,14 +31,37 @@ There are only two tables:
 
 - `github_commits` contains repository identity, SHA, pusher, commit time,
   subject line, canonical URL, and persistence time.
-- `github_account_checkpoints` contains the newest assimilated event ID and
-  last successful poll time for each of the two accounts.
+- `github_account_checkpoints` contains the newest assimilated event ID, last
+  successful poll time, and pause state for each of the two accounts.
 
 For each account, the poller reads events newest-first until it reaches the
 saved event ID. It fetches commit metadata, then inserts the commits and advances
 the checkpoint in one transaction. A failed run leaves the checkpoint where it
 was; the next run repeats the same interval. Duplicate webhook deliveries,
 overlap between webhook and polling, and retried cron calls are harmless.
+
+### Pause or resume an account
+
+Set `paused` on the account's checkpoint row. A paused account makes no polling
+API requests, advances no checkpoint, and ignores incoming push webhooks:
+
+```sql
+update github_account_checkpoints
+set paused = true
+where account = 'yuppiestechdev';
+```
+
+Resume it with:
+
+```sql
+update github_account_checkpoints
+set paused = false
+where account = 'yuppiestechdev';
+```
+
+The checkpoint is deliberately preserved while paused. When the account is
+resumed, the next poll assimilates activity since that checkpoint, provided it
+is still inside GitHub's bounded Events API window.
 
 The first run assimilates the activity currently available from GitHub's Events
 API. There is no arbitrary 400-day scan. [GitHub exposes at most 300 events and

--- a/drizzle/0001_shallow_harpoon.sql
+++ b/drizzle/0001_shallow_harpoon.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "github_account_checkpoints" ADD COLUMN "paused" boolean DEFAULT false NOT NULL;

--- a/drizzle/meta/0001_snapshot.json
+++ b/drizzle/meta/0001_snapshot.json
@@ -1,0 +1,174 @@
+{
+  "id": "7f211a6d-7e0d-4f7c-9731-aad3a901d4b4",
+  "prevId": "f8dda5f6-e816-444b-a616-fe5ea230af2e",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.github_account_checkpoints": {
+      "name": "github_account_checkpoints",
+      "schema": "",
+      "columns": {
+        "account": {
+          "name": "account",
+          "type": "varchar(39)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "latest_event_id": {
+          "name": "latest_event_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_polled_at": {
+          "name": "last_polled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "paused": {
+          "name": "paused",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "github_account_checkpoints_tracked_account": {
+          "name": "github_account_checkpoints_tracked_account",
+          "value": "\"github_account_checkpoints\".\"account\" IN ('f0rr0', 'yuppiestechdev')"
+        },
+        "github_account_checkpoints_event_id_shape": {
+          "name": "github_account_checkpoints_event_id_shape",
+          "value": "\"github_account_checkpoints\".\"latest_event_id\" IS NULL OR \"github_account_checkpoints\".\"latest_event_id\" ~ '^[0-9]{1,64}$'"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.github_commits": {
+      "name": "github_commits",
+      "schema": "",
+      "columns": {
+        "committed_at": {
+          "name": "committed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "persisted_at": {
+          "name": "persisted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "repository": {
+          "name": "repository",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pushed_by": {
+          "name": "pushed_by",
+          "type": "varchar(39)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sha": {
+          "name": "sha",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "github_commits_committed_at_idx": {
+          "name": "github_commits_committed_at_idx",
+          "columns": [
+            {
+              "expression": "committed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_commits_pushed_by_idx": {
+          "name": "github_commits_pushed_by_idx",
+          "columns": [
+            {
+              "expression": "pushed_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "github_commits_repository_id_sha_pk": {
+          "name": "github_commits_repository_id_sha_pk",
+          "columns": ["repository_id", "sha"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "github_commits_sha_shape": {
+          "name": "github_commits_sha_shape",
+          "value": "\"github_commits\".\"sha\" ~ '^[a-f0-9]{40}$'"
+        },
+        "github_commits_tracked_pusher": {
+          "name": "github_commits_tracked_pusher",
+          "value": "\"github_commits\".\"pushed_by\" IN ('f0rr0', 'yuppiestechdev')"
+        }
+      },
+      "isRLSEnabled": true
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1787738037804,
       "tag": "0000_superb_the_fury",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1787740477101,
+      "tag": "0001_shallow_harpoon",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -1,5 +1,6 @@
 import { sql } from "drizzle-orm";
 import {
+  boolean,
   check,
   index,
   pgTable,
@@ -52,6 +53,7 @@ export const githubAccountCheckpoints = pgTable(
     })
       .defaultNow()
       .notNull(),
+    paused: boolean("paused").default(false).notNull(),
   },
   (table) => [
     check(

--- a/src/lib/github-commits-store.ts
+++ b/src/lib/github-commits-store.ts
@@ -16,13 +16,21 @@ export class CheckpointConflictError extends Error {
 
 export interface GitHubAccountCheckpoint {
   latestEventId: string | null;
+  paused: boolean;
 }
+
+export const isGitHubAccountPaused = (
+  checkpoint: GitHubAccountCheckpoint | null
+) => checkpoint?.paused === true;
 
 export const readGitHubAccountCheckpoint = async (
   account: TrackedGitHubAccount
 ): Promise<GitHubAccountCheckpoint | null> => {
   const [checkpoint] = await getDatabase()
-    .select({ latestEventId: githubAccountCheckpoints.latestEventId })
+    .select({
+      latestEventId: githubAccountCheckpoints.latestEventId,
+      paused: githubAccountCheckpoints.paused,
+    })
     .from(githubAccountCheckpoints)
     .where(eq(githubAccountCheckpoints.account, account))
     .limit(1);
@@ -101,7 +109,8 @@ export const persistAccountSync = async (input: {
       .where(
         and(
           eq(githubAccountCheckpoints.account, input.account),
-          checkpointCondition
+          checkpointCondition,
+          eq(githubAccountCheckpoints.paused, input.expectedCheckpoint.paused)
         )
       )
       .returning({ account: githubAccountCheckpoints.account });

--- a/src/lib/github-commits.ts
+++ b/src/lib/github-commits.ts
@@ -15,6 +15,7 @@ import type {
 } from "@/lib/github-commits-core";
 import {
   CheckpointConflictError,
+  isGitHubAccountPaused,
   persistAccountSync,
   persistGitHubCommits,
   readGitHubAccountCheckpoint,
@@ -38,6 +39,7 @@ export interface GitHubAccountSyncResult {
   checkpointChanged: boolean;
   commits: number;
   events: number;
+  paused: boolean;
 }
 
 export interface GitHubSyncResult {
@@ -45,6 +47,7 @@ export interface GitHubSyncResult {
   checkpoints: number;
   commits: number;
   events: number;
+  paused: number;
 }
 
 export class GitHubSyncConfigurationError extends Error {
@@ -298,20 +301,33 @@ const collectNewEvents = async (
 export const syncGitHubAccount = async (
   account: TrackedGitHubAccount
 ): Promise<GitHubAccountSyncResult> => {
-  const token = tokenFor(account);
-  await assertTokenIdentity(account, token);
+  let token: string | null = null;
 
   for (let attempt = 0; attempt < CHECKPOINT_ATTEMPTS; attempt += 1) {
     const checkpoint = await readGitHubAccountCheckpoint(account);
+    if (isGitHubAccountPaused(checkpoint)) {
+      return {
+        account,
+        checkpointChanged: false,
+        commits: 0,
+        events: 0,
+        paused: true,
+      };
+    }
+    if (token === null) {
+      token = tokenFor(account);
+      await assertTokenIdentity(account, token);
+    }
+    const activeToken = token;
     const collected = await collectNewEvents(
       account,
-      token,
+      activeToken,
       checkpoint?.latestEventId ?? null
     );
     const commits = (
       await fetchInBatches(
         collected.pushes,
-        async (push) => await collectPushCommits(push, token)
+        async (push) => await collectPushCommits(push, activeToken)
       )
     ).flat();
 
@@ -328,6 +344,7 @@ export const syncGitHubAccount = async (
           collected.latestEventId !== (checkpoint?.latestEventId ?? null),
         commits: persisted,
         events: collected.events,
+        paused: false,
       };
     } catch (error) {
       if (
@@ -357,10 +374,15 @@ export const syncGitHubAccounts = async (): Promise<GitHubSyncResult> => {
     checkpoints: results.filter((result) => result.checkpointChanged).length,
     commits: results.reduce((total, result) => total + result.commits, 0),
     events: results.reduce((total, result) => total + result.events, 0),
+    paused: results.filter((result) => result.paused).length,
   };
 };
 
 export const syncGitHubWebhookPush = async (push: GitHubPush) => {
+  const checkpoint = await readGitHubAccountCheckpoint(push.pushedBy);
+  if (isGitHubAccountPaused(checkpoint)) {
+    return 0;
+  }
   const needsGitHubRequest =
     push.size === null ||
     push.commits.length < push.size ||

--- a/tests/github-commits.test.mjs
+++ b/tests/github-commits.test.mjs
@@ -7,6 +7,7 @@ import {
   pushFromWebhook,
   repositoryFrom,
 } from "../src/lib/github-commits-core.ts";
+import { isGitHubAccountPaused } from "../src/lib/github-commits-store.ts";
 
 const sha = "a".repeat(40);
 const before = "b".repeat(40);
@@ -264,5 +265,17 @@ describe("token identity", () => {
       "yuppiestechdev"
     );
     expect(authenticatedGitHubAccountFrom({ login: "someone" })).toBeNull();
+  });
+});
+
+describe("account pause state", () => {
+  test("skips only checkpoints explicitly marked as paused", () => {
+    expect(
+      isGitHubAccountPaused({ latestEventId: "123456789", paused: true })
+    ).toBe(true);
+    expect(
+      isGitHubAccountPaused({ latestEventId: "123456789", paused: false })
+    ).toBe(false);
+    expect(isGitHubAccountPaused(null)).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- add a persisted `paused` flag to GitHub account checkpoints
- skip polling and webhook ingestion while an account is paused
- preserve the checkpoint so unpausing catches up missed activity
- document the database controls and add regression coverage

## Verification
- `bun test`
- `bun run typecheck`
- `bun run lint`
- `bunx drizzle-kit check`
- `bun run build`
- applied migration and verified pause/unpause against Supabase