### PR TITLE
fix(github): use GitHub activity counters

### DIFF
--- a/docs/github-activity-public-commit-summaries.md
+++ b/docs/github-activity-public-commit-summaries.md
@@ -11,10 +11,10 @@ the assimilated-event checkpoints remain unchanged.
 ```text
 verified tracked-author commit
   -> fetch title, cleaned body, changed filenames/statuses, and available diffs
-  -> count additions/deletions directly from available unified patches
-  -> derive languages and substantive churn in application code
+  -> read commit-wide and per-file additions/deletions from GitHub
+  -> derive languages and substantive churn from the per-file counters
   -> one gpt-5-nano call producing both public summary lengths
-  -> persist the summaries, recipe/model/input hash, languages, and churn
+  -> persist both Nano summaries, recipe/model/input hash, languages, and churn
   -> show the headline for low-churn commits; otherwise show short
 ```
 
@@ -61,10 +61,15 @@ attempt for explicit operational inspection and omitted from the public feed.
 It is not retried inside or after the request. Raw patches are not persisted
 because the source can be fetched again from GitHub.
 
-Patch additions and deletions are parsed from actual `+` and `-` lines while
-excluding unified-diff file headers. GitHub's aggregate counters are not used.
-When GitHub omits a non-binary patch, the visible count is stored and displayed
-as partial rather than replaced with an unrelated aggregate.
+The displayed additions and deletions are GitHub's commit-wide `stats` values.
+The headline threshold and language weights use GitHub's per-file additions and
+deletions so generated output, lockfiles, vendored files, and binary assets can
+still be excluded procedurally. Missing or truncated patch text does not make
+these counts partial. Patch text is used only as Nano evidence.
+
+Both Nano outputs are persisted in `summary_headline` and `summary_short` along
+with their exact model snapshot, prompt recipe, and input hash. The page chooses
+between the two stored values without another model call.
 
 ## Timeline presentation
 

--- a/docs/github-commits.md
+++ b/docs/github-commits.md
@@ -36,7 +36,7 @@ There are only two tables:
 
 - `github_commits` starts with repository ID/full name, SHA, verified tracked
   author, commit time, and commit subject. Processing adds repository
-  visibility/owner display facts, patch-derived line counts and languages, two
+  visibility/owner display facts, GitHub-reported line counts and languages, two
   public summaries, and the model/recipe/input hash needed to audit them. It
   never stores patches, trees, blobs, or webhook payloads.
 - `github_account_checkpoints` contains only the account, newest assimilated
@@ -50,7 +50,7 @@ overlap between webhook and polling, and retried cron calls are harmless.
 
 After ingestion commits successfully, the same invocation claims up to eight
 newest unprocessed rows. Each row re-fetches its current repository and commit
-evidence, derives facts from the patch, and makes exactly one summary call.
+evidence, derives facts from GitHub's counters, and makes exactly one summary call.
 Claiming is conditional, so webhook and cron invocations cannot process the same
 row concurrently. A failed attempt is terminal and omitted from the public feed;
 there is no automatic model retry or duplicate billing loop.
@@ -105,6 +105,18 @@ Apply the schema explicitly:
 ```sh
 bun run db:migrate
 ```
+
+After migrating existing activity from patch-derived counts to GitHub's native
+counters, refresh only the stored deterministic facts—without making Nano
+calls—with:
+
+```sh
+bun run github:refresh-counters
+```
+
+The migration clears the old patch-derived values first. If GitHub can no longer
+serve an existing commit, that item stays out of the public feed instead of
+presenting the old values as GitHub counters.
 
 This migration intentionally removes the earlier experimental timeline tables
 and any intermediate commit/checkpoint tables. Their data can be rebuilt from
@@ -224,8 +236,8 @@ Repository presentation is deliberately separate from stored source data:
 
 The client never receives repository IDs, SHAs, full repository names, author
 handles, raw commit messages, file paths, or patches. Each UTC date is rendered
-as a section. Commits with at most 25 substantive patch lines use the headline;
-larger commits use the detailed summary.
+as a section. Commits with at most 25 substantive GitHub-reported changed lines
+use the stored headline; larger commits use the stored detailed summary.
 
 ## Deliberate limits
 

--- a/drizzle/0005_glamorous_karnak.sql
+++ b/drizzle/0005_glamorous_karnak.sql
@@ -1,0 +1,6 @@
+ALTER TABLE "github_commits" RENAME COLUMN "patch_additions" TO "additions";--> statement-breakpoint
+ALTER TABLE "github_commits" RENAME COLUMN "patch_deletions" TO "deletions";--> statement-breakpoint
+UPDATE "github_commits" SET "additions" = NULL, "deletions" = NULL;--> statement-breakpoint
+ALTER TABLE "github_commits" DROP CONSTRAINT "github_commits_nonnegative_activity_counts";--> statement-breakpoint
+ALTER TABLE "github_commits" DROP COLUMN "patches_complete";--> statement-breakpoint
+ALTER TABLE "github_commits" ADD CONSTRAINT "github_commits_nonnegative_activity_counts" CHECK (("github_commits"."changed_files" IS NULL OR "github_commits"."changed_files" >= 0) AND ("github_commits"."additions" IS NULL OR "github_commits"."additions" >= 0) AND ("github_commits"."deletions" IS NULL OR "github_commits"."deletions" >= 0) AND ("github_commits"."substantive_loc" IS NULL OR "github_commits"."substantive_loc" >= 0));

--- a/drizzle/meta/0005_snapshot.json
+++ b/drizzle/meta/0005_snapshot.json
@@ -1,0 +1,314 @@
+{
+  "id": "1b566a46-0a5e-4b9e-a80e-a8ca63c95344",
+  "prevId": "cfacc574-8776-4c14-8ccd-4894cb59e37d",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.github_account_checkpoints": {
+      "name": "github_account_checkpoints",
+      "schema": "",
+      "columns": {
+        "account": {
+          "name": "account",
+          "type": "varchar(39)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "latest_event_id": {
+          "name": "latest_event_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "paused": {
+          "name": "paused",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "github_account_checkpoints_tracked_account": {
+          "name": "github_account_checkpoints_tracked_account",
+          "value": "\"github_account_checkpoints\".\"account\" IN ('f0rr0', 'yuppiestechdev')"
+        },
+        "github_account_checkpoints_event_id_shape": {
+          "name": "github_account_checkpoints_event_id_shape",
+          "value": "\"github_account_checkpoints\".\"latest_event_id\" IS NULL OR \"github_account_checkpoints\".\"latest_event_id\" ~ '^[0-9]{1,64}$'"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.github_commits": {
+      "name": "github_commits",
+      "schema": "",
+      "columns": {
+        "activity_public_id": {
+          "name": "activity_public_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "additions": {
+          "name": "additions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_login": {
+          "name": "author_login",
+          "type": "varchar(39)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changed_files": {
+          "name": "changed_files",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "committed_at": {
+          "name": "committed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deletions": {
+          "name": "deletions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "languages": {
+          "name": "languages",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository": {
+          "name": "repository",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository_owner_avatar_url": {
+          "name": "repository_owner_avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repository_owner_login": {
+          "name": "repository_owner_login",
+          "type": "varchar(39)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repository_owner_type": {
+          "name": "repository_owner_type",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repository_private": {
+          "name": "repository_private",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sha": {
+          "name": "sha",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "substantive_loc": {
+          "name": "substantive_loc",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary_attempted_at": {
+          "name": "summary_attempted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary_error": {
+          "name": "summary_error",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary_headline": {
+          "name": "summary_headline",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary_input_hash": {
+          "name": "summary_input_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary_model": {
+          "name": "summary_model",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary_recipe": {
+          "name": "summary_recipe",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary_short": {
+          "name": "summary_short",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "github_commits_activity_public_id_unique": {
+          "name": "github_commits_activity_public_id_unique",
+          "columns": [
+            {
+              "expression": "activity_public_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_commits_activity_cursor_idx": {
+          "name": "github_commits_activity_cursor_idx",
+          "columns": [
+            {
+              "expression": "committed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "activity_public_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_commits_committed_at_idx": {
+          "name": "github_commits_committed_at_idx",
+          "columns": [
+            {
+              "expression": "committed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_commits_summary_pending_idx": {
+          "name": "github_commits_summary_pending_idx",
+          "columns": [
+            {
+              "expression": "summary_attempted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "committed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "github_commits_repository_id_sha_pk": {
+          "name": "github_commits_repository_id_sha_pk",
+          "columns": ["repository_id", "sha"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "github_commits_sha_shape": {
+          "name": "github_commits_sha_shape",
+          "value": "\"github_commits\".\"sha\" ~ '^[a-f0-9]{40}$'"
+        },
+        "github_commits_tracked_author": {
+          "name": "github_commits_tracked_author",
+          "value": "\"github_commits\".\"author_login\" IN ('f0rr0', 'yuppiestechdev')"
+        },
+        "github_commits_nonnegative_activity_counts": {
+          "name": "github_commits_nonnegative_activity_counts",
+          "value": "(\"github_commits\".\"changed_files\" IS NULL OR \"github_commits\".\"changed_files\" >= 0) AND (\"github_commits\".\"additions\" IS NULL OR \"github_commits\".\"additions\" >= 0) AND (\"github_commits\".\"deletions\" IS NULL OR \"github_commits\".\"deletions\" >= 0) AND (\"github_commits\".\"substantive_loc\" IS NULL OR \"github_commits\".\"substantive_loc\" >= 0)"
+        },
+        "github_commits_owner_type": {
+          "name": "github_commits_owner_type",
+          "value": "\"github_commits\".\"repository_owner_type\" IS NULL OR \"github_commits\".\"repository_owner_type\" IN ('Organization', 'User')"
+        },
+        "github_commits_summary_hash_shape": {
+          "name": "github_commits_summary_hash_shape",
+          "value": "\"github_commits\".\"summary_input_hash\" IS NULL OR \"github_commits\".\"summary_input_hash\" ~ '^[a-f0-9]{64}$'"
+        },
+        "github_commits_summary_pair": {
+          "name": "github_commits_summary_pair",
+          "value": "(\"github_commits\".\"summary_headline\" IS NULL) = (\"github_commits\".\"summary_short\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": true
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1787918582569,
       "tag": "0004_serious_sphinx",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "7",
+      "when": 1787921146709,
+      "tag": "0005_glamorous_karnak",
+      "breakpoints": true
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "db:migrate": "drizzle-kit migrate",
     "db:studio": "drizzle-kit studio",
     "github:sync": "bun scripts/sync-github-commits.ts",
+    "github:refresh-counters": "bun scripts/refresh-github-activity-counters.ts",
     "supabase:cron": "bun scripts/configure-supabase-cron.ts"
   },
   "dependencies": {

--- a/scripts/refresh-github-activity-counters.ts
+++ b/scripts/refresh-github-activity-counters.ts
@@ -1,0 +1,40 @@
+import { closeDatabase } from "../src/db/client";
+import { fetchGitHubActivityCommitSource } from "../src/lib/github-activity-processor";
+import {
+  deriveCommitLanguages,
+  substantiveCommitLoc,
+} from "../src/lib/github-activity-public-summary";
+import {
+  readCompletedGitHubActivityCommits,
+  updateGitHubActivityCounters,
+} from "../src/lib/github-activity-store";
+
+let completed = 0;
+let failed = 0;
+
+try {
+  const commits = await readCompletedGitHubActivityCommits();
+  for (const commit of commits) {
+    try {
+      const source = await fetchGitHubActivityCommitSource(commit);
+      await updateGitHubActivityCounters(commit, {
+        additions: source.commit.stats.additions,
+        changedFiles: source.commit.files.length,
+        deletions: source.commit.stats.deletions,
+        languages: deriveCommitLanguages(source.commit.files),
+        substantiveLoc: substantiveCommitLoc(source.commit.files),
+      });
+      completed += 1;
+    } catch {
+      failed += 1;
+    }
+  }
+  process.stdout.write(
+    `${JSON.stringify({ completed, failed, total: commits.length })}\n`
+  );
+  if (failed > 0) {
+    process.exitCode = 1;
+  }
+} finally {
+  await closeDatabase();
+}

--- a/scripts/sample-nano-public-summaries.ts
+++ b/scripts/sample-nano-public-summaries.ts
@@ -171,7 +171,8 @@ const fetchCommitWithToken = async (
     root === null ||
     !isObject(root.commit) ||
     !isObject(root.author) ||
-    !isObject(root.commit.author)
+    !isObject(root.commit.author) ||
+    !isObject(root.stats)
   ) {
     throw new Error("GitHub returned incomplete commit evidence.");
   }
@@ -181,6 +182,12 @@ const fetchCommitWithToken = async (
     throw new Error("The live commit no longer matches its stored provenance.");
   }
   const committedAt = requiredString(root.commit.author.date, "commit date");
+  const additions = requiredInteger(root.stats.additions, "commit additions");
+  const deletions = requiredInteger(root.stats.deletions, "commit deletions");
+  const total = requiredInteger(root.stats.total, "commit changed lines");
+  if (total !== additions + deletions) {
+    throw new Error("GitHub returned inconsistent commit statistics.");
+  }
   const parents = Array.isArray(root.parents)
     ? root.parents.map((parent) => {
         if (!isObject(parent)) {
@@ -197,6 +204,7 @@ const fetchCommitWithToken = async (
     message: requiredString(root.commit.message, "commit message"),
     parents,
     sha,
+    stats: { additions, deletions, total },
   };
 };
 

--- a/src/components/github-timeline.tsx
+++ b/src/components/github-timeline.tsx
@@ -85,9 +85,6 @@ function ActivityEntry({ item }: Readonly<{ item: PublicGitHubActivityItem }>) {
   const visibleLanguages = item.languages.slice(0, 6);
   const hiddenLanguageCount = item.languages.length - visibleLanguages.length;
   const repositoryLabel = item.repositoryLabel ?? "Private contribution";
-  const locTitle = item.locComplete
-    ? "Lines counted directly from the GitHub patch"
-    : "Lines visible in the available GitHub patch; some file patches were unavailable";
 
   return (
     <li className="github-activity-entry">
@@ -151,10 +148,12 @@ function ActivityEntry({ item }: Readonly<{ item: PublicGitHubActivityItem }>) {
         )}
 
         <div className="github-activity-facts">
-          <span className="github-activity-loc" title={locTitle}>
+          <span
+            className="github-activity-loc"
+            title="Lines added and deleted according to GitHub"
+          >
             <span className="github-activity-additions">+{item.additions}</span>
             <span className="github-activity-deletions">−{item.deletions}</span>
-            {item.locComplete ? null : <span>partial</span>}
           </span>
           <span>
             {item.changedFiles} {item.changedFiles === 1 ? "file" : "files"}

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -20,17 +20,16 @@ export const githubCommits = pgTable(
   "github_commits",
   {
     activityPublicId: uuid("activity_public_id"),
+    additions: integer("additions"),
     author: varchar("author_login", { length: 39 }).notNull(),
     changedFiles: integer("changed_files"),
     committedAt: timestamp("committed_at", {
       mode: "date",
       withTimezone: true,
     }).notNull(),
+    deletions: integer("deletions"),
     languages: jsonb("languages").$type<readonly PublicCommitLanguage[]>(),
     message: text("message").notNull(),
-    patchAdditions: integer("patch_additions"),
-    patchDeletions: integer("patch_deletions"),
-    patchesComplete: boolean("patches_complete"),
     repository: varchar("repository", { length: 200 }).notNull(),
     repositoryId: varchar("repository_id", { length: 32 }).notNull(),
     repositoryOwnerAvatarUrl: text("repository_owner_avatar_url"),
@@ -71,7 +70,7 @@ export const githubCommits = pgTable(
     ),
     check(
       "github_commits_nonnegative_activity_counts",
-      sql`(${table.changedFiles} IS NULL OR ${table.changedFiles} >= 0) AND (${table.patchAdditions} IS NULL OR ${table.patchAdditions} >= 0) AND (${table.patchDeletions} IS NULL OR ${table.patchDeletions} >= 0) AND (${table.substantiveLoc} IS NULL OR ${table.substantiveLoc} >= 0)`
+      sql`(${table.changedFiles} IS NULL OR ${table.changedFiles} >= 0) AND (${table.additions} IS NULL OR ${table.additions} >= 0) AND (${table.deletions} IS NULL OR ${table.deletions} >= 0) AND (${table.substantiveLoc} IS NULL OR ${table.substantiveLoc} >= 0)`
     ),
     check(
       "github_commits_owner_type",

--- a/src/lib/github-activity-processor.ts
+++ b/src/lib/github-activity-processor.ts
@@ -7,7 +7,6 @@ import {
   buildCommitPublicSummaryModelInput,
   deriveCommitLanguages,
   parseCommitPublicSummary,
-  patchCommitLoc,
   PUBLIC_COMMIT_SUMMARY_MAX_OUTPUT_TOKENS,
   PUBLIC_COMMIT_SUMMARY_RECIPE,
   PUBLIC_COMMIT_SUMMARY_SYSTEM_PROMPT,
@@ -51,7 +50,7 @@ interface RepositoryEvidence {
   private: boolean;
 }
 
-interface CommitSource {
+export interface GitHubActivityCommitSource {
   commit: PublicCommitEvidence;
   repository: RepositoryEvidence;
 }
@@ -200,7 +199,8 @@ const commitEvidenceFrom = (
   if (
     !isObject(root.commit) ||
     !isObject(root.commit.author) ||
-    !isObject(root.author)
+    !isObject(root.author) ||
+    !isObject(root.stats)
   ) {
     throw new ActivityProcessingError(
       "source_invalid",
@@ -235,19 +235,29 @@ const commitEvidenceFrom = (
         return requiredString(parent.sha, "parent SHA").toLowerCase();
       })
     : [];
+  const additions = requiredInteger(root.stats.additions, "commit additions");
+  const deletions = requiredInteger(root.stats.deletions, "commit deletions");
+  const total = requiredInteger(root.stats.total, "commit changed lines");
+  if (total !== additions + deletions) {
+    throw new ActivityProcessingError(
+      "source_invalid",
+      "GitHub returned inconsistent commit statistics."
+    );
+  }
   return {
     committedAt: committedAt.toISOString(),
     files,
     message: requiredString(root.commit.message, "commit message"),
     parents,
     sha,
+    stats: { additions, deletions, total },
   };
 };
 
 const fetchCommitSourceWithToken = async (
   row: ClaimedGitHubActivityCommit,
   token: string
-): Promise<CommitSource> => {
+): Promise<GitHubActivityCommitSource> => {
   const repositoryPayload = await fetchJson(
     repositoryApiPath(row.repository),
     token
@@ -305,7 +315,9 @@ const fetchCommitSourceWithToken = async (
   };
 };
 
-const fetchCommitSource = async (row: ClaimedGitHubActivityCommit) => {
+export const fetchGitHubActivityCommitSource = async (
+  row: ClaimedGitHubActivityCommit
+) => {
   const tokens = tokenCandidatesFor(row.author);
   if (tokens.length === 0) {
     throw new ActivityProcessingError(
@@ -368,7 +380,7 @@ const modelFailureCode = (error: unknown) => {
 
 const processClaimedCommit = async (row: ClaimedGitHubActivityCommit) => {
   try {
-    const source = await fetchCommitSource(row);
+    const source = await fetchGitHubActivityCommitSource(row);
     let generated: Awaited<ReturnType<typeof generateCommitSummary>>;
     try {
       generated = await generateCommitSummary(source.commit);
@@ -405,14 +417,12 @@ const processClaimedCommit = async (row: ClaimedGitHubActivityCommit) => {
         validationErrors.join(" ")
       );
     }
-    const loc = patchCommitLoc(source.commit.files);
     await completeGitHubActivity(row, {
       activityPublicId: randomUUID(),
+      additions: source.commit.stats.additions,
       changedFiles: source.commit.files.length,
+      deletions: source.commit.stats.deletions,
       languages: deriveCommitLanguages(source.commit.files),
-      patchAdditions: loc.additions,
-      patchDeletions: loc.deletions,
-      patchesComplete: loc.complete,
       repository: source.repository.fullName,
       repositoryOwnerAvatarUrl: source.repository.avatarUrl,
       repositoryOwnerLogin: source.repository.ownerLogin,

--- a/src/lib/github-activity-public-summary.ts
+++ b/src/lib/github-activity-public-summary.ts
@@ -31,8 +31,6 @@ const lockfilePattern =
   /(?:^|\/)(?:bun\.lockb?|cargo\.lock|composer\.lock|gemfile\.lock|go\.sum|package-lock\.json|pipfile\.lock|pnpm-lock\.ya?ml|poetry\.lock|uv\.lock|yarn\.lock)$/iu;
 const binaryAssetPattern =
   /\.(?:7z|avif|bmp|eot|gif|gz|ico|jpe?g|mov|mp3|mp4|ogg|otf|pdf|png|tar|tiff?|ttf|wav|webm|webp|woff2?|zip)$/iu;
-const unifiedHeaderPattern =
-  /^(?:--- (?:a\/|\/dev\/null)|\+\+\+ (?:b\/|\/dev\/null))/u;
 
 const languageByExtension: Readonly<
   Record<string, { id: string; label: string }>
@@ -111,6 +109,7 @@ export interface PublicCommitEvidence {
   message: string;
   parents: readonly string[];
   sha: string;
+  stats: PublicCommitStats;
 }
 
 export interface PublicCommitLanguage {
@@ -119,9 +118,8 @@ export interface PublicCommitLanguage {
   label: string;
 }
 
-export interface PublicCommitPatchLoc {
+export interface PublicCommitStats {
   additions: number;
-  complete: boolean;
   deletions: number;
   total: number;
 }
@@ -285,24 +283,6 @@ export const parseCommitPublicSummary = (
   return { headline, short };
 };
 
-export const patchFileLoc = (patch: string | null) => {
-  let additions = 0;
-  let deletions = 0;
-  if (patch !== null) {
-    for (const line of patch.split("\n")) {
-      if (unifiedHeaderPattern.test(line)) {
-        continue;
-      }
-      if (line.startsWith("+")) {
-        additions += 1;
-      } else if (line.startsWith("-")) {
-        deletions += 1;
-      }
-    }
-  }
-  return { additions, deletions, total: additions + deletions };
-};
-
 export const deriveCommitLanguages = (
   files: readonly PublicCommitFileEvidence[]
 ): readonly PublicCommitLanguage[] => {
@@ -317,7 +297,7 @@ export const deriveCommitLanguages = (
     if (language === undefined) {
       continue;
     }
-    const changedLines = patchFileLoc(file.patch).total;
+    const changedLines = file.additions + file.deletions;
     if (changedLines === 0) {
       continue;
     }
@@ -340,32 +320,10 @@ export const substantiveCommitLoc = (
   let total = 0;
   for (const file of files) {
     if (isSubstantiveFile(file)) {
-      total += patchFileLoc(file.patch).total;
+      total += file.additions + file.deletions;
     }
   }
   return total;
-};
-
-export const patchCommitLoc = (
-  files: readonly PublicCommitFileEvidence[]
-): PublicCommitPatchLoc => {
-  let additions = 0;
-  let deletions = 0;
-  let complete = true;
-  for (const file of files) {
-    const fileLoc = patchFileLoc(file.patch);
-    additions += fileLoc.additions;
-    deletions += fileLoc.deletions;
-    if (file.patch === null && !binaryAssetPattern.test(file.filename)) {
-      complete = false;
-    }
-  }
-  return {
-    additions,
-    complete,
-    deletions,
-    total: additions + deletions,
-  };
 };
 
 const checkedThreshold = (threshold: number) => {

--- a/src/lib/github-activity-store.ts
+++ b/src/lib/github-activity-store.ts
@@ -27,11 +27,10 @@ export interface ClaimedGitHubActivityCommit {
 
 export interface CompletedGitHubActivity {
   activityPublicId: string;
+  additions: number;
   changedFiles: number;
+  deletions: number;
   languages: readonly PublicCommitLanguage[];
-  patchAdditions: number;
-  patchDeletions: number;
-  patchesComplete: boolean;
   repository: string;
   repositoryOwnerAvatarUrl: string | null;
   repositoryOwnerLogin: string;
@@ -43,6 +42,14 @@ export interface CompletedGitHubActivity {
   summaryModel: string;
   summaryRecipe: string;
   summaryShort: string;
+}
+
+export interface GitHubActivityCounters {
+  additions: number;
+  changedFiles: number;
+  deletions: number;
+  languages: readonly PublicCommitLanguage[];
+  substantiveLoc: number;
 }
 
 const commitIdentity = (commit: { repositoryId: string; sha: string }) =>
@@ -105,11 +112,10 @@ export const completeGitHubActivity = async (
     .update(githubCommits)
     .set({
       activityPublicId: activity.activityPublicId,
+      additions: activity.additions,
       changedFiles: activity.changedFiles,
+      deletions: activity.deletions,
       languages: activity.languages,
-      patchAdditions: activity.patchAdditions,
-      patchDeletions: activity.patchDeletions,
-      patchesComplete: activity.patchesComplete,
       repository: activity.repository,
       repositoryOwnerAvatarUrl: activity.repositoryOwnerAvatarUrl,
       repositoryOwnerLogin: activity.repositoryOwnerLogin,
@@ -150,6 +156,48 @@ export const failGitHubActivity = async (
         isNull(githubCommits.summaryHeadline)
       )
     );
+};
+
+export const readCompletedGitHubActivityCommits = async (): Promise<
+  readonly ClaimedGitHubActivityCommit[]
+> => {
+  const rows = await getDatabase()
+    .select({
+      author: githubCommits.author,
+      committedAt: githubCommits.committedAt,
+      message: githubCommits.message,
+      repository: githubCommits.repository,
+      repositoryId: githubCommits.repositoryId,
+      sha: githubCommits.sha,
+    })
+    .from(githubCommits)
+    .where(isNotNull(githubCommits.summaryHeadline))
+    .orderBy(desc(githubCommits.committedAt), desc(githubCommits.sha));
+  return rows.map((row) => ({
+    ...row,
+    author: row.author as TrackedGitHubAccount,
+    committedAt: row.committedAt.toISOString(),
+  }));
+};
+
+export const updateGitHubActivityCounters = async (
+  commit: ClaimedGitHubActivityCommit,
+  counters: GitHubActivityCounters
+) => {
+  const [updated] = await getDatabase()
+    .update(githubCommits)
+    .set(counters)
+    .where(
+      and(
+        commitIdentity(commit),
+        isNotNull(githubCommits.summaryHeadline),
+        isNotNull(githubCommits.summaryShort)
+      )
+    )
+    .returning({ repositoryId: githubCommits.repositoryId });
+  if (updated === undefined) {
+    throw new Error("The completed GitHub activity commit changed.");
+  }
 };
 
 const safeAvatarUrl = (value: string | null) => {
@@ -196,12 +244,11 @@ export const readPublicGitHubActivityPage = async (
   const rows = await getDatabase()
     .select({
       activityPublicId: githubCommits.activityPublicId,
+      additions: githubCommits.additions,
       changedFiles: githubCommits.changedFiles,
       committedAt: githubCommits.committedAt,
+      deletions: githubCommits.deletions,
       languages: githubCommits.languages,
-      patchAdditions: githubCommits.patchAdditions,
-      patchDeletions: githubCommits.patchDeletions,
-      patchesComplete: githubCommits.patchesComplete,
       repository: githubCommits.repository,
       repositoryOwnerAvatarUrl: githubCommits.repositoryOwnerAvatarUrl,
       repositoryOwnerLogin: githubCommits.repositoryOwnerLogin,
@@ -219,9 +266,8 @@ export const readPublicGitHubActivityPage = async (
         isNotNull(githubCommits.summaryShort),
         isNotNull(githubCommits.repositoryOwnerLogin),
         isNotNull(githubCommits.repositoryPrivate),
-        isNotNull(githubCommits.patchAdditions),
-        isNotNull(githubCommits.patchDeletions),
-        isNotNull(githubCommits.patchesComplete),
+        isNotNull(githubCommits.additions),
+        isNotNull(githubCommits.deletions),
         isNotNull(githubCommits.changedFiles),
         isNotNull(githubCommits.substantiveLoc),
         cursorCondition
@@ -238,10 +284,9 @@ export const readPublicGitHubActivityPage = async (
   const items = pageRows.map((row) => {
     if (
       row.activityPublicId === null ||
+      row.additions === null ||
       row.changedFiles === null ||
-      row.patchAdditions === null ||
-      row.patchDeletions === null ||
-      row.patchesComplete === null ||
+      row.deletions === null ||
       row.repositoryOwnerLogin === null ||
       row.repositoryPrivate === null ||
       row.substantiveLoc === null ||
@@ -261,17 +306,16 @@ export const readPublicGitHubActivityPage = async (
         ? "headline"
         : "short";
     return {
-      additions: row.patchAdditions,
+      additions: row.additions,
       avatarUrl: safeAvatarUrl(row.repositoryOwnerAvatarUrl),
       changedFiles: row.changedFiles,
       committedAt: row.committedAt.toISOString(),
-      deletions: row.patchDeletions,
+      deletions: row.deletions,
       id: row.activityPublicId,
       languages: (row.languages ?? []).map((language) => ({
         ...language,
         iconUrl: publicLanguageIconUrl(language.id),
       })),
-      locComplete: row.patchesComplete,
       repositoryLabel: repository.repositoryLabel,
       summary:
         summaryKind === "headline" ? row.summaryHeadline : row.summaryShort,

--- a/src/lib/github-activity-types.ts
+++ b/src/lib/github-activity-types.ts
@@ -13,7 +13,6 @@ export interface PublicGitHubActivityItem {
   deletions: number;
   id: string;
   languages: readonly PublicGitHubActivityLanguage[];
-  locComplete: boolean;
   repositoryLabel: string | null;
   summary: string;
   summaryKind: "headline" | "short";

--- a/tests/github-activity-feed.test.mjs
+++ b/tests/github-activity-feed.test.mjs
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
+import { githubCommits } from "../src/db/schema.ts";
 import {
   decodeGitHubActivityCursor,
   encodeGitHubActivityCursor,
@@ -10,6 +11,11 @@ import {
 } from "../src/lib/github-activity-display.ts";
 
 describe("public GitHub activity projection", () => {
+  test("persists both Nano summary variants", () => {
+    expect(githubCommits.summaryHeadline.name).toBe("summary_headline");
+    expect(githubCommits.summaryShort.name).toBe("summary_short");
+  });
+
   test("round trips an opaque cursor without repository identity", () => {
     const cursor = {
       committedAt: "2026-08-28T08:30:00.000Z",

--- a/tests/github-activity-public-summary.test.mjs
+++ b/tests/github-activity-public-summary.test.mjs
@@ -3,8 +3,6 @@ import { describe, expect, test } from "bun:test";
 import {
   buildCommitPublicSummaryModelInput,
   deriveCommitLanguages,
-  patchCommitLoc,
-  patchFileLoc,
   parseCommitPublicSummary,
   PUBLIC_COMMIT_SUMMARY_HEADLINE_MAX_WORDS,
   PUBLIC_COMMIT_SUMMARY_MAX_INPUT_CHARACTERS,
@@ -27,13 +25,18 @@ const file = (filename, additions, deletions, patch = "+change") => ({
 const commit = (
   files,
   message = "fix(auth): refresh sessions\n\nHandle expiry."
-) => ({
-  committedAt: "2026-08-27T00:00:00.000Z",
-  files,
-  message,
-  parents: ["parent"],
-  sha: "sha",
-});
+) => {
+  const additions = files.reduce((total, item) => total + item.additions, 0);
+  const deletions = files.reduce((total, item) => total + item.deletions, 0);
+  return {
+    committedAt: "2026-08-27T00:00:00.000Z",
+    files,
+    message,
+    parents: ["parent"],
+    sha: "sha",
+    stats: { additions, deletions, total: additions + deletions },
+  };
+};
 
 describe("public commit summaries", () => {
   test("parses the two labelled values with an optional blank separator", () => {
@@ -103,13 +106,13 @@ describe("public commit summaries", () => {
     expect(input).toContain("module-00.ts");
   });
 
-  test("derives languages and substantive LOC from patch lines", () => {
+  test("derives languages and substantive LOC from GitHub file counters", () => {
     const files = [
-      file("src/index.ts", 900, 900, "+one\n+two\n-old"),
-      file("src/view.tsx", 900, 900, "+one"),
-      file("worker.py", 900, 900, "+one\n-old"),
-      file("dist/bundle.js", 1, 0, "+generated"),
-      file("pnpm-lock.yaml", 1, 0, "+lock"),
+      file("src/index.ts", 2, 1, "+patch text need not match counters"),
+      file("src/view.tsx", 1, 0, null),
+      file("worker.py", 1, 1, null),
+      file("dist/bundle.js", 500, 500, "+generated"),
+      file("pnpm-lock.yaml", 500, 500, "+lock"),
       file("public/hero.png", 300, 0, null),
     ];
     expect(substantiveCommitLoc(files)).toBe(6);
@@ -119,42 +122,10 @@ describe("public commit summaries", () => {
     ]);
   });
 
-  test("counts additions and deletions from unified patches without headers", () => {
-    expect(
-      patchFileLoc(
-        "--- a/src/index.ts\n+++ b/src/index.ts\n@@ -1 +1,2 @@\n-old\n+new\n+extra\n context"
-      )
-    ).toEqual({ additions: 2, deletions: 1, total: 3 });
-    expect(
-      patchFileLoc("@@ -1 +1 @@\n--- old divider\n+++ new divider")
-    ).toEqual({ additions: 1, deletions: 1, total: 2 });
-    expect(
-      patchCommitLoc([
-        file("src/index.ts", 99, 99, "+one\n-two"),
-        file("src/missing.ts", 5, 5, null),
-        file("public/logo.png", 1, 1, null),
-      ])
-    ).toEqual({ additions: 1, complete: false, deletions: 1, total: 2 });
-  });
-
   test("selects headline through 25 substantive lines and short above it", () => {
     const summaries = { headline: "Improve sessions", short: "One. More." };
-    const small = [
-      file(
-        "src/index.ts",
-        900,
-        900,
-        Array.from({ length: 25 }, () => "+x").join("\n")
-      ),
-    ];
-    const large = [
-      file(
-        "src/index.ts",
-        1,
-        0,
-        Array.from({ length: 26 }, () => "+x").join("\n")
-      ),
-    ];
+    const small = [file("src/index.ts", 20, 5, null)];
+    const large = [file("src/index.ts", 26, 0, "+one visible line")];
     expect(publicCommitSummaryDisplayMode(small)).toBe("headline");
     expect(publicCommitSummaryDisplayMode(large)).toBe("short");
     expect(selectPublicCommitSummary(summaries, small)).toBe(


### PR DESCRIPTION
## Summary
- use GitHub commit stats for displayed additions/deletions and per-file counters for deterministic language/threshold facts
- keep patches only as Nano evidence and continue persisting both headline and short summaries
- migrate and add a zero-LLM backfill for existing completed activity

## Validation
- bun run format
- bun run typecheck
- bun test
- bun run lint
- bunx drizzle-kit check