### PR TITLE
feat(github): harden oversized commit summaries

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -19,6 +19,7 @@
         "clsx": "^2.1.1",
         "drizzle-orm": "0.45.2",
         "feed": "^5.2.1",
+        "gpt-tokenizer": "4.0.0",
         "lucide-react": "^1.21.0",
         "mermaid": "^11.16.0",
         "next": "^16.2.12",
@@ -986,6 +987,8 @@
     "glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
     "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
+
+    "gpt-tokenizer": ["gpt-tokenizer@4.0.0", "", {}, "sha512-YAWIyzvuVUHEfW7tFfFAxH8qQb+Q3RU9nYOTy7skMNX5qzU6Q8jxTHZLyO56ug1vYvCR7wndzpd3jwD86/mhjQ=="],
 
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
 

--- a/docs/github-activity-public-commit-summaries.md
+++ b/docs/github-activity-public-commit-summaries.md
@@ -42,22 +42,95 @@ not asked to infer languages.
 
 ## Model context and output
 
-Nano receives all repository and commit evidence that the authenticated GitHub
-fetch path returns and parses. Repository evidence includes its owner, full
-name, visibility, ownership relationship, description, homepage, topics, and
-avatar URL. Commit evidence includes the complete commit message, time, SHA,
-parents, aggregate statistics, every returned file's metadata, and every patch
-string GitHub returns. A missing GitHub patch is represented as unavailable.
+The pipeline starts with the repository and commit evidence that the
+authenticated GitHub fetch path returns. Repository evidence includes its
+owner, full name, visibility, ownership relationship, description, homepage,
+topics, and avatar URL. Commit evidence includes the complete commit message,
+time, SHA, parents, aggregate statistics, every returned file's metadata, and
+every patch string GitHub returns. A missing GitHub patch is represented as
+unavailable.
 
-This evidence is serialized without a local character budget, commit-message
-cleaning, body truncation, path clipping, patch excerpts, or representative-file
-selection. A complete file index precedes the full diffs. Generated and
-supporting evidence appears before production evidence so a large generated
-artifact cannot bury the delivered behavior; ordering never removes evidence.
-GitHub can still omit patch text in its own response; the application does not
-manufacture evidence in that case. The prompt is generic and infers a natural
-product, project, or feature surface from the supplied evidence. There are no
-repository-specific mappings, heuristics, whitelists, or allowlists.
+The completed request is measured locally with Nano's model-specific tokenizer.
+Ordinary requests through 240,000 input tokens keep all evidence unabridged in
+the stable full-evidence structure. This is below [Nano's 400,000-token context
+window](https://developers.openai.com/api/docs/models/gpt-5-nano) and leaves
+160,000 tokens for framing, reasoning, and output; the summary call itself still
+has no application-level output cap. A UTF-8 byte upper-bound lets ordinary
+small requests bypass the lazily loaded tokenizer entirely. When the byte upper
+bound has not already proved the whole request fits, inputs above a 4 MB
+procedural safety bound or containing an unbroken serialized evidence line
+above 64 KB skip the exact full-input tokenization probe and enter compaction.
+This covers pathological patch, message, description, and path text; a large
+ordinary multiline diff can still take the exact probe and remain whole.
+
+Only an oversized request switches to deterministic procedural compaction:
+
+1. Keep the full repository and commit metadata and a compact, complete ledger
+   of every returned changed file, including status, counters, old path,
+   evidence class, and whether GitHub supplied a patch.
+2. Deduplicate byte-identical patch strings while retaining every associated
+   file ID. Semantic diff parsing is bounded to 100,000 lines overall, 16 MB of
+   patches overall, and 1 MB per patch. A patch outside those bounds receives a
+   deterministic 1 KB head/tail excerpt with its exact original line count,
+   byte count, and omitted-byte count; the manifest labels it as locally raw
+   compacted and does not report it as parsed coverage or an upstream mismatch.
+3. For patches inside the parsing bounds, remove unchanged unified-diff context
+   while retaining patch metadata, every hunk header, every changed line, and
+   an explicit skip marker at each context gap. When no patch needed raw
+   compaction and that representation fits, nothing else is omitted.
+4. If it remains oversized, create byte-bounded samples from contiguous edit
+   blocks. A replacement keeps both its deletion and addition sides together.
+   Giant individual lines keep deterministic head and tail evidence with the
+   exact omitted-byte count. Beginning, end, and middle blocks are considered
+   before denser samples, but selected evidence is rendered back in source
+   order with explicit changed-line gaps.
+5. Estimate each complete bounded sample with Nano's tokenizer. Stable
+   module/file breadth feeds a token-weighted 6:2:1 allocation across product,
+   tests/docs, and generated/vendor/lock/binary evidence. A sample that does
+   not fit is skipped instead of blocking smaller later evidence. The whole
+   constructed request is then counted exactly and tail samples are removed
+   until it fits.
+6. In the normal compact manifest, report GitHub aggregate changed lines;
+   returned and represented files,
+   unique patches, hunks, patch metadata, unique patch lines, and duplicate
+   patch occurrences; upstream-missing patches; and per-file counter/patch
+   mismatches. Locally raw-compacted patch/file counts and excerpt coverage are
+   separate from those parsed counters.
+
+If repository, commit, and complete-ledger metadata alone were ever to exceed
+the budget, a separately rendered extreme manifest retains aggregate commit and
+file facts, clips the commit message to the remaining token budget, and retains
+the minimal repository identity when it fits. It otherwise explicitly omits
+repository fields, paths, and patches; it never slices the constructed prompt
+through JSON or section boundaries. Detailed raw/mismatch provenance is retained
+when the extreme budget can hold it and otherwise yields to the minimal
+aggregate manifest without claiming complete patch coverage.
+
+The evidence classes affect budget share only; no class is unconditionally
+filtered. A generated-only or tests-only commit therefore receives the
+available budget. The prompt and compactor use no repository-specific mapping,
+whitelist, or LLM pre-summary, and compaction adds no model call or retry.
+
+GitHub's `files[].patch` is best-effort source evidence rather than a guaranteed
+complete Git diff. The [commit endpoint](https://docs.github.com/en/rest/commits/commits#get-a-commit)
+paginates file metadata up to 3,000 files, binary changes can lack patch text,
+and GitHub warns that large raw diff or patch responses can fail. An exactly
+3,000-file response is retained and marked as provider-cap-ambiguous instead of
+being rejected. That flag is persisted; the page displays the file count as a
+lower bound and labels file-derived language coverage as partial. The
+compaction manifest distinguishes upstream unavailable or counter-mismatched
+patches from evidence omitted locally. Raw patches and compaction intermediates
+are not persisted.
+
+The reducer follows Git's documented [zero-context diff
+primitive](https://git-scm.com/docs/diff-context-options.html),
+Gerrit's explicit [`skip` representation for omitted common
+lines](https://gerrit-review.googlesource.com/Documentation/rest-api-changes.html#diff-content),
+and the useful part of [Aider's token-budgeted repo-map
+design](https://aider.chat/docs/repomap.html): deterministic ranking followed by
+budget fill. It does not use AST parsing, embeddings, an LLM pre-summary, or
+OpenAI's [conversation compaction](https://developers.openai.com/api/docs/guides/compaction),
+which manages multi-turn state rather than a single commit diff.
 
 There is no content disclosure validator, privacy-term filter, word-count
 rejection, response-length rejection, shape rejection, or display truncation.
@@ -72,8 +145,8 @@ character; it does not remove text.
 Only a source-fetch failure, model request or transport failure, or empty Nano
 response fails processing. Such a failure is terminal for explicit operational
 inspection and omitted from the public feed. The call is not retried inside or
-after the request. Raw patches and repository descriptions are not persisted
-because they can be fetched again from GitHub.
+after the request. Repository descriptions are not persisted because they can
+be fetched again from GitHub.
 
 The displayed additions and deletions are GitHub's commit-wide `stats` values.
 The headline threshold and language weights use GitHub's per-file additions and

--- a/docs/github-activity-public-summary-samples.md
+++ b/docs/github-activity-public-summary-samples.md
@@ -73,6 +73,7 @@ to stage and package the new tools artifacts.
 ## Usage observation
 
 The first four commits used 419, 521, 2,620, and 4,253 input tokens. The
-12,828-total-line commit used 177,766 input tokens because the experiment sent
-its complete available diff. This exceptional case dominates cost and is the
-main input-compaction question to evaluate before production rollout.
+12,828-total-line commit used 177,766 input tokens and remains below the current
+240,000-token full-evidence boundary. Larger inputs now use the deterministic
+diff compactor documented in `github-activity-public-commit-summaries.md`; no
+additional model call is introduced.

--- a/docs/github-commits.md
+++ b/docs/github-commits.md
@@ -131,15 +131,33 @@ A successful candidate replaces the two persisted summary variants and their
 recipe/model/input hash. A failed candidate leaves the previous valid pair
 untouched.
 
-The Nano call sees all repository and commit evidence returned and parsed by the
+The pipeline starts with repository and commit evidence returned by the
 authenticated GitHub fetch path. That includes repository identity, ownership,
 visibility, description, homepage, topics, and avatar URL; the complete commit
 message and metadata; every returned file's metadata; and every patch string
-GitHub provides. The application passes that evidence without local clipping,
-body cleaning, excerpt selection, or an input character budget. Its prompt is
-generic and has no repository-specific mappings, heuristics, whitelists, or
-allowlists. A complete file index precedes every full diff; generated and
-supporting evidence is ordered before production evidence without dropping it.
+GitHub provides. The complete request is measured with Nano's model-specific
+tokenizer and keeps all evidence unabridged through 240,000 input tokens. If the
+UTF-8 upper bound has not already proved the request fits, a 4 MB input safety
+bound or 64 KB unbroken serialized-line bound routes pathological patch,
+message, description, or path text to compaction before exact full-input
+tokenization; large multiline diffs can still remain whole when they fit.
+
+Above that boundary, one deterministic local pass keeps the repository and
+commit metadata plus a complete compact file ledger, deduplicates identical
+patches, and bounds semantic parsing by patch bytes and total lines. A patch
+outside those memory bounds becomes an explicitly labeled deterministic
+head/tail excerpt with exact omission counters. Parsed patches first replace
+only unchanged context with skip markers. If every changed line still does not
+fit, byte-bounded atomic edit samples keep both sides of replacements together.
+Module/file breadth and a generic token-weighted 6:2:1 allocation cover product,
+test/doc, and generated evidence; samples render in source order with explicit
+gaps. Sample costs are estimated individually, then the final request is
+token-counted exactly and trimmed structurally before the single Nano call. The
+normal compaction manifest separates upstream-missing, counter-mismatched,
+locally raw-compacted, and budget-omitted evidence. An extreme metadata-only
+fallback may omit those detailed distinctions when its minimal aggregate
+manifest is all that fits. There is no LLM pre-summary, second call, retry,
+repository-specific mapping, whitelist, or persisted patch/compaction state.
 
 Every nonempty Nano response is accepted and persisted. The expected
 `HEADLINE` and `SHORT` labels are parsed when present; an unexpectedly shaped

--- a/drizzle/0006_steep_aqueduct.sql
+++ b/drizzle/0006_steep_aqueduct.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "github_commits" ADD COLUMN "provider_file_cap_reached" boolean DEFAULT false NOT NULL;

--- a/drizzle/meta/0006_snapshot.json
+++ b/drizzle/meta/0006_snapshot.json
@@ -1,0 +1,321 @@
+{
+  "id": "a61c0568-08a3-44a3-a3b4-492c794bdfc2",
+  "prevId": "1b566a46-0a5e-4b9e-a80e-a8ca63c95344",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.github_account_checkpoints": {
+      "name": "github_account_checkpoints",
+      "schema": "",
+      "columns": {
+        "account": {
+          "name": "account",
+          "type": "varchar(39)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "latest_event_id": {
+          "name": "latest_event_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "paused": {
+          "name": "paused",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "github_account_checkpoints_tracked_account": {
+          "name": "github_account_checkpoints_tracked_account",
+          "value": "\"github_account_checkpoints\".\"account\" IN ('f0rr0', 'yuppiestechdev')"
+        },
+        "github_account_checkpoints_event_id_shape": {
+          "name": "github_account_checkpoints_event_id_shape",
+          "value": "\"github_account_checkpoints\".\"latest_event_id\" IS NULL OR \"github_account_checkpoints\".\"latest_event_id\" ~ '^[0-9]{1,64}$'"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.github_commits": {
+      "name": "github_commits",
+      "schema": "",
+      "columns": {
+        "activity_public_id": {
+          "name": "activity_public_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "additions": {
+          "name": "additions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_login": {
+          "name": "author_login",
+          "type": "varchar(39)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changed_files": {
+          "name": "changed_files",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "committed_at": {
+          "name": "committed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deletions": {
+          "name": "deletions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "languages": {
+          "name": "languages",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_file_cap_reached": {
+          "name": "provider_file_cap_reached",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "repository": {
+          "name": "repository",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository_owner_avatar_url": {
+          "name": "repository_owner_avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repository_owner_login": {
+          "name": "repository_owner_login",
+          "type": "varchar(39)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repository_owner_type": {
+          "name": "repository_owner_type",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repository_private": {
+          "name": "repository_private",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sha": {
+          "name": "sha",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "substantive_loc": {
+          "name": "substantive_loc",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary_attempted_at": {
+          "name": "summary_attempted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary_error": {
+          "name": "summary_error",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary_headline": {
+          "name": "summary_headline",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary_input_hash": {
+          "name": "summary_input_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary_model": {
+          "name": "summary_model",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary_recipe": {
+          "name": "summary_recipe",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary_short": {
+          "name": "summary_short",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "github_commits_activity_public_id_unique": {
+          "name": "github_commits_activity_public_id_unique",
+          "columns": [
+            {
+              "expression": "activity_public_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_commits_activity_cursor_idx": {
+          "name": "github_commits_activity_cursor_idx",
+          "columns": [
+            {
+              "expression": "committed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "activity_public_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_commits_committed_at_idx": {
+          "name": "github_commits_committed_at_idx",
+          "columns": [
+            {
+              "expression": "committed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_commits_summary_pending_idx": {
+          "name": "github_commits_summary_pending_idx",
+          "columns": [
+            {
+              "expression": "summary_attempted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "committed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "github_commits_repository_id_sha_pk": {
+          "name": "github_commits_repository_id_sha_pk",
+          "columns": ["repository_id", "sha"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "github_commits_sha_shape": {
+          "name": "github_commits_sha_shape",
+          "value": "\"github_commits\".\"sha\" ~ '^[a-f0-9]{40}$'"
+        },
+        "github_commits_tracked_author": {
+          "name": "github_commits_tracked_author",
+          "value": "\"github_commits\".\"author_login\" IN ('f0rr0', 'yuppiestechdev')"
+        },
+        "github_commits_nonnegative_activity_counts": {
+          "name": "github_commits_nonnegative_activity_counts",
+          "value": "(\"github_commits\".\"changed_files\" IS NULL OR \"github_commits\".\"changed_files\" >= 0) AND (\"github_commits\".\"additions\" IS NULL OR \"github_commits\".\"additions\" >= 0) AND (\"github_commits\".\"deletions\" IS NULL OR \"github_commits\".\"deletions\" >= 0) AND (\"github_commits\".\"substantive_loc\" IS NULL OR \"github_commits\".\"substantive_loc\" >= 0)"
+        },
+        "github_commits_owner_type": {
+          "name": "github_commits_owner_type",
+          "value": "\"github_commits\".\"repository_owner_type\" IS NULL OR \"github_commits\".\"repository_owner_type\" IN ('Organization', 'User')"
+        },
+        "github_commits_summary_hash_shape": {
+          "name": "github_commits_summary_hash_shape",
+          "value": "\"github_commits\".\"summary_input_hash\" IS NULL OR \"github_commits\".\"summary_input_hash\" ~ '^[a-f0-9]{64}$'"
+        },
+        "github_commits_summary_pair": {
+          "name": "github_commits_summary_pair",
+          "value": "(\"github_commits\".\"summary_headline\" IS NULL) = (\"github_commits\".\"summary_short\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": true
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -43,6 +43,13 @@
       "when": 1787921146709,
       "tag": "0005_glamorous_karnak",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "7",
+      "when": 1787934897652,
+      "tag": "0006_steep_aqueduct",
+      "breakpoints": true
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "clsx": "^2.1.1",
     "drizzle-orm": "0.45.2",
     "feed": "^5.2.1",
+    "gpt-tokenizer": "4.0.0",
     "lucide-react": "^1.21.0",
     "mermaid": "^11.16.0",
     "next": "^16.2.12",

--- a/scripts/refresh-github-activity-counters.ts
+++ b/scripts/refresh-github-activity-counters.ts
@@ -22,6 +22,7 @@ try {
         changedFiles: source.commit.files.length,
         deletions: source.commit.stats.deletions,
         languages: deriveCommitLanguages(source.commit.files),
+        providerFileCapReached: source.commit.providerFileCapReached,
         substantiveLoc: substantiveCommitLoc(source.commit.files),
       });
       completed += 1;

--- a/scripts/sample-nano-public-summaries.ts
+++ b/scripts/sample-nano-public-summaries.ts
@@ -7,7 +7,6 @@ import { closeDatabase, getDatabase } from "../src/db/client";
 import { githubCommits } from "../src/db/schema";
 import { fetchGitHubActivityCommitSource } from "../src/lib/github-activity-processor";
 import {
-  buildCommitPublicSummaryModelInput,
   DEFAULT_PUBLIC_COMMIT_SUMMARY_LOW_LOC_THRESHOLD,
   deriveCommitLanguages,
   formatPublicCommitSummaryMarkdown,
@@ -19,6 +18,11 @@ import {
   substantiveCommitLoc,
 } from "../src/lib/github-activity-public-summary";
 import type { PublicCommitFileEvidence } from "../src/lib/github-activity-public-summary";
+import {
+  buildCommitPublicSummaryModelInput,
+  countCommitPublicSummaryRequestTokens,
+  PUBLIC_COMMIT_SUMMARY_MAX_REQUEST_INPUT_TOKENS,
+} from "../src/lib/github-activity-public-summary-input";
 import type { ClaimedGitHubActivityCommit } from "../src/lib/github-activity-store";
 import { trackedGitHubAccountFrom } from "../src/lib/github-commits-core";
 
@@ -163,7 +167,7 @@ const main = async () => {
       displayMode: publicCommitSummaryDisplayMode(commit.files),
       languages: deriveCommitLanguages(commit.files),
       loc: locFrom(commit.files),
-      modelInput: buildCommitPublicSummaryModelInput(commit, {
+      modelInput: await buildCommitPublicSummaryModelInput(commit, {
         avatarUrl: repository.avatarUrl,
         description: repository.description,
         directlyOwned: trackedGitHubAccountFrom(repository.ownerLogin) !== null,
@@ -190,6 +194,12 @@ const main = async () => {
       committedAt: source.commit.committedAt,
       deterministicLanguages: source.languages,
       inputCharacters: source.modelInput.length,
+      inputCompacted: source.modelInput.includes(
+        "LARGE COMMIT COMPACTION MANIFEST"
+      ),
+      inputTokens: await countCommitPublicSummaryRequestTokens(
+        source.modelInput
+      ),
       loc: source.loc,
       repository: source.repository,
       sha: source.commit.sha,
@@ -246,6 +256,7 @@ const main = async () => {
       {
         configuration: {
           lowLocThreshold: DEFAULT_PUBLIC_COMMIT_SUMMARY_LOW_LOC_THRESHOLD,
+          maxRequestInputTokens: PUBLIC_COMMIT_SUMMARY_MAX_REQUEST_INPUT_TOKENS,
           maxRetries: 0,
           model: NANO_MODEL,
           modelAttemptsPerCommit: 1,

--- a/src/components/github-timeline.tsx
+++ b/src/components/github-timeline.tsx
@@ -150,20 +150,62 @@ function ActivityEntry({ item }: Readonly<{ item: PublicGitHubActivityItem }>) {
         <div className="github-activity-facts">
           <span
             className="github-activity-loc"
-            title="Lines added and deleted according to GitHub"
+            title={
+              item.providerFileCapReached
+                ? "Total lines added and deleted according to GitHub. Per-language line counts cover only the file details GitHub returned and may be incomplete."
+                : "Lines added and deleted according to GitHub"
+            }
           >
-            <span className="github-activity-additions">+{item.additions}</span>
-            <span className="github-activity-deletions">−{item.deletions}</span>
+            <span aria-hidden="true" className="github-activity-additions">
+              +{item.additions}
+            </span>
+            <span aria-hidden="true" className="github-activity-deletions">
+              −{item.deletions}
+            </span>
+            <span className="sr-only">
+              {item.additions} lines added and {item.deletions} lines deleted
+              according to GitHub.
+              {item.providerFileCapReached
+                ? " Per-language line counts cover only the file details GitHub returned and may be incomplete."
+                : null}
+            </span>
           </span>
-          <span>
-            {item.changedFiles} {item.changedFiles === 1 ? "file" : "files"}
+          <span
+            title={
+              item.providerFileCapReached
+                ? "At least 3,000 changed files; GitHub capped the returned file details"
+                : undefined
+            }
+          >
+            {item.providerFileCapReached ? (
+              <>
+                <span aria-hidden="true">{item.changedFiles}+ files</span>
+                <span className="sr-only">
+                  {item.changedFiles} or more changed files; GitHub caps
+                  returned file details at 3,000 files
+                </span>
+              </>
+            ) : (
+              `${item.changedFiles} ${item.changedFiles === 1 ? "file" : "files"}`
+            )}
           </span>
           {visibleLanguages.length === 0 ? null : (
-            <ul aria-label="Languages" className="github-activity-languages">
+            <ul
+              aria-label={
+                item.providerFileCapReached
+                  ? "Languages found in the first 3,000 files returned by GitHub; the full commit may include more"
+                  : "Languages"
+              }
+              className="github-activity-languages"
+            >
               {visibleLanguages.map((language) => (
                 <li
                   key={language.id}
-                  title={`${language.changedLines} changed lines`}
+                  title={
+                    item.providerFileCapReached
+                      ? `${language.changedLines} changed lines in the returned file details; incomplete because GitHub capped them at 3,000 files`
+                      : `${language.changedLines} changed lines`
+                  }
                 >
                   {language.iconUrl === null ? (
                     <Code2 aria-hidden="true" className="size-3.5" />

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -30,6 +30,9 @@ export const githubCommits = pgTable(
     deletions: integer("deletions"),
     languages: jsonb("languages").$type<readonly PublicCommitLanguage[]>(),
     message: text("message").notNull(),
+    providerFileCapReached: boolean("provider_file_cap_reached")
+      .default(false)
+      .notNull(),
     repository: varchar("repository", { length: 200 }).notNull(),
     repositoryId: varchar("repository_id", { length: 32 }).notNull(),
     repositoryOwnerAvatarUrl: text("repository_owner_avatar_url"),

--- a/src/lib/github-activity-feed.ts
+++ b/src/lib/github-activity-feed.ts
@@ -16,7 +16,7 @@ const EMPTY_PAGE: PublicGitHubActivityPage = {
 
 const readCachedInitialActivity = unstable_cache(
   async () => await readPublicGitHubActivityPage(null),
-  ["public-github-activity-v1"],
+  ["public-github-activity-v2"],
   { revalidate: 900, tags: ["github-activity"] }
 );
 

--- a/src/lib/github-activity-processor.ts
+++ b/src/lib/github-activity-processor.ts
@@ -4,7 +4,6 @@ import { openai } from "@ai-sdk/openai";
 import { APICallError, generateText } from "ai";
 
 import {
-  buildCommitPublicSummaryModelInput,
   deriveCommitLanguages,
   formatPublicCommitSummaryMarkdown,
   parseCommitPublicSummary,
@@ -16,6 +15,7 @@ import type {
   PublicCommitEvidence,
   PublicCommitFileEvidence,
 } from "@/lib/github-activity-public-summary";
+import { buildCommitPublicSummaryModelInput } from "@/lib/github-activity-public-summary-input";
 import {
   claimPendingGitHubActivity,
   completeGitHubActivity,
@@ -92,6 +92,13 @@ const requiredInteger = (value: unknown, label: string) => {
 
 const optionalString = (value: unknown) =>
   typeof value === "string" && value.length > 0 ? value : null;
+
+const compareCodeUnitStrings = (left: string, right: string) => {
+  if (left === right) {
+    return 0;
+  }
+  return left < right ? -1 : 1;
+};
 
 const repositoryApiPath = (repository: string, suffix = "") => {
   const [owner, name, ...rest] = repository.split("/");
@@ -204,6 +211,7 @@ const fileEvidenceFrom = (value: unknown): PublicCommitFileEvidence => {
 const commitEvidenceFrom = (
   root: JsonObject,
   files: readonly PublicCommitFileEvidence[],
+  providerFileCapReached: boolean,
   expected: ClaimedGitHubActivityCommit
 ): PublicCommitEvidence => {
   if (
@@ -259,6 +267,7 @@ const commitEvidenceFrom = (
     files,
     message: requiredString(root.commit.message, "commit message"),
     parents,
+    providerFileCapReached,
     sha,
     stats: { additions, deletions, total },
   };
@@ -278,6 +287,7 @@ const fetchCommitSourceWithToken = async (
   );
   const files = new Map<string, PublicCommitFileEvidence>();
   let root: JsonObject | null = null;
+  let providerFileCapReached = false;
   for (let page = 1; page <= MAXIMUM_GITHUB_FILE_PAGES; page += 1) {
     const value = await fetchJson(
       repositoryApiPath(
@@ -301,10 +311,7 @@ const fetchCommitSourceWithToken = async (
       break;
     }
     if (page === MAXIMUM_GITHUB_FILE_PAGES) {
-      throw new ActivityProcessingError(
-        "source_too_large",
-        "The commit exceeded GitHub's file pagination budget."
-      );
+      providerFileCapReached = true;
     }
   }
   if (root === null) {
@@ -317,8 +324,9 @@ const fetchCommitSourceWithToken = async (
     commit: commitEvidenceFrom(
       root,
       [...files.values()].toSorted((left, right) =>
-        left.filename.localeCompare(right.filename)
+        compareCodeUnitStrings(left.filename, right.filename)
       ),
+      providerFileCapReached,
       row
     ),
     repository,
@@ -361,7 +369,7 @@ const directlyOwnedRepository = (source: GitHubActivityCommitSource) =>
   trackedGitHubAccountFrom(source.repository.ownerLogin) !== null;
 
 const generateCommitSummary = async (source: GitHubActivityCommitSource) => {
-  const modelInput = buildCommitPublicSummaryModelInput(source.commit, {
+  const modelInput = await buildCommitPublicSummaryModelInput(source.commit, {
     avatarUrl: source.repository.avatarUrl,
     description: source.repository.description,
     directlyOwned: directlyOwnedRepository(source),
@@ -437,6 +445,7 @@ const processClaimedCommit = async (row: ClaimedGitHubActivityCommit) => {
       changedFiles: source.commit.files.length,
       deletions: source.commit.stats.deletions,
       languages: deriveCommitLanguages(source.commit.files),
+      providerFileCapReached: source.commit.providerFileCapReached,
       repository: source.repository.fullName,
       repositoryOwnerAvatarUrl: source.repository.avatarUrl,
       repositoryOwnerLogin: source.repository.ownerLogin,

--- a/src/lib/github-activity-public-summary-input.ts
+++ b/src/lib/github-activity-public-summary-input.ts
@@ -1,0 +1,1775 @@
+import { Buffer } from "node:buffer";
+
+import type * as NanoTokenizerModule from "gpt-tokenizer/model/gpt-5-nano-2025-08-07";
+
+import {
+  publicCommitEvidenceClass,
+  PUBLIC_COMMIT_SUMMARY_SYSTEM_PROMPT,
+} from "@/lib/github-activity-public-summary";
+import type {
+  PublicCommitEvidence,
+  PublicCommitEvidenceClass,
+  PublicCommitFileEvidence,
+  PublicCommitSummaryRepositoryContext,
+} from "@/lib/github-activity-public-summary";
+
+export const PUBLIC_COMMIT_SUMMARY_MAX_REQUEST_INPUT_TOKENS = 240_000;
+
+const REQUEST_FRAMING_TOKEN_RESERVE = 64;
+const SAMPLE_MANIFEST_TOKEN_RESERVE = 128;
+const CHANGED_LINES_PER_SAMPLE = 18;
+const MAX_CHANGED_LINE_BYTES = 1000;
+const MAX_EXTREME_MESSAGE_BYTES = 16_000;
+const MAX_EXACT_MODEL_INPUT_BYTES = 4_000_000;
+const MAX_EXACT_PATCH_LINE_BYTES = 64_000;
+const MAX_PARSED_PATCH_BYTES = 16_000_000;
+const MAX_PARSED_SINGLE_PATCH_BYTES = 1_000_000;
+const MAX_SAMPLE_BYTES = 7000;
+const METADATA_LINES_PER_SAMPLE = 12;
+const MAX_RETAINED_PATCH_LINES = 100_000;
+const COMPACT_INPUT_VERSION = "deterministic-diff-v2";
+const NO_DISALLOWED_SPECIAL_TOKENS = new Set<string>();
+const taskInstruction = `Before answering, silently complete: “A person using this product can now …” Use that answer as the result when the evidence supports one. Otherwise describe the furthest downstream developer or operational result. Prefer visible behavior over its backing implementation; when visible options narrow feed, search, or listing results, call them filters.`;
+const providerCapInstruction = `providerFileCapReached means GitHub returned its 3,000-file ceiling, so the returned file list may itself be incomplete.`;
+
+const evidenceClassWeight: Readonly<Record<PublicCommitEvidenceClass, number>> =
+  {
+    product: 6,
+    supporting: 2,
+    "low-signal": 1,
+  };
+
+const evidenceClassOrder: readonly PublicCommitEvidenceClass[] = [
+  "product",
+  "supporting",
+  "low-signal",
+];
+
+const fullEvidenceClassOrder: Readonly<
+  Record<PublicCommitEvidenceClass, number>
+> = {
+  "low-signal": 0,
+  supporting: 1,
+  product: 2,
+};
+
+const evidenceClassRank = new Map(
+  evidenceClassOrder.map((evidenceClass, index) => [evidenceClass, index])
+);
+
+interface PatchChangedLine {
+  omittedBytes: number;
+  ordinal: number;
+  text: string;
+}
+
+interface PatchEditBlock {
+  changedLines: readonly PatchChangedLine[];
+  contextLinesBefore: number;
+  index: number;
+}
+
+interface PatchHunk {
+  changedLineCount: number;
+  contextLines: number;
+  editBlocks: readonly PatchEditBlock[];
+  header: string;
+  index: number;
+  trailingContextLines: number;
+}
+
+interface PatchSample {
+  blockIndex: number | null;
+  changedLines: readonly PatchChangedLine[];
+  hunkIndex: number | null;
+  kind: "changes" | "metadata" | "raw";
+  metadataLineEnd: number | null;
+  metadataLineStart: number | null;
+  metadataLines: readonly string[];
+  partiallyCompactedMetadataLineIndexes: readonly number[];
+  patchIndex: number;
+}
+
+interface RawPatchCompaction {
+  evidenceLines: readonly string[];
+  omittedBytes: number;
+  originalBytes: number;
+  originalLines: number;
+}
+
+interface UniquePatchEvidence {
+  evidenceClass: PublicCommitEvidenceClass;
+  fileIds: readonly string[];
+  firstFilename: string;
+  hunks: readonly PatchHunk[];
+  index: number;
+  metadataLines: readonly string[];
+  patch: string;
+  rawCompaction: RawPatchCompaction | null;
+  samples: readonly PatchSample[];
+}
+
+type NanoTokenizer = typeof NanoTokenizerModule;
+
+export interface BuildCommitPublicSummaryModelInputOptions {
+  maxRequestInputTokens?: number;
+}
+
+let tokenizerPromise: Promise<NanoTokenizer> | undefined;
+let systemPromptTokenCountPromise: Promise<number> | undefined;
+
+const tokenizer = async () => {
+  tokenizerPromise ??= import("gpt-tokenizer/model/gpt-5-nano-2025-08-07");
+  return await tokenizerPromise;
+};
+
+const utf8Length = (value: string) => Buffer.byteLength(value, "utf-8");
+
+const requestDefinitelyFits = (modelInput: string, maximum: number) =>
+  utf8Length(PUBLIC_COMMIT_SUMMARY_SYSTEM_PROMPT) +
+    utf8Length(modelInput) +
+    REQUEST_FRAMING_TOKEN_RESERVE <=
+  maximum;
+
+const countTextTokens = async (value: string) => {
+  const { countTokens } = await tokenizer();
+  return countTokens(value, {
+    disallowedSpecial: NO_DISALLOWED_SPECIAL_TOKENS,
+  });
+};
+
+const systemPromptTokenCount = async () => {
+  systemPromptTokenCountPromise ??= countTextTokens(
+    PUBLIC_COMMIT_SUMMARY_SYSTEM_PROMPT
+  );
+  return await systemPromptTokenCountPromise;
+};
+
+const modelInputFitsTokenBudget = async (
+  modelInput: string,
+  maximum: number
+) => {
+  const allowed =
+    maximum - (await systemPromptTokenCount()) - REQUEST_FRAMING_TOKEN_RESERVE;
+  if (allowed < 1) {
+    return false;
+  }
+  const { isWithinTokenLimit } = await tokenizer();
+  return (
+    isWithinTokenLimit(modelInput, allowed, {
+      disallowedSpecial: NO_DISALLOWED_SPECIAL_TOKENS,
+    }) !== false
+  );
+};
+
+export const countCommitPublicSummaryRequestTokens = async (
+  modelInput: string
+) =>
+  (await systemPromptTokenCount()) +
+  (await countTextTokens(modelInput)) +
+  REQUEST_FRAMING_TOKEN_RESERVE;
+
+const compareText = (left: string, right: string) =>
+  left < right ? -1 : left > right ? 1 : 0;
+
+const publicCommitFileMetadata = (file: PublicCommitFileEvidence) =>
+  JSON.stringify(
+    {
+      additions: file.additions,
+      deletions: file.deletions,
+      filename: file.filename,
+      previousFilename: file.previousFilename,
+      status: file.status,
+    },
+    null,
+    2
+  );
+
+const fullEvidencePriority = (file: PublicCommitFileEvidence) =>
+  fullEvidenceClassOrder[publicCommitEvidenceClass(file)];
+
+const sortedCommitFiles = (files: readonly PublicCommitFileEvidence[]) =>
+  files.toSorted((left, right) => compareText(left.filename, right.filename));
+
+const exactModelInputTokenProbeIsSafe = (value: string) => {
+  if (utf8Length(value) > MAX_EXACT_MODEL_INPUT_BYTES) {
+    return false;
+  }
+  let lineStart = 0;
+  while (lineStart <= value.length) {
+    const newline = value.indexOf("\n", lineStart);
+    const lineEnd = newline === -1 ? value.length : newline;
+    const codeUnits = lineEnd - lineStart;
+    if (
+      codeUnits > MAX_EXACT_PATCH_LINE_BYTES / 4 &&
+      utf8Length(value.slice(lineStart, lineEnd)) > MAX_EXACT_PATCH_LINE_BYTES
+    ) {
+      return false;
+    }
+    if (newline === -1) {
+      break;
+    }
+    lineStart = newline + 1;
+  }
+  return true;
+};
+
+const repositoryEvidenceFrom = (
+  repository: PublicCommitSummaryRepositoryContext
+) => JSON.stringify(repository, null, 2);
+
+const commitEvidenceFrom = (
+  commit: PublicCommitEvidence,
+  includeProviderFileCap = false
+) =>
+  JSON.stringify(
+    {
+      committedAt: commit.committedAt,
+      message: commit.message,
+      parents: commit.parents,
+      ...(includeProviderFileCap
+        ? { providerFileCapReached: commit.providerFileCapReached }
+        : {}),
+      sha: commit.sha,
+      stats: commit.stats,
+    },
+    null,
+    2
+  );
+
+const buildFullModelInput = (
+  commit: PublicCommitEvidence,
+  repository: PublicCommitSummaryRepositoryContext,
+  sortedFiles: readonly PublicCommitFileEvidence[]
+) => {
+  const evidenceOrder = sortedFiles.toSorted(
+    (left, right) => fullEvidencePriority(left) - fullEvidencePriority(right)
+  );
+  const fileIndex = sortedFiles.map(publicCommitFileMetadata);
+  const providerCapReached = commit.providerFileCapReached;
+  const changes = evidenceOrder.map((file) => {
+    const metadata = publicCommitFileMetadata(file);
+    return `FILE\n${metadata}\nGITHUB-RETURNED PATCH\n${file.patch ?? "[patch unavailable from GitHub]"}`;
+  });
+  if (providerCapReached) {
+    return `REPOSITORY EVIDENCE\n${repositoryEvidenceFrom(repository)}\n\nCOMMIT EVIDENCE\n${commitEvidenceFrom(commit, true)}\n${providerCapInstruction}\n\nCOMPLETE GITHUB-RETURNED CHANGED FILE INDEX\n${fileIndex.join("\n\n")}\n\nGITHUB-RETURNED CHANGED FILES AND PATCH EVIDENCE\n${changes.join("\n\n")}\n\nEND OF EVIDENCE\n${taskInstruction}`;
+  }
+  return `REPOSITORY EVIDENCE\n${repositoryEvidenceFrom(repository)}\n\nCOMMIT EVIDENCE\n${commitEvidenceFrom(commit)}\n\nCOMPLETE GITHUB-RETURNED CHANGED FILE INDEX\n${fileIndex.join("\n\n")}\n\nGITHUB-RETURNED CHANGED FILES AND PATCH EVIDENCE\n${changes.join("\n\n")}\n\nEND OF EVIDENCE\n${taskInstruction}`;
+};
+
+const parsePatch = (
+  patch: string
+): { hunks: readonly PatchHunk[]; metadataLines: readonly string[] } => {
+  const metadataLines: string[] = [];
+  const hunks: {
+    changedLineCount: number;
+    contextLines: number;
+    editBlocks: {
+      changedLines: PatchChangedLine[];
+      contextLinesBefore: number;
+    }[];
+    header: string;
+    trailingContextLines: number;
+  }[] = [];
+  let currentHunk: (typeof hunks)[number] | null = null;
+  let currentBlock: (typeof hunks)[number]["editBlocks"][number] | null = null;
+  let pendingContextLines = 0;
+
+  const finishHunk = () => {
+    if (currentHunk !== null) {
+      currentHunk.trailingContextLines = pendingContextLines;
+      currentHunk.contextLines += pendingContextLines;
+    }
+    pendingContextLines = 0;
+    currentBlock = null;
+  };
+
+  for (const line of patch.split(/\r?\n/u)) {
+    if (line.startsWith("@@")) {
+      finishHunk();
+      currentHunk = {
+        changedLineCount: 0,
+        contextLines: 0,
+        editBlocks: [],
+        header: line,
+        trailingContextLines: 0,
+      };
+      hunks.push(currentHunk);
+      continue;
+    }
+    if (currentHunk === null) {
+      if (line.length > 0) {
+        metadataLines.push(line);
+      }
+      continue;
+    }
+    const changed = line.startsWith("+") || line.startsWith("-");
+    if (changed) {
+      if (currentBlock === null) {
+        currentBlock = {
+          changedLines: [],
+          contextLinesBefore: pendingContextLines,
+        };
+        currentHunk.contextLines += pendingContextLines;
+        pendingContextLines = 0;
+        currentHunk.editBlocks.push(currentBlock);
+      }
+      currentHunk.changedLineCount += 1;
+      currentBlock.changedLines.push({
+        omittedBytes: 0,
+        ordinal: currentHunk.changedLineCount,
+        text: line,
+      });
+      continue;
+    }
+    if (line === "\\ No newline at end of file" && currentBlock !== null) {
+      const previous = currentBlock.changedLines.at(-1);
+      if (previous !== undefined) {
+        previous.text = `${previous.text}\n${line}`;
+      }
+      continue;
+    }
+    if (line.length > 0) {
+      pendingContextLines += 1;
+      currentBlock = null;
+    }
+  }
+  finishHunk();
+  return {
+    hunks: hunks.map((hunk, index) => ({
+      ...hunk,
+      editBlocks: hunk.editBlocks.map((block, blockIndex) => ({
+        ...block,
+        index: blockIndex,
+      })),
+      index,
+    })),
+    metadataLines,
+  };
+};
+
+const spreadOrder = (length: number) => {
+  if (length <= 1) {
+    return length === 0 ? [] : [0];
+  }
+  const order = [0, length - 1];
+  const intervals: (readonly [number, number])[] = [[1, length - 2]];
+  for (const [start, end] of intervals) {
+    if (start > end) {
+      continue;
+    }
+    const middle = Math.floor((start + end) / 2);
+    order.push(middle);
+    intervals.push([start, middle - 1], [middle + 1, end]);
+  }
+  return order;
+};
+
+const utf8PrefixWithin = (value: string, maximumBytes: number) => {
+  let low = 0;
+  let high = Math.min(value.length, maximumBytes);
+  while (low < high) {
+    const middle = Math.ceil((low + high) / 2);
+    if (utf8Length(value.slice(0, middle)) <= maximumBytes) {
+      low = middle;
+    } else {
+      high = middle - 1;
+    }
+  }
+  let end = low;
+  if (
+    end > 0 &&
+    end < value.length &&
+    /[\uD800-\uDBFF]/u.test(value[end - 1] ?? "") &&
+    /[\uDC00-\uDFFF]/u.test(value[end] ?? "")
+  ) {
+    end -= 1;
+  }
+  return value.slice(0, end);
+};
+
+const utf8SuffixWithin = (value: string, maximumBytes: number) => {
+  const maximumCodeUnits = Math.min(value.length, maximumBytes);
+  let low = 0;
+  let high = maximumCodeUnits;
+  while (low < high) {
+    const middle = Math.ceil((low + high) / 2);
+    if (utf8Length(value.slice(value.length - middle)) <= maximumBytes) {
+      low = middle;
+    } else {
+      high = middle - 1;
+    }
+  }
+  let start = value.length - low;
+  if (
+    start > 0 &&
+    start < value.length &&
+    /[\uD800-\uDBFF]/u.test(value[start - 1] ?? "") &&
+    /[\uDC00-\uDFFF]/u.test(value[start] ?? "")
+  ) {
+    start += 1;
+  }
+  return value.slice(start);
+};
+
+const clippedUtf8 = (
+  value: string,
+  source: "line" | "message" | "patch" = "line",
+  maximumBytes = MAX_CHANGED_LINE_BYTES
+) => {
+  const originalBytes = utf8Length(value);
+  if (originalBytes <= maximumBytes) {
+    return { omittedBytes: 0, text: value };
+  }
+  let omittedBytes = originalBytes - maximumBytes;
+  let marker = "";
+  let head = "";
+  let tail = "";
+  for (let pass = 0; pass < 3; pass += 1) {
+    marker = `…[${omittedBytes} UTF-8 bytes omitted from this ${source}]…`;
+    const available = Math.max(2, maximumBytes - utf8Length(marker));
+    head = utf8PrefixWithin(value, Math.ceil(available / 2));
+    tail = utf8SuffixWithin(value, Math.floor(available / 2));
+    omittedBytes = originalBytes - utf8Length(head) - utf8Length(tail);
+  }
+  marker = `…[${omittedBytes} UTF-8 bytes omitted from this ${source}]…`;
+  return {
+    omittedBytes,
+    text: `${head}${marker}${tail}`,
+  };
+};
+
+const clippedUtf8Line = (value: string) => clippedUtf8(value).text;
+
+const compactedChangedLine = (line: PatchChangedLine): PatchChangedLine => {
+  const clipped = clippedUtf8(line.text);
+  return { ...line, ...clipped };
+};
+
+const chunkChangedLines = (
+  lines: readonly PatchChangedLine[],
+  maximumLines: number,
+  maximumBytes: number
+) => {
+  const chunks: PatchChangedLine[][] = [];
+  let current: PatchChangedLine[] = [];
+  let currentBytes = 0;
+  for (const sourceLine of lines) {
+    const line = compactedChangedLine(sourceLine);
+    const lineBytes = utf8Length(line.text) + 1;
+    if (
+      current.length > 0 &&
+      (current.length >= maximumLines ||
+        currentBytes + lineBytes > maximumBytes)
+    ) {
+      chunks.push(current);
+      current = [];
+      currentBytes = 0;
+    }
+    current.push(line);
+    currentBytes += lineBytes;
+  }
+  if (current.length > 0) {
+    chunks.push(current);
+  }
+  return chunks;
+};
+
+const changeRuns = (lines: readonly PatchChangedLine[]) => {
+  const runs: PatchChangedLine[][] = [];
+  for (const line of lines) {
+    const [sign] = line.text;
+    const current = runs.at(-1);
+    const [firstCurrentLine] = current ?? [];
+    if (
+      current === undefined ||
+      !firstCurrentLine?.text.startsWith(sign ?? "")
+    ) {
+      runs.push([line]);
+    } else {
+      current.push(line);
+    }
+  }
+  return runs;
+};
+
+const atomicSamplesFromBlock = (
+  block: PatchEditBlock,
+  hunkIndex: number,
+  patchIndex: number
+) => {
+  const units: (readonly PatchChangedLine[])[] = [];
+  const runs = changeRuns(block.changedLines);
+  for (let index = 0; index < runs.length; index += 1) {
+    const current = runs[index];
+    const next = runs[index + 1];
+    if (current?.[0]?.text.startsWith("-") && next?.[0]?.text.startsWith("+")) {
+      const removed = chunkChangedLines(
+        current,
+        CHANGED_LINES_PER_SAMPLE / 2,
+        MAX_SAMPLE_BYTES / 2
+      );
+      const added = chunkChangedLines(
+        next,
+        CHANGED_LINES_PER_SAMPLE / 2,
+        MAX_SAMPLE_BYTES / 2
+      );
+      const removedAnchor = removed[0]?.slice(0, 1) ?? [];
+      const addedAnchor = added[0]?.slice(0, 1) ?? [];
+      const parts = Math.max(removed.length, added.length);
+      for (let part = 0; part < parts; part += 1) {
+        units.push([
+          ...(removed[part] ?? removedAnchor),
+          ...(added[part] ?? addedAnchor),
+        ]);
+      }
+      index += 1;
+    } else if (current !== undefined) {
+      units.push(
+        ...chunkChangedLines(
+          current,
+          CHANGED_LINES_PER_SAMPLE,
+          MAX_SAMPLE_BYTES
+        )
+      );
+    }
+  }
+  return spreadOrder(units.length).flatMap((unitIndex) => {
+    const changedLines = units[unitIndex];
+    return changedLines === undefined
+      ? []
+      : [
+          {
+            blockIndex: block.index,
+            changedLines,
+            hunkIndex,
+            kind: "changes" as const,
+            metadataLineEnd: null,
+            metadataLineStart: null,
+            metadataLines: [],
+            partiallyCompactedMetadataLineIndexes: [],
+            patchIndex,
+          },
+        ];
+  });
+};
+
+const changeSamplesFromHunks = (
+  hunks: readonly PatchHunk[],
+  patchIndex: number
+) => {
+  const perHunk = hunks.map((hunk) => {
+    const perBlock = hunk.editBlocks.map((block) =>
+      atomicSamplesFromBlock(block, hunk.index, patchIndex)
+    );
+    const samples: PatchSample[] = [];
+    const maximum = Math.max(0, ...perBlock.map((block) => block.length));
+    for (let round = 0; round < maximum; round += 1) {
+      for (const blockIndex of spreadOrder(perBlock.length)) {
+        const sample = perBlock[blockIndex]?.[round];
+        if (sample !== undefined) {
+          samples.push(sample);
+        }
+      }
+    }
+    return samples;
+  });
+  const samples: PatchSample[] = [];
+  const maximum = Math.max(0, ...perHunk.map((hunk) => hunk.length));
+  for (let round = 0; round < maximum; round += 1) {
+    for (const hunkIndex of spreadOrder(perHunk.length)) {
+      const sample = perHunk[hunkIndex]?.[round];
+      if (sample !== undefined) {
+        samples.push(sample);
+      }
+    }
+  }
+  return samples;
+};
+
+const metadataSamplesFrom = (lines: readonly string[], patchIndex: number) => {
+  const chunks: {
+    end: number;
+    lines: string[];
+    partiallyCompactedLineIndexes: number[];
+    start: number;
+  }[] = [];
+  let current: (typeof chunks)[number] | null = null;
+  let currentBytes = 0;
+  for (const [index, sourceLine] of lines.entries()) {
+    const clipped = clippedUtf8(sourceLine);
+    const line = clipped.text;
+    const lineBytes = utf8Length(line) + 1;
+    if (
+      current !== null &&
+      (current.lines.length >= METADATA_LINES_PER_SAMPLE ||
+        currentBytes + lineBytes > MAX_SAMPLE_BYTES)
+    ) {
+      chunks.push(current);
+      current = null;
+      currentBytes = 0;
+    }
+    current ??= {
+      end: index,
+      lines: [],
+      partiallyCompactedLineIndexes: [],
+      start: index,
+    };
+    current.lines.push(line);
+    if (clipped.omittedBytes > 0) {
+      current.partiallyCompactedLineIndexes.push(index);
+    }
+    current.end = index;
+    currentBytes += lineBytes;
+  }
+  if (current !== null) {
+    chunks.push(current);
+  }
+  return spreadOrder(chunks.length).flatMap((chunkIndex) => {
+    const chunk = chunks[chunkIndex];
+    return chunk === undefined
+      ? []
+      : [
+          {
+            blockIndex: null,
+            changedLines: [],
+            hunkIndex: null,
+            kind: "metadata" as const,
+            metadataLineEnd: chunk.end,
+            metadataLineStart: chunk.start,
+            metadataLines: chunk.lines,
+            partiallyCompactedMetadataLineIndexes:
+              chunk.partiallyCompactedLineIndexes,
+            patchIndex,
+          },
+        ];
+  });
+};
+
+const samplesFromPatch = (
+  hunks: readonly PatchHunk[],
+  metadataLines: readonly string[],
+  patchIndex: number,
+  rawCompaction: RawPatchCompaction | null
+) => {
+  if (rawCompaction !== null) {
+    return [
+      {
+        blockIndex: null,
+        changedLines: [],
+        hunkIndex: null,
+        kind: "raw" as const,
+        metadataLineEnd: null,
+        metadataLineStart: null,
+        metadataLines: rawCompaction.evidenceLines,
+        partiallyCompactedMetadataLineIndexes: [],
+        patchIndex,
+      },
+    ];
+  }
+  const changes = changeSamplesFromHunks(hunks, patchIndex);
+  const metadata = metadataSamplesFrom(metadataLines, patchIndex);
+  const preferred = changes.length === 0 ? metadata : changes;
+  const secondary = changes.length === 0 ? [] : metadata;
+  return [...preferred, ...secondary];
+};
+
+const maximumEvidenceClass = (
+  current: PublicCommitEvidenceClass,
+  candidate: PublicCommitEvidenceClass
+) =>
+  (evidenceClassRank.get(candidate) ?? Number.MAX_VALUE) <
+  (evidenceClassRank.get(current) ?? Number.MAX_VALUE)
+    ? candidate
+    : current;
+
+const patchLineCountWithin = (patch: string, maximum: number) => {
+  let lines = 1;
+  let offset = -1;
+  while (lines <= maximum) {
+    offset = patch.indexOf("\n", offset + 1);
+    if (offset === -1) {
+      return lines;
+    }
+    lines += 1;
+  }
+  return null;
+};
+
+const patchLineCount = (patch: string) => {
+  let lines = 1;
+  let offset = -1;
+  while (true) {
+    offset = patch.indexOf("\n", offset + 1);
+    if (offset === -1) {
+      return lines;
+    }
+    lines += 1;
+  }
+};
+
+const rawCompactedPatchEvidence = (patch: string, originalBytes: number) => {
+  const excerpt = clippedUtf8(patch, "patch");
+  const originalLines = patchLineCount(patch);
+  return {
+    evidenceLines: [
+      `[LOCAL RAW PATCH COMPACTION: semantic hunk parsing skipped to keep memory bounded; ${originalLines} raw lines and ${originalBytes} UTF-8 bytes in the GitHub-returned patch; ${excerpt.omittedBytes} bytes omitted from the deterministic head/tail excerpt below]`,
+      JSON.stringify({ headAndTailPatchExcerpt: excerpt.text }),
+    ],
+    omittedBytes: excerpt.omittedBytes,
+    originalBytes,
+    originalLines,
+  } satisfies RawPatchCompaction;
+};
+
+const uniquePatchesFrom = (
+  sortedFiles: readonly PublicCommitFileEvidence[]
+): readonly UniquePatchEvidence[] => {
+  const patchGroups = new Map<
+    string,
+    {
+      evidenceClass: PublicCommitEvidenceClass;
+      fileIds: string[];
+      firstFilename: string;
+    }
+  >();
+  for (const [index, file] of sortedFiles.entries()) {
+    if (file.patch === null) {
+      continue;
+    }
+    const fileId = `F${String(index + 1).padStart(4, "0")}`;
+    const evidenceClass = publicCommitEvidenceClass(file);
+    const existing = patchGroups.get(file.patch);
+    if (existing === undefined) {
+      patchGroups.set(file.patch, {
+        evidenceClass,
+        fileIds: [fileId],
+        firstFilename: file.filename,
+      });
+    } else {
+      existing.fileIds.push(fileId);
+      existing.evidenceClass = maximumEvidenceClass(
+        existing.evidenceClass,
+        evidenceClass
+      );
+    }
+  }
+  const groups = [...patchGroups.entries()].toSorted(
+    ([, left], [, right]) =>
+      (evidenceClassRank.get(left.evidenceClass) ?? Number.MAX_VALUE) -
+        (evidenceClassRank.get(right.evidenceClass) ?? Number.MAX_VALUE) ||
+      compareText(left.firstFilename, right.firstFilename)
+  );
+  let retainedPatchLines = 0;
+  let retainedPatchBytes = 0;
+  return groups.map(([patch, group], index) => {
+    const patchBytes = utf8Length(patch);
+    const remaining = Math.max(
+      0,
+      MAX_RETAINED_PATCH_LINES - retainedPatchLines
+    );
+    const patchLines = patchLineCountWithin(patch, remaining);
+    const rawCompaction =
+      patchLines === null ||
+      patchBytes > MAX_PARSED_SINGLE_PATCH_BYTES ||
+      retainedPatchBytes + patchBytes > MAX_PARSED_PATCH_BYTES
+        ? rawCompactedPatchEvidence(patch, patchBytes)
+        : null;
+    if (rawCompaction === null && patchLines !== null) {
+      retainedPatchLines += patchLines;
+      retainedPatchBytes += patchBytes;
+    }
+    const parsed =
+      rawCompaction === null
+        ? parsePatch(patch)
+        : { hunks: [], metadataLines: [] };
+    return {
+      ...group,
+      ...parsed,
+      index,
+      patch,
+      rawCompaction,
+      samples: samplesFromPatch(
+        parsed.hunks,
+        parsed.metadataLines,
+        index,
+        rawCompaction
+      ),
+    };
+  });
+};
+
+const compactFileIndexLine = (file: PublicCommitFileEvidence, index: number) =>
+  JSON.stringify({
+    additions: file.additions,
+    deletions: file.deletions,
+    evidenceClass: publicCommitEvidenceClass(file),
+    id: `F${String(index + 1).padStart(4, "0")}`,
+    patchAvailable: file.patch !== null,
+    path: file.filename,
+    previousPath: file.previousFilename,
+    status: file.status,
+  });
+
+const totalChangedLines = (patch: UniquePatchEvidence) =>
+  patch.hunks.reduce((total, hunk) => total + hunk.changedLineCount, 0);
+
+const totalContextLines = (patch: UniquePatchEvidence) =>
+  patch.hunks.reduce((total, hunk) => total + hunk.contextLines, 0);
+
+const ordinalRanges = (ordinals: readonly number[]) => {
+  const sorted = [...new Set(ordinals)].toSorted((left, right) => left - right);
+  const ranges: string[] = [];
+  for (const value of sorted) {
+    const previous = ranges.at(-1);
+    const match =
+      previous === undefined ? null : /^(\d+)(?:-(\d+))?$/u.exec(previous);
+    const end = Number(match?.[2] ?? match?.[1]);
+    if (match !== null && value === end + 1) {
+      ranges[ranges.length - 1] = `${match[1]}-${value}`;
+    } else {
+      ranges.push(String(value));
+    }
+  }
+  return ranges.join(", ");
+};
+
+const renderWholeHunk = (hunk: PatchHunk) => {
+  const body: string[] = [hunk.header];
+  for (const block of hunk.editBlocks) {
+    if (block.contextLinesBefore > 0) {
+      body.push(`[SKIP ${block.contextLinesBefore} UNCHANGED CONTEXT LINES]`);
+    }
+    body.push(...block.changedLines.map((line) => line.text));
+  }
+  if (hunk.trailingContextLines > 0) {
+    body.push(`[SKIP ${hunk.trailingContextLines} UNCHANGED CONTEXT LINES]`);
+  }
+  return body.join("\n");
+};
+
+const renderWholeChangedPatch = (patch: UniquePatchEvidence) => {
+  if (patch.rawCompaction !== null) {
+    return `PATCH P${String(patch.index + 1).padStart(4, "0")}\nfiles: ${patch.fileIds.join(", ")}\nrepresentativePath: ${JSON.stringify(patch.firstFilename)}\nevidenceClass: ${patch.evidenceClass}\ncoverage: semantic changed-line, metadata, and hunk parsing skipped locally for this oversized raw patch\nOVERSIZED RAW PATCH HEAD/TAIL EVIDENCE\n${patch.rawCompaction.evidenceLines.join("\n")}`;
+  }
+  const metadata =
+    patch.metadataLines.length === 0
+      ? []
+      : ["PATCH METADATA", ...patch.metadataLines];
+  const evidence = [...metadata, ...patch.hunks.map(renderWholeHunk)];
+  return `PATCH P${String(patch.index + 1).padStart(4, "0")}\nfiles: ${patch.fileIds.join(", ")}\nrepresentativePath: ${JSON.stringify(patch.firstFilename)}\nevidenceClass: ${patch.evidenceClass}\ncoverage: all ${totalChangedLines(patch)} unique changed lines, ${patch.metadataLines.length} metadata lines, and ${patch.hunks.length} hunks; ${totalContextLines(patch)} unique unchanged context lines replaced by explicit skip markers\n${evidence.join("\n")}`;
+};
+
+const selectedSamplesByPatch = (
+  selected: readonly PatchSample[],
+  patches: readonly UniquePatchEvidence[]
+) => {
+  const byPatch = new Map<number, PatchSample[]>();
+  for (const sample of selected) {
+    const current = byPatch.get(sample.patchIndex) ?? [];
+    current.push(sample);
+    byPatch.set(sample.patchIndex, current);
+  }
+  return patches.flatMap((patch) => {
+    const samples = byPatch.get(patch.index);
+    return samples === undefined ? [] : [{ patch, samples }];
+  });
+};
+
+const renderSelectedMetadata = (
+  patch: UniquePatchEvidence,
+  samples: readonly PatchSample[]
+) => {
+  if (patch.rawCompaction !== null) {
+    return [];
+  }
+  const indexedLines = new Map<number, string>();
+  for (const sample of samples) {
+    if (sample.kind !== "metadata" || sample.metadataLineStart === null) {
+      continue;
+    }
+    for (const [offset, line] of sample.metadataLines.entries()) {
+      indexedLines.set(sample.metadataLineStart + offset, line);
+    }
+  }
+  const selected = [...indexedLines.entries()].toSorted(
+    ([left], [right]) => left - right
+  );
+  if (selected.length === 0) {
+    return [];
+  }
+  const body = [
+    `PATCH METADATA: ${selected.length}/${patch.metadataLines.length} lines represented`,
+  ];
+  let previous = -1;
+  for (const [index, line] of selected) {
+    const omitted = index - previous - 1;
+    if (omitted > 0) {
+      body.push(`[OMITTED ${omitted} PATCH METADATA LINES]`);
+    }
+    body.push(line);
+    previous = index;
+  }
+  const trailing = patch.metadataLines.length - previous - 1;
+  if (trailing > 0) {
+    body.push(`[OMITTED ${trailing} PATCH METADATA LINES]`);
+  }
+  return body;
+};
+
+const changedLinesInBlocks = (blocks: readonly PatchEditBlock[]) => {
+  let total = 0;
+  for (const block of blocks) {
+    total += block.changedLines.length;
+  }
+  return total;
+};
+
+const contextLinesBeforeBlocks = (blocks: readonly PatchEditBlock[]) => {
+  let total = 0;
+  for (const block of blocks) {
+    total += block.contextLinesBefore;
+  }
+  return total;
+};
+
+const omittedBlocksMarker = (blocks: readonly PatchEditBlock[]) =>
+  `[OMITTED ${blocks.length} EDIT BLOCKS WITH ${changedLinesInBlocks(blocks)} CHANGED LINES AND ${contextLinesBeforeBlocks(blocks)} PRECEDING UNCHANGED CONTEXT LINES]`;
+
+const omittedHunksMarker = (hunks: readonly PatchHunk[]) => {
+  let changedLines = 0;
+  let contextLines = 0;
+  for (const hunk of hunks) {
+    changedLines += hunk.changedLineCount;
+    contextLines += hunk.contextLines;
+  }
+  return `[OMITTED ${hunks.length} HUNKS WITH ${changedLines} CHANGED LINES AND ${contextLines} UNCHANGED CONTEXT LINES]`;
+};
+
+const renderSelectedBlock = (
+  hunk: PatchHunk,
+  block: PatchEditBlock,
+  selectedLines: ReadonlyMap<number, string>
+) => {
+  const body: string[] = [];
+  if (block.contextLinesBefore > 0) {
+    body.push(`[SKIP ${block.contextLinesBefore} UNCHANGED CONTEXT LINES]`);
+  }
+  const sortedLines = [...selectedLines.entries()].toSorted(
+    ([left], [right]) => left - right
+  );
+  body.push(
+    `EDIT BLOCK ${block.index + 1}/${hunk.editBlocks.length}; CHANGED-LINE ORDINALS ${ordinalRanges(sortedLines.map(([ordinal]) => ordinal))} OF ${hunk.changedLineCount}`
+  );
+  let previousOrdinal = block.changedLines[0]?.ordinal ?? 1;
+  for (const [ordinal, line] of sortedLines) {
+    const omitted = ordinal - previousOrdinal;
+    if (omitted > 0) {
+      body.push(`[OMITTED ${omitted} CHANGED LINES]`);
+    }
+    body.push(line);
+    previousOrdinal = ordinal + 1;
+  }
+  const blockEnd = block.changedLines.at(-1)?.ordinal ?? previousOrdinal - 1;
+  if (previousOrdinal <= blockEnd) {
+    body.push(`[OMITTED ${blockEnd - previousOrdinal + 1} CHANGED LINES]`);
+  }
+  return body;
+};
+
+const renderSelectedHunk = (
+  hunk: PatchHunk,
+  samples: readonly PatchSample[]
+) => {
+  const byBlock = new Map<number, Map<number, string>>();
+  for (const sample of samples) {
+    if (
+      sample.kind !== "changes" ||
+      sample.hunkIndex !== hunk.index ||
+      sample.blockIndex === null
+    ) {
+      continue;
+    }
+    const selectedLines = byBlock.get(sample.blockIndex) ?? new Map();
+    for (const line of sample.changedLines) {
+      selectedLines.set(line.ordinal, line.text);
+    }
+    byBlock.set(sample.blockIndex, selectedLines);
+  }
+  if (byBlock.size === 0) {
+    return null;
+  }
+  const body: string[] = [clippedUtf8Line(hunk.header)];
+  let previousBlockIndex = -1;
+  for (const [blockIndex, selectedLines] of [...byBlock.entries()].toSorted(
+    ([left], [right]) => left - right
+  )) {
+    const block = hunk.editBlocks[blockIndex];
+    if (block === undefined) {
+      continue;
+    }
+    if (blockIndex > previousBlockIndex + 1) {
+      const omittedBlocks = hunk.editBlocks.slice(
+        previousBlockIndex + 1,
+        blockIndex
+      );
+      body.push(omittedBlocksMarker(omittedBlocks));
+    }
+    body.push(...renderSelectedBlock(hunk, block, selectedLines));
+    previousBlockIndex = blockIndex;
+  }
+  if (previousBlockIndex < hunk.editBlocks.length - 1) {
+    const omittedBlocks = hunk.editBlocks.slice(previousBlockIndex + 1);
+    body.push(omittedBlocksMarker(omittedBlocks));
+  }
+  if (hunk.trailingContextLines > 0) {
+    body.push(`[SKIP ${hunk.trailingContextLines} UNCHANGED CONTEXT LINES]`);
+  }
+  return body.join("\n");
+};
+
+const selectedMetadataIndexes = (sample: PatchSample) => {
+  const start = sample.metadataLineStart;
+  return start === null
+    ? []
+    : sample.metadataLines.map((_, offset) => start + offset);
+};
+
+const renderSampledPatch = (
+  patch: UniquePatchEvidence,
+  samples: readonly PatchSample[]
+) => {
+  if (patch.rawCompaction !== null) {
+    const represented = samples.some((sample) => sample.kind === "raw");
+    const evidence = represented
+      ? patch.rawCompaction.evidenceLines.join("\n")
+      : "[LOCAL RAW PATCH EXCERPT NOT REPRESENTED IN THE REQUEST BUDGET]";
+    return `PATCH P${String(patch.index + 1).padStart(4, "0")}\nfiles: ${patch.fileIds.join(", ")}\nrepresentativePath: ${JSON.stringify(patch.firstFilename)}\nevidenceClass: ${patch.evidenceClass}\ncoverage: semantic changed-line, metadata, and hunk coverage unavailable because this ${patch.rawCompaction.originalLines}-line, ${patch.rawCompaction.originalBytes}-byte GitHub-returned patch was compacted locally before parsing; deterministic head/tail excerpt represented: ${represented}\nOVERSIZED RAW PATCH HEAD/TAIL EVIDENCE\n${evidence}`;
+  }
+  const selectedChangedLines = new Set(
+    samples.flatMap((sample) =>
+      sample.changedLines.map(
+        (line) => `${sample.hunkIndex ?? -1}:${line.ordinal}`
+      )
+    )
+  ).size;
+  const selectedHunks = new Set(
+    samples.flatMap((sample) =>
+      sample.hunkIndex === null ? [] : [sample.hunkIndex]
+    )
+  ).size;
+  const partiallyCompactedChangedLines = new Set(
+    samples.flatMap((sample) =>
+      sample.changedLines.flatMap((line) =>
+        line.omittedBytes === 0
+          ? []
+          : [`${sample.hunkIndex ?? -1}:${line.ordinal}`]
+      )
+    )
+  ).size;
+  const selectedMetadataLines = new Set(
+    samples.flatMap(selectedMetadataIndexes)
+  ).size;
+  const partiallyCompactedMetadataLines = new Set(
+    samples.flatMap((sample) => sample.partiallyCompactedMetadataLineIndexes)
+  ).size;
+  const selectedHunkIndexes = [
+    ...new Set(
+      samples.flatMap((sample) =>
+        sample.hunkIndex === null ? [] : [sample.hunkIndex]
+      )
+    ),
+  ].toSorted((left, right) => left - right);
+  const renderedHunks: string[] = [];
+  let previousHunkIndex = -1;
+  for (const hunkIndex of selectedHunkIndexes) {
+    if (hunkIndex > previousHunkIndex + 1) {
+      renderedHunks.push(
+        omittedHunksMarker(patch.hunks.slice(previousHunkIndex + 1, hunkIndex))
+      );
+    }
+    const hunk = patch.hunks[hunkIndex];
+    const rendered =
+      hunk === undefined ? null : renderSelectedHunk(hunk, samples);
+    if (rendered !== null) {
+      renderedHunks.push(rendered);
+    }
+    previousHunkIndex = hunkIndex;
+  }
+  if (previousHunkIndex < patch.hunks.length - 1) {
+    renderedHunks.push(
+      omittedHunksMarker(patch.hunks.slice(previousHunkIndex + 1))
+    );
+  }
+  const evidence = [
+    ...renderSelectedMetadata(patch, samples),
+    ...renderedHunks,
+  ];
+  return `PATCH P${String(patch.index + 1).padStart(4, "0")}\nfiles: ${patch.fileIds.join(", ")}\nrepresentativePath: ${JSON.stringify(patch.firstFilename)}\nevidenceClass: ${patch.evidenceClass}\ncoverage: ${selectedChangedLines}/${totalChangedLines(patch)} unique changed lines (${partiallyCompactedChangedLines} line-level byte-compacted), ${selectedMetadataLines}/${patch.metadataLines.length} unique-patch metadata lines (${partiallyCompactedMetadataLines} line-level byte-compacted), and ${selectedHunks}/${patch.hunks.length} unique-patch hunks represented; all ${totalContextLines(patch)} unique-patch unchanged context lines omitted with explicit gap markers\n${evidence.join("\n")}`;
+};
+
+const moduleFromPath = (path: string) => {
+  const separator = path.indexOf("/");
+  return separator === -1 ? "[root]" : path.slice(0, separator);
+};
+
+const moduleBreadthPatches = (patches: readonly UniquePatchEvidence[]) => {
+  const byModule = new Map<string, UniquePatchEvidence[]>();
+  for (const patch of patches.toSorted((left, right) =>
+    compareText(left.firstFilename, right.firstFilename)
+  )) {
+    const moduleName = moduleFromPath(patch.firstFilename);
+    const queue = byModule.get(moduleName) ?? [];
+    queue.push(patch);
+    byModule.set(moduleName, queue);
+  }
+  const modules = [...byModule.keys()].toSorted(compareText);
+  const ordered: UniquePatchEvidence[] = [];
+  let round = 0;
+  let found = true;
+  while (found) {
+    found = false;
+    for (const moduleName of modules) {
+      const patch = byModule.get(moduleName)?.[round];
+      if (patch !== undefined) {
+        ordered.push(patch);
+        found = true;
+      }
+    }
+    round += 1;
+  }
+  return ordered;
+};
+
+const sampleQueuesByClass = (patches: readonly UniquePatchEvidence[]) => {
+  const queues = new Map<PublicCommitEvidenceClass, PatchSample[]>();
+  for (const evidenceClass of evidenceClassOrder) {
+    const matching = moduleBreadthPatches(
+      patches.filter((patch) => patch.evidenceClass === evidenceClass)
+    );
+    const queue = matching.flatMap((patch) => patch.samples.slice(0, 1));
+    const maximum = Math.max(
+      0,
+      ...matching.map((patch) => patch.samples.length)
+    );
+    for (let round = 1; round < maximum; round += 1) {
+      for (const patch of matching) {
+        const sample = patch.samples[round];
+        if (sample !== undefined) {
+          queue.push(sample);
+        }
+      }
+    }
+    queues.set(evidenceClass, queue);
+  }
+  return queues;
+};
+
+const renderSampleUnit = (sample: PatchSample) =>
+  sample.kind === "raw"
+    ? `OVERSIZED RAW PATCH HEAD/TAIL EVIDENCE\n${sample.metadataLines.join("\n")}`
+    : sample.kind === "metadata"
+      ? `PATCH METADATA LINES ${Number(sample.metadataLineStart) + 1}-${Number(sample.metadataLineEnd) + 1}\n${sample.metadataLines.join("\n")}`
+      : `HUNK ${Number(sample.hunkIndex) + 1} EDIT BLOCK ${Number(sample.blockIndex) + 1}; CHANGED-LINE ORDINALS ${ordinalRanges(sample.changedLines.map((line) => line.ordinal))}\n${sample.changedLines.map((line) => line.text).join("\n")}`;
+
+const tokenWeightedSampleOrder = async (
+  patches: readonly UniquePatchEvidence[]
+) => {
+  const queues = sampleQueuesByClass(patches);
+  const cursors = new Map<PublicCommitEvidenceClass, number>();
+  const virtualFinish = new Map<PublicCommitEvidenceClass, number>();
+  const costs = new Map<PatchSample, number>();
+  for (const patch of patches) {
+    for (const sample of patch.samples) {
+      costs.set(sample, (await countTextTokens(renderSampleUnit(sample))) + 8);
+    }
+  }
+  const ordered: { cost: number; sample: PatchSample }[] = [];
+  while (
+    evidenceClassOrder.some(
+      (evidenceClass) =>
+        (cursors.get(evidenceClass) ?? 0) <
+        (queues.get(evidenceClass)?.length ?? 0)
+    )
+  ) {
+    const available = evidenceClassOrder.filter(
+      (evidenceClass) =>
+        (cursors.get(evidenceClass) ?? 0) <
+        (queues.get(evidenceClass)?.length ?? 0)
+    );
+    const sortedAvailable = available.toSorted((left, right) => {
+      const difference =
+        (virtualFinish.get(left) ?? 0) - (virtualFinish.get(right) ?? 0);
+      return difference === 0
+        ? evidenceClassOrder.indexOf(left) - evidenceClassOrder.indexOf(right)
+        : difference;
+    });
+    const [selectedClass] = sortedAvailable;
+    if (selectedClass === undefined) {
+      break;
+    }
+    const cursor = cursors.get(selectedClass) ?? 0;
+    const sample = queues.get(selectedClass)?.[cursor];
+    if (sample === undefined) {
+      cursors.set(selectedClass, cursor + 1);
+      continue;
+    }
+    ordered.push({ cost: costs.get(sample) ?? 1, sample });
+    cursors.set(selectedClass, cursor + 1);
+    virtualFinish.set(
+      selectedClass,
+      (virtualFinish.get(selectedClass) ?? 0) +
+        (costs.get(sample) ?? 1) / evidenceClassWeight[selectedClass]
+    );
+  }
+  return ordered;
+};
+
+const sampleCoverage = (
+  patches: readonly UniquePatchEvidence[],
+  selected: readonly PatchSample[] | null
+) => {
+  const allChangedLines = patches.reduce(
+    (total, patch) => total + totalChangedLines(patch),
+    0
+  );
+  const selectedChangedKeys = new Set<string>();
+  const partiallyCompactedChangedKeys = new Set<string>();
+  const selectedMetadataKeys = new Set<string>();
+  const partiallyCompactedMetadataKeys = new Set<string>();
+  const selectedPatchIndexes = new Set<number>();
+  const selectedRawPatchIndexes = new Set<number>();
+  const selectedHunkKeys = new Set<string>();
+  const selectedFileIds = new Set<string>();
+  const selectedChangedKeysByPatch = new Map<number, Set<string>>();
+  if (selected === null) {
+    for (const patch of patches) {
+      selectedPatchIndexes.add(patch.index);
+      if (patch.rawCompaction !== null) {
+        selectedRawPatchIndexes.add(patch.index);
+      }
+      for (const fileId of patch.fileIds) {
+        selectedFileIds.add(fileId);
+      }
+      selectedChangedKeysByPatch.set(
+        patch.index,
+        new Set(
+          patch.hunks.flatMap((hunk) =>
+            hunk.editBlocks.flatMap((block) =>
+              block.changedLines.map((line) => `${hunk.index}:${line.ordinal}`)
+            )
+          )
+        )
+      );
+      for (const hunk of patch.hunks) {
+        selectedHunkKeys.add(`${patch.index}:${hunk.index}`);
+      }
+    }
+  } else {
+    for (const sample of selected) {
+      const patch = patches[sample.patchIndex];
+      if (patch === undefined) {
+        continue;
+      }
+      selectedPatchIndexes.add(patch.index);
+      if (sample.kind === "raw") {
+        selectedRawPatchIndexes.add(patch.index);
+      }
+      for (const fileId of patch.fileIds) {
+        selectedFileIds.add(fileId);
+      }
+      for (const line of sample.changedLines) {
+        const localKey = `${sample.hunkIndex ?? -1}:${line.ordinal}`;
+        const key = `${sample.patchIndex}:${localKey}`;
+        selectedChangedKeys.add(key);
+        const patchKeys =
+          selectedChangedKeysByPatch.get(sample.patchIndex) ?? new Set();
+        patchKeys.add(localKey);
+        selectedChangedKeysByPatch.set(sample.patchIndex, patchKeys);
+        if (line.omittedBytes > 0) {
+          partiallyCompactedChangedKeys.add(key);
+        }
+      }
+      if (sample.hunkIndex !== null) {
+        selectedHunkKeys.add(`${sample.patchIndex}:${sample.hunkIndex}`);
+      }
+      if (sample.kind === "metadata") {
+        for (const metadataIndex of selectedMetadataIndexes(sample)) {
+          selectedMetadataKeys.add(`${sample.patchIndex}:${metadataIndex}`);
+        }
+        for (const metadataIndex of sample.partiallyCompactedMetadataLineIndexes) {
+          partiallyCompactedMetadataKeys.add(
+            `${sample.patchIndex}:${metadataIndex}`
+          );
+        }
+      }
+    }
+  }
+  return {
+    changedLines:
+      selected === null ? allChangedLines : selectedChangedKeys.size,
+    files: selectedFileIds.size,
+    hunks: selectedHunkKeys.size,
+    metadataLines:
+      selected === null
+        ? patches.reduce(
+            (total, patch) => total + patch.metadataLines.length,
+            0
+          )
+        : selectedMetadataKeys.size,
+    partiallyCompactedChangedLines: partiallyCompactedChangedKeys.size,
+    partiallyCompactedMetadataLines: partiallyCompactedMetadataKeys.size,
+    patches: selectedPatchIndexes.size,
+    rawPatches: selectedRawPatchIndexes.size,
+    selectedChangedKeysByPatch,
+  };
+};
+
+const compactManifest = (
+  commit: PublicCommitEvidence,
+  sortedFiles: readonly PublicCommitFileEvidence[],
+  patches: readonly UniquePatchEvidence[],
+  selected: readonly PatchSample[] | null
+) => {
+  const availableFiles = sortedFiles.filter(
+    (file) => file.patch !== null
+  ).length;
+  const parsedPatches = patches.filter((patch) => patch.rawCompaction === null);
+  const rawPatches = patches.filter((patch) => patch.rawCompaction !== null);
+  const uniqueChangedLines = patches.reduce(
+    (total, patch) => total + totalChangedLines(patch),
+    0
+  );
+  const occurrenceChangedLines = patches.reduce(
+    (total, patch) => total + totalChangedLines(patch) * patch.fileIds.length,
+    0
+  );
+  const contextLines = patches.reduce(
+    (total, patch) => total + totalContextLines(patch),
+    0
+  );
+  const totalHunks = patches.reduce(
+    (total, patch) => total + patch.hunks.length,
+    0
+  );
+  const totalMetadataLines = patches.reduce(
+    (total, patch) => total + patch.metadataLines.length,
+    0
+  );
+  const patchChangedLineCount = new Map(
+    parsedPatches.map((patch) => [patch.patch, totalChangedLines(patch)])
+  );
+  const patchCounterMismatchFiles = sortedFiles.filter((file) => {
+    if (file.patch === null) {
+      return false;
+    }
+    const parsedCount = patchChangedLineCount.get(file.patch);
+    return (
+      parsedCount !== undefined &&
+      parsedCount !== file.additions + file.deletions
+    );
+  }).length;
+  const coverage = sampleCoverage(patches, selected);
+  let representedOccurrences = 0;
+  for (const patch of patches) {
+    const represented =
+      coverage.selectedChangedKeysByPatch.get(patch.index)?.size ?? 0;
+    representedOccurrences += represented * patch.fileIds.length;
+  }
+  const rawFileOccurrences = rawPatches.reduce(
+    (total, patch) => total + patch.fileIds.length,
+    0
+  );
+  const rawOriginalBytes = rawPatches.reduce(
+    (total, patch) => total + (patch.rawCompaction?.originalBytes ?? 0),
+    0
+  );
+  const rawOriginalLines = rawPatches.reduce(
+    (total, patch) => total + (patch.rawCompaction?.originalLines ?? 0),
+    0
+  );
+  const rawOmittedBytes = rawPatches.reduce(
+    (total, patch) => total + (patch.rawCompaction?.omittedBytes ?? 0),
+    0
+  );
+  return JSON.stringify(
+    {
+      files: {
+        ...(rawPatches.length === 0
+          ? { patchCounterMismatch: patchCounterMismatchFiles }
+          : {
+              patchCounterComparisonUnavailableDueToLocalRawCompaction:
+                rawFileOccurrences,
+              patchCounterMismatchInParsedPatches: patchCounterMismatchFiles,
+            }),
+        patchEvidenceRepresented: coverage.files,
+        patchReturned: availableFiles,
+        patchUnavailableUpstream: sortedFiles.length - availableFiles,
+        providerFileCapReached: commit.providerFileCapReached,
+        totalReturned: sortedFiles.length,
+      },
+      githubReportedChangedLines: commit.stats.total,
+      hunksInUniquePatches: {
+        available: totalHunks,
+        represented: coverage.hunks,
+      },
+      method:
+        selected === null
+          ? "all GitHub-returned changed lines and patch metadata; unchanged context replaced by explicit skip markers"
+          : rawPatches.length === 0
+            ? "bounded atomic edit samples; token-weighted 6:2:1 product/supporting/low-signal allocation with module and file breadth before depth"
+            : "bounded raw head/tail excerpts for locally unparsed oversized patches plus bounded atomic edit samples for parsed patches; token-weighted 6:2:1 product/supporting/low-signal allocation with module and file breadth before depth",
+      ...(rawPatches.length === 0
+        ? {}
+        : {
+            parsedCoverageScope:
+              "hunk, metadata, changed-line, context-line, occurrence, and counter-mismatch coverage excludes locally raw-compacted patches",
+          }),
+      ...(rawPatches.length === 0
+        ? {}
+        : {
+            localRawPatchCompaction: {
+              bytesOmittedFromExcerpts: rawOmittedBytes,
+              excerptsRepresented: coverage.rawPatches,
+              fileOccurrences: rawFileOccurrences,
+              originalBytes: rawOriginalBytes,
+              originalLines: rawOriginalLines,
+              parsedCoverageCountersExcludeThesePatches: true,
+              uniquePatches: rawPatches.length,
+            },
+          }),
+      patchChangedLineOccurrences: {
+        available: occurrenceChangedLines,
+        ...(rawPatches.length === 0
+          ? {}
+          : { scope: "locally parsed patches only" }),
+        represented: representedOccurrences,
+      },
+      uniquePatchMetadataLines: {
+        available: totalMetadataLines,
+        partiallyCompacted: coverage.partiallyCompactedMetadataLines,
+        represented: coverage.metadataLines,
+      },
+      patches: {
+        ...(rawPatches.length === 0
+          ? {}
+          : {
+              locallyParsed: parsedPatches.length,
+              locallyRawCompacted: rawPatches.length,
+            }),
+        represented: coverage.patches,
+        uniqueReturned: patches.length,
+      },
+      uniquePatchChangedLines: {
+        available: uniqueChangedLines,
+        partiallyCompacted: coverage.partiallyCompactedChangedLines,
+        represented: coverage.changedLines,
+      },
+      uniqueUnchangedContextLinesOmitted: contextLines,
+      version: COMPACT_INPUT_VERSION,
+    },
+    null,
+    2
+  );
+};
+
+const buildCompactModelInput = (
+  commit: PublicCommitEvidence,
+  repository: PublicCommitSummaryRepositoryContext,
+  sortedFiles: readonly PublicCommitFileEvidence[],
+  patches: readonly UniquePatchEvidence[],
+  selected: readonly PatchSample[] | null
+) => {
+  const fileIndex = sortedFiles.map(compactFileIndexLine).join("\n");
+  const patchEvidence =
+    selected === null
+      ? patches.map(renderWholeChangedPatch)
+      : selectedSamplesByPatch(selected, patches).map(({ patch, samples }) =>
+          renderSampledPatch(patch, samples)
+        );
+  return `REPOSITORY EVIDENCE\n${repositoryEvidenceFrom(repository)}\n\nCOMMIT EVIDENCE\n${commitEvidenceFrom(commit, true)}\n${providerCapInstruction}\n\nLARGE COMMIT COMPACTION MANIFEST\n${compactManifest(commit, sortedFiles, patches, selected)}\nThe complete GitHub-returned file ledger below is lossless. GitHub-unavailable, counter-mismatched, locally raw-compacted, and budget-omitted patch evidence are distinct. Parsed samples preserve edit pairs, source order, and explicit gaps; locally raw-compacted patches are explicitly labeled head/tail excerpts. Base conclusions only on represented evidence.\n\nCOMPLETE GITHUB-RETURNED CHANGED FILE LEDGER\n${fileIndex}\n\nCOMPACTED GITHUB-RETURNED PATCH EVIDENCE\n${patchEvidence.join("\n\n")}\n\nEND OF EVIDENCE\n${taskInstruction}`;
+};
+
+const checkedTokenBudget = (value: number) => {
+  if (!Number.isSafeInteger(value) || value < 512) {
+    throw new RangeError(
+      "The public commit summary request token budget must be an integer of at least 512."
+    );
+  }
+  return value;
+};
+
+const compactMessageTokens = async (value: string, keptTokens: number) => {
+  const { decode, encode } = await tokenizer();
+  const tokens = encode(value, {
+    disallowedSpecial: NO_DISALLOWED_SPECIAL_TOKENS,
+  });
+  if (tokens.length <= keptTokens) {
+    return value;
+  }
+  if (keptTokens <= 0) {
+    return `[${tokens.length} message tokens omitted]`;
+  }
+  const head = Math.ceil(keptTokens * 0.75);
+  const tail = keptTokens - head;
+  return `${decode(tokens.slice(0, head))} … [${tokens.length - keptTokens} message tokens omitted] … ${decode(tokens.slice(tokens.length - tail))}`;
+};
+
+const buildExtremeModelInput = async (
+  commit: PublicCommitEvidence,
+  repository: PublicCommitSummaryRepositoryContext,
+  sortedFiles: readonly PublicCommitFileEvidence[],
+  patches: readonly UniquePatchEvidence[],
+  maximum: number
+) => {
+  const allowed =
+    maximum -
+    (await countTextTokens(PUBLIC_COMMIT_SUMMARY_SYSTEM_PROMPT)) -
+    REQUEST_FRAMING_TOKEN_RESERVE;
+  const evidenceClasses = { "low-signal": 0, product: 0, supporting: 0 };
+  for (const file of sortedFiles) {
+    evidenceClasses[publicCommitEvidenceClass(file)] += 1;
+  }
+  const rawPatches = patches.filter((patch) => patch.rawCompaction !== null);
+  const rawPatchStrings = new Set(rawPatches.map((patch) => patch.patch));
+  const parsedPatchChangedLineCount = new Map(
+    patches.flatMap((patch) =>
+      patch.rawCompaction === null
+        ? [[patch.patch, totalChangedLines(patch)] as const]
+        : []
+    )
+  );
+  const rawPatchFileOccurrences = sortedFiles.filter(
+    (file) => file.patch !== null && rawPatchStrings.has(file.patch)
+  ).length;
+  const parsedPatchCounterMismatches = sortedFiles.filter((file) => {
+    if (file.patch === null) {
+      return false;
+    }
+    const parsedCount = parsedPatchChangedLineCount.get(file.patch);
+    return (
+      parsedCount !== undefined &&
+      parsedCount !== file.additions + file.deletions
+    );
+  }).length;
+  const clippedMessage = clippedUtf8(
+    commit.message,
+    "message",
+    MAX_EXTREME_MESSAGE_BYTES
+  );
+  const render = (
+    message: string,
+    includeRepository: boolean,
+    includePatchProvenance: boolean
+  ) =>
+    `EXTREME METADATA COMPACTION (complete file ledger, paths, descriptions, and patch evidence omitted; long message text explicitly clipped)\n${JSON.stringify(
+      {
+        commit: {
+          message,
+          ...(clippedMessage.omittedBytes > 0
+            ? { messageUtf8BytesOmitted: clippedMessage.omittedBytes }
+            : {}),
+          sha: commit.sha,
+          stats: commit.stats,
+        },
+        files: {
+          byEvidenceClass: evidenceClasses,
+          ...(includePatchProvenance
+            ? {
+                patchCounterComparisonUnavailableDueToLocalRawCompaction:
+                  rawPatchFileOccurrences,
+                patchCounterMismatchInParsedPatches:
+                  parsedPatchCounterMismatches,
+              }
+            : {}),
+          patchReturned: sortedFiles.filter((file) => file.patch !== null)
+            .length,
+          ...(includePatchProvenance
+            ? {
+                patchUnavailableUpstream: sortedFiles.filter(
+                  (file) => file.patch === null
+                ).length,
+              }
+            : {}),
+          providerFileCapReached: commit.providerFileCapReached,
+          totalReturned: sortedFiles.length,
+        },
+        ...(includePatchProvenance
+          ? {
+              locallyParsedPatchesOmitted: patches.length - rawPatches.length,
+              locallyRawCompactedPatchesOmitted: rawPatches.length,
+            }
+          : {}),
+        patchesOmitted: patches.length,
+        repository: includeRepository
+          ? {
+              directlyOwned: repository.directlyOwned,
+              fullName: repository.fullName,
+              private: repository.private,
+            }
+          : "[repository fields omitted for request budget]",
+        version: COMPACT_INPUT_VERSION,
+      }
+    )}`;
+  const boundedMessage = clippedMessage.text;
+  const fullMessageTokens = await countTextTokens(boundedMessage);
+  const variants = [
+    { includePatchProvenance: true, includeRepository: true },
+    { includePatchProvenance: true, includeRepository: false },
+    { includePatchProvenance: false, includeRepository: true },
+    { includePatchProvenance: false, includeRepository: false },
+  ];
+  for (const { includePatchProvenance, includeRepository } of variants) {
+    let low = 0;
+    let high = fullMessageTokens;
+    let best: string | null = null;
+    while (low <= high) {
+      const middle = Math.floor((low + high) / 2);
+      const candidate = render(
+        await compactMessageTokens(boundedMessage, middle),
+        includeRepository,
+        includePatchProvenance
+      );
+      if (
+        exactModelInputTokenProbeIsSafe(candidate) &&
+        (await countTextTokens(candidate)) <= allowed
+      ) {
+        best = candidate;
+        low = middle + 1;
+      } else {
+        high = middle - 1;
+      }
+    }
+    if (best !== null) {
+      return best;
+    }
+  }
+  throw new RangeError(
+    "The request token budget cannot hold even the minimal commit evidence manifest."
+  );
+};
+
+const incrementalSampleCost = async (
+  sample: PatchSample,
+  patch: UniquePatchEvidence,
+  firstForPatch: boolean,
+  intrinsicCost: number
+) =>
+  firstForPatch
+    ? (await countTextTokens(renderSampledPatch(patch, [sample]))) + 2
+    : intrinsicCost;
+
+const selectSamplesWithinBudget = async (
+  commit: PublicCommitEvidence,
+  repository: PublicCommitSummaryRepositoryContext,
+  sortedFiles: readonly PublicCommitFileEvidence[],
+  patches: readonly UniquePatchEvidence[],
+  maximum: number
+) => {
+  const render = (selected: readonly PatchSample[]) =>
+    buildCompactModelInput(commit, repository, sortedFiles, patches, selected);
+  const emptyInput = render([]);
+  if (!exactModelInputTokenProbeIsSafe(emptyInput)) {
+    return await buildExtremeModelInput(
+      commit,
+      repository,
+      sortedFiles,
+      patches,
+      maximum
+    );
+  }
+  const emptyTokens = await countCommitPublicSummaryRequestTokens(emptyInput);
+  if (emptyTokens > maximum) {
+    return await buildExtremeModelInput(
+      commit,
+      repository,
+      sortedFiles,
+      patches,
+      maximum
+    );
+  }
+  let remaining = Math.max(
+    0,
+    maximum - emptyTokens - SAMPLE_MANIFEST_TOKEN_RESERVE
+  );
+  const selected: PatchSample[] = [];
+  const selectedPatchIndexes = new Set<number>();
+  for (const { cost: intrinsicCost, sample } of await tokenWeightedSampleOrder(
+    patches
+  )) {
+    const patch = patches[sample.patchIndex];
+    if (patch === undefined) {
+      continue;
+    }
+    const cost = await incrementalSampleCost(
+      sample,
+      patch,
+      !selectedPatchIndexes.has(patch.index),
+      intrinsicCost
+    );
+    if (cost > remaining) {
+      continue;
+    }
+    selected.push(sample);
+    selectedPatchIndexes.add(patch.index);
+    remaining -= cost;
+  }
+  let result = render(selected);
+  while (selected.length > 0) {
+    if (
+      exactModelInputTokenProbeIsSafe(result) &&
+      (await countCommitPublicSummaryRequestTokens(result)) <= maximum
+    ) {
+      break;
+    }
+    selected.pop();
+    result = render(selected);
+  }
+  return result;
+};
+
+export const buildCommitPublicSummaryModelInput = async (
+  commit: PublicCommitEvidence,
+  repository: PublicCommitSummaryRepositoryContext,
+  options: BuildCommitPublicSummaryModelInputOptions = {}
+) => {
+  const maximum = checkedTokenBudget(
+    options.maxRequestInputTokens ??
+      PUBLIC_COMMIT_SUMMARY_MAX_REQUEST_INPUT_TOKENS
+  );
+  const sortedFiles = sortedCommitFiles(commit.files);
+  const fullInput = buildFullModelInput(commit, repository, sortedFiles);
+  if (
+    requestDefinitelyFits(fullInput, maximum) ||
+    (exactModelInputTokenProbeIsSafe(fullInput) &&
+      (await modelInputFitsTokenBudget(fullInput, maximum)))
+  ) {
+    return fullInput;
+  }
+
+  const patches = uniquePatchesFrom(sortedFiles);
+  if (patches.every((patch) => patch.rawCompaction === null)) {
+    const changedOnlyInput = buildCompactModelInput(
+      commit,
+      repository,
+      sortedFiles,
+      patches,
+      null
+    );
+    if (
+      requestDefinitelyFits(changedOnlyInput, maximum) ||
+      (exactModelInputTokenProbeIsSafe(changedOnlyInput) &&
+        (await modelInputFitsTokenBudget(changedOnlyInput, maximum)))
+    ) {
+      return changedOnlyInput;
+    }
+  }
+
+  return await selectSamplesWithinBudget(
+    commit,
+    repository,
+    sortedFiles,
+    patches,
+    maximum
+  );
+};

--- a/src/lib/github-activity-public-summary.ts
+++ b/src/lib/github-activity-public-summary.ts
@@ -1,4 +1,4 @@
-export const PUBLIC_COMMIT_SUMMARY_RECIPE = "public-commit-product-context-v34";
+export const PUBLIC_COMMIT_SUMMARY_RECIPE = "public-commit-product-context-v35";
 export const DEFAULT_PUBLIC_COMMIT_SUMMARY_LOW_LOC_THRESHOLD = 25;
 
 export const PUBLIC_COMMIT_SUMMARY_SYSTEM_PROMPT = `Summarize one software commit for a public engineering portfolio. The reader is casually technical and has no repository context.
@@ -93,6 +93,7 @@ export interface PublicCommitEvidence {
   files: readonly PublicCommitFileEvidence[];
   message: string;
   parents: readonly string[];
+  providerFileCapReached: boolean;
   sha: string;
   stats: PublicCommitStats;
 }
@@ -129,55 +130,17 @@ const isSubstantiveFile = (file: PublicCommitFileEvidence) =>
 const extensionFrom = (filename: string) =>
   /\.([A-Za-z0-9]+)$/u.exec(filename)?.[1]?.toLowerCase() ?? null;
 
-const publicCommitFileMetadata = (file: PublicCommitFileEvidence) =>
-  JSON.stringify(
-    {
-      additions: file.additions,
-      deletions: file.deletions,
-      filename: file.filename,
-      previousFilename: file.previousFilename,
-      status: file.status,
-    },
-    null,
-    2
-  );
+export type PublicCommitEvidenceClass = "low-signal" | "product" | "supporting";
 
-const publicCommitEvidencePriority = (file: PublicCommitFileEvidence) => {
+export const publicCommitEvidenceClass = (
+  file: PublicCommitFileEvidence
+): PublicCommitEvidenceClass => {
   if (!isSubstantiveFile(file)) {
-    return 0;
+    return "low-signal";
   }
-  return supportingEvidencePattern.test(file.filename) ? 1 : 2;
-};
-
-export const buildCommitPublicSummaryModelInput = (
-  commit: PublicCommitEvidence,
-  repository: PublicCommitSummaryRepositoryContext
-) => {
-  const sortedFiles = commit.files.toSorted((left, right) =>
-    left.filename.localeCompare(right.filename)
-  );
-  const evidenceOrder = sortedFiles.toSorted(
-    (left, right) =>
-      publicCommitEvidencePriority(left) - publicCommitEvidencePriority(right)
-  );
-  const repositoryEvidence = JSON.stringify(repository, null, 2);
-  const commitEvidence = JSON.stringify(
-    {
-      committedAt: commit.committedAt,
-      message: commit.message,
-      parents: commit.parents,
-      sha: commit.sha,
-      stats: commit.stats,
-    },
-    null,
-    2
-  );
-  const fileIndex = sortedFiles.map(publicCommitFileMetadata);
-  const changes = evidenceOrder.map((file) => {
-    const metadata = publicCommitFileMetadata(file);
-    return `FILE\n${metadata}\nPATCH\n${file.patch ?? "[patch unavailable from GitHub]"}`;
-  });
-  return `REPOSITORY EVIDENCE\n${repositoryEvidence}\n\nCOMMIT EVIDENCE\n${commitEvidence}\n\nCOMPLETE CHANGED FILE INDEX\n${fileIndex.join("\n\n")}\n\nCOMPLETE CHANGED FILES AND DIFFS\n${changes.join("\n\n")}\n\nEND OF EVIDENCE\nBefore answering, silently complete: “A person using this product can now …” Use that answer as the result when the evidence supports one. Otherwise describe the furthest downstream developer or operational result. Prefer visible behavior over its backing implementation; when visible options narrow feed, search, or listing results, call them filters.`;
+  return supportingEvidencePattern.test(file.filename)
+    ? "supporting"
+    : "product";
 };
 
 export const parseCommitPublicSummary = (

--- a/src/lib/github-activity-store.ts
+++ b/src/lib/github-activity-store.ts
@@ -31,6 +31,7 @@ export interface CompletedGitHubActivity {
   changedFiles: number;
   deletions: number;
   languages: readonly PublicCommitLanguage[];
+  providerFileCapReached: boolean;
   repository: string;
   repositoryOwnerAvatarUrl: string | null;
   repositoryOwnerLogin: string;
@@ -49,6 +50,7 @@ export interface GitHubActivityCounters {
   changedFiles: number;
   deletions: number;
   languages: readonly PublicCommitLanguage[];
+  providerFileCapReached: boolean;
   substantiveLoc: number;
 }
 
@@ -124,6 +126,7 @@ export const completeGitHubActivity = async (
       changedFiles: activity.changedFiles,
       deletions: activity.deletions,
       languages: activity.languages,
+      providerFileCapReached: activity.providerFileCapReached,
       repository: activity.repository,
       repositoryOwnerAvatarUrl: activity.repositoryOwnerAvatarUrl,
       repositoryOwnerLogin: activity.repositoryOwnerLogin,
@@ -315,6 +318,7 @@ export const readPublicGitHubActivityPage = async (
       committedAt: githubCommits.committedAt,
       deletions: githubCommits.deletions,
       languages: githubCommits.languages,
+      providerFileCapReached: githubCommits.providerFileCapReached,
       repository: githubCommits.repository,
       repositoryOwnerAvatarUrl: githubCommits.repositoryOwnerAvatarUrl,
       repositoryOwnerLogin: githubCommits.repositoryOwnerLogin,
@@ -368,6 +372,7 @@ export const readPublicGitHubActivityPage = async (
       sha: row.sha,
     });
     const summaryKind =
+      !row.providerFileCapReached &&
       row.substantiveLoc <= DEFAULT_PUBLIC_COMMIT_SUMMARY_LOW_LOC_THRESHOLD
         ? "headline"
         : "short";
@@ -382,6 +387,7 @@ export const readPublicGitHubActivityPage = async (
         ...language,
         iconUrl: publicLanguageIconUrl(language.id),
       })),
+      providerFileCapReached: row.providerFileCapReached,
       repositoryLabel: repository.repositoryLabel,
       summary:
         summaryKind === "headline" ? row.summaryHeadline : row.summaryShort,

--- a/src/lib/github-activity-types.ts
+++ b/src/lib/github-activity-types.ts
@@ -13,6 +13,7 @@ export interface PublicGitHubActivityItem {
   deletions: number;
   id: string;
   languages: readonly PublicGitHubActivityLanguage[];
+  providerFileCapReached: boolean;
   repositoryLabel: string | null;
   summary: string;
   summaryKind: "headline" | "short";

--- a/tests/github-activity-feed.test.mjs
+++ b/tests/github-activity-feed.test.mjs
@@ -1,5 +1,9 @@
 import { describe, expect, test } from "bun:test";
 
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { GitHubTimeline } from "../src/components/github-timeline.tsx";
 import { githubCommits } from "../src/db/schema.ts";
 import {
   decodeGitHubActivityCursor,
@@ -14,6 +18,55 @@ describe("public GitHub activity projection", () => {
   test("persists both Nano summary variants", () => {
     expect(githubCommits.summaryHeadline.name).toBe("summary_headline");
     expect(githubCommits.summaryShort.name).toBe("summary_short");
+  });
+
+  test("persists whether GitHub capped the returned file evidence", () => {
+    expect(githubCommits.providerFileCapReached.name).toBe(
+      "provider_file_cap_reached"
+    );
+    expect(githubCommits.providerFileCapReached.notNull).toBe(true);
+    expect(githubCommits.providerFileCapReached.hasDefault).toBe(true);
+  });
+
+  test("renders provider-capped evidence as a lower bound", () => {
+    const html = renderToStaticMarkup(
+      createElement(GitHubTimeline, {
+        initialPage: {
+          items: [
+            {
+              additions: 1,
+              avatarUrl: null,
+              changedFiles: 3000,
+              committedAt: "2026-08-28T08:30:00.000Z",
+              deletions: 2,
+              id: "provider-capped-commit",
+              languages: [
+                {
+                  changedLines: 3,
+                  iconUrl: null,
+                  id: "typescript",
+                  label: "TypeScript",
+                },
+              ],
+              providerFileCapReached: true,
+              repositoryLabel: null,
+              summary: "Improves a large change.",
+              summaryKind: "short",
+              url: null,
+            },
+          ],
+          nextCursor: null,
+        },
+      })
+    );
+
+    expect(html).toContain("3000+ files");
+    expect(html).toContain(
+      "3000 or more changed files; GitHub caps returned file details at 3,000 files"
+    );
+    expect(html).toContain(
+      'aria-label="Languages found in the first 3,000 files returned by GitHub; the full commit may include more"'
+    );
   });
 
   test("round trips an opaque cursor without repository identity", () => {

--- a/tests/github-activity-processor.test.mjs
+++ b/tests/github-activity-processor.test.mjs
@@ -1,0 +1,91 @@
+import { afterEach, describe, expect, test } from "bun:test";
+
+import { fetchGitHubActivityCommitSource } from "../src/lib/github-activity-processor.ts";
+
+const originalFetch = globalThis.fetch;
+const originalF0rr0Token = process.env.GITHUB_F0RR0_TOKEN;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  if (originalF0rr0Token === undefined) {
+    delete process.env.GITHUB_F0RR0_TOKEN;
+  } else {
+    process.env.GITHUB_F0RR0_TOKEN = originalF0rr0Token;
+  }
+});
+
+describe("GitHub activity commit acquisition", () => {
+  test("accepts an exactly full 3,000-file response and marks the provider cap", async () => {
+    const sha = "a".repeat(40);
+    const parentSha = "b".repeat(40);
+    const filenames = Array.from(
+      { length: 3000 },
+      (_, index) => `src/file-${String(index).padStart(4, "0")}.ts`
+    );
+    filenames[0] = "é.ts";
+    filenames[1] = "z.ts";
+    filenames[2] = "A.ts";
+    const requestedPages = [];
+
+    process.env.GITHUB_F0RR0_TOKEN = "test-token";
+    globalThis.fetch = async (input) => {
+      const url =
+        input instanceof Request ? new URL(input.url) : new URL(input);
+      if (url.pathname === "/repos/example-org/example-repo") {
+        return Response.json({
+          description: "Example repository",
+          full_name: "example-org/example-repo",
+          homepage: null,
+          id: 123,
+          owner: {
+            avatar_url: "https://avatars.githubusercontent.com/u/123?v=4",
+            login: "example-org",
+            type: "Organization",
+          },
+          private: false,
+          topics: [],
+        });
+      }
+
+      expect(url.pathname).toBe(
+        `/repos/example-org/example-repo/commits/${sha}`
+      );
+      const page = Number(url.searchParams.get("page"));
+      requestedPages.push(page);
+      const offset = (page - 1) * 100;
+      return Response.json({
+        author: { login: "f0rr0" },
+        commit: {
+          author: { date: "2026-08-28T12:00:00Z" },
+          message: "feat: process a very large commit",
+        },
+        files: filenames.slice(offset, offset + 100).map((filename) => ({
+          additions: 1,
+          deletions: 0,
+          filename,
+          patch: "+change",
+          status: "modified",
+        })),
+        parents: [{ sha: parentSha }],
+        sha,
+        stats: { additions: 3000, deletions: 0, total: 3000 },
+      });
+    };
+
+    const source = await fetchGitHubActivityCommitSource({
+      author: "f0rr0",
+      committedAt: "2026-08-28T12:00:00.000Z",
+      message: "feat: process a very large commit",
+      repository: "example-org/example-repo",
+      repositoryId: "123",
+      sha,
+    });
+
+    expect(requestedPages).toEqual(Array.from({ length: 30 }, (_, i) => i + 1));
+    expect(source.commit.files).toHaveLength(3000);
+    expect(source.commit.providerFileCapReached).toBe(true);
+    expect(source.commit.files[0]?.filename).toBe("A.ts");
+    expect(source.commit.files.at(-2)?.filename).toBe("z.ts");
+    expect(source.commit.files.at(-1)?.filename).toBe("é.ts");
+  });
+});

--- a/tests/github-activity-public-summary.test.mjs
+++ b/tests/github-activity-public-summary.test.mjs
@@ -2,6 +2,9 @@ import { describe, expect, test } from "bun:test";
 
 import {
   buildCommitPublicSummaryModelInput,
+  countCommitPublicSummaryRequestTokens,
+} from "../src/lib/github-activity-public-summary-input.ts";
+import {
   deriveCommitLanguages,
   formatPublicCommitSummaryMarkdown,
   parseCommitPublicSummary,
@@ -43,10 +46,18 @@ const commit = (
     files,
     message,
     parents: ["parent"],
+    providerFileCapReached: false,
     sha: "sha",
     stats: { additions, deletions, total: additions + deletions },
   };
 };
+
+const largePatch = (label) =>
+  `@@ -1,360 +1,360 @@ ${label}Feature()\n context for ${label}\n${Array.from(
+    { length: 360 },
+    (_, index) =>
+      `+${label}_${index === 359 ? "END" : String(index).padStart(3, "0")}`
+  ).join("\n")}\n trailing context for ${label}`;
 
 describe("public commit summaries", () => {
   test("parses the requested shape and preserves every other nonempty response", () => {
@@ -127,8 +138,8 @@ describe("public commit summaries", () => {
     expect(formatted.short).toBe(summary.short);
   });
 
-  test("builds the canonical full-diff input with complete repository context", () => {
-    const input = buildCommitPublicSummaryModelInput(
+  test("builds the canonical full-diff input with complete repository context", async () => {
+    const input = await buildCommitPublicSummaryModelInput(
       commit([
         file("src/session.ts", 2, 1, "+refreshSession();"),
         file("tests/session.test.ts", 3, 0, "+expect(refresh).toWork();"),
@@ -153,9 +164,16 @@ describe("public commit summaries", () => {
     expect(input).toContain("src/session.ts");
     expect(input).toContain("+refreshSession();");
     expect(input).toContain("tests/session.test.ts");
+    expect(input).toContain("COMPLETE GITHUB-RETURNED CHANGED FILE INDEX");
+    expect(input).toContain("GITHUB-RETURNED CHANGED FILES AND PATCH EVIDENCE");
+    expect(input).toContain("GITHUB-RETURNED PATCH");
+    expect(input).not.toContain("providerFileCapReached");
+    expect(input.indexOf("tests/session.test.ts")).toBeLessThan(
+      input.lastIndexOf("src/session.ts")
+    );
   });
 
-  test("does not clip long repository, message, filename, or patch evidence", () => {
+  test("does not clip long repository, message, filename, or patch evidence", async () => {
     const descriptionTail = "DESCRIPTION_TAIL";
     const messageTail = "MESSAGE_TAIL";
     const firstPatchTail = "FIRST_PATCH_TAIL";
@@ -178,7 +196,7 @@ describe("public commit summaries", () => {
         `${"-const last = false;\n".repeat(10_000)}${lastPatchTail}`
       ),
     ];
-    const input = buildCommitPublicSummaryModelInput(
+    const input = await buildCommitPublicSummaryModelInput(
       commit(files, `${"Detailed intent. ".repeat(500)}${messageTail}`),
       context
     );
@@ -188,6 +206,424 @@ describe("public commit summaries", () => {
     expect(input).toContain(lastPatchTail);
     expect(input).toContain("deep-directory/".repeat(100));
     expect(input).not.toContain("excerpt truncated");
+  });
+
+  test("switches to lossless changed-line compaction only above the token budget", async () => {
+    const contextTail = "CONTEXT_TAIL_SHOULD_BE_OMITTED";
+    const changedTail = "+CHANGED_TAIL_MUST_REMAIN";
+    const context = `${" unchanged context for the function\n".repeat(900)} ${contextTail}\n`;
+    const patch = `@@ -1,900 +1,21 @@ buildProductFeed()\n${context}+firstChange\n${Array.from({ length: 18 }, (_, index) => `+change_${index}`).join("\n")}\n${changedTail}`;
+    const source = commit([file("src/feed.ts", 21, 0, patch)]);
+    const full = await buildCommitPublicSummaryModelInput(
+      source,
+      repositoryContext
+    );
+    const fullTokens = await countCommitPublicSummaryRequestTokens(full);
+
+    expect(
+      await buildCommitPublicSummaryModelInput(source, repositoryContext, {
+        maxRequestInputTokens: fullTokens,
+      })
+    ).toBe(full);
+
+    const compacted = await buildCommitPublicSummaryModelInput(
+      source,
+      repositoryContext,
+      { maxRequestInputTokens: fullTokens - 1 }
+    );
+    expect(compacted).toContain("LARGE COMMIT COMPACTION MANIFEST");
+    expect(compacted).toContain(
+      "all GitHub-returned changed lines and patch metadata"
+    );
+    expect(compacted).toContain(changedTail);
+    expect(compacted).not.toContain(contextTail);
+    expect(
+      await countCommitPublicSummaryRequestTokens(compacted)
+    ).toBeLessThanOrEqual(fullTokens - 1);
+  });
+
+  test("samples oversized patches fairly, deduplicates them, and keeps the complete ledger", async () => {
+    const productPatch = largePatch("PRODUCT");
+    const files = [
+      file("src/product.ts", 360, 0, productPatch),
+      file("src/product-copy.ts", 360, 0, productPatch),
+      file("tests/product.test.ts", 360, 0, largePatch("SUPPORTING")),
+      file("dist/generated.min.js", 360, 0, largePatch("GENERATED")),
+      file("assets/unavailable.bin", 1, 0, null),
+    ];
+    const source = commit(files, "feat: expand the product capability");
+    const compacted = await buildCommitPublicSummaryModelInput(
+      source,
+      repositoryContext,
+      { maxRequestInputTokens: 2600 }
+    );
+    const permuted = await buildCommitPublicSummaryModelInput(
+      commit(files.toReversed(), "feat: expand the product capability"),
+      repositoryContext,
+      { maxRequestInputTokens: 2600 }
+    );
+
+    expect(compacted).toBe(permuted);
+    expect(
+      await countCommitPublicSummaryRequestTokens(compacted)
+    ).toBeLessThanOrEqual(2600);
+    for (const changedFile of files) {
+      expect(compacted).toContain(changedFile.filename);
+    }
+    expect(compacted).toContain('"patchAvailable":false');
+    expect(compacted).toContain('"uniqueReturned": 3');
+    expect(compacted).toMatch(/files: F\d{4}, F\d{4}/u);
+    expect(compacted).toContain("PRODUCT_000");
+    expect(compacted).toContain("SUPPORTING_000");
+    expect(compacted).toContain("GENERATED_000");
+    expect(compacted).not.toContain("trailing context for PRODUCT");
+    expect(compacted).toContain("token-weighted 6:2:1");
+  });
+
+  test("an oversized early sample cannot suppress later product evidence", async () => {
+    const oversizedGeneratedPatch = `@@ -0,0 +1 @@ generatedBundle()\n+${"x".repeat(30_000)}`;
+    const productSignal = "+PRODUCT_SIGNAL_MUST_SURVIVE";
+    const source = commit(
+      [
+        file("dist/generated.min.js", 1, 0, oversizedGeneratedPatch),
+        file(
+          "src/product.ts",
+          1,
+          0,
+          `@@ -0,0 +1 @@ addProductCapability()\n${productSignal}`
+        ),
+      ],
+      "feat: add the product capability"
+    );
+    const compacted = await buildCommitPublicSummaryModelInput(
+      source,
+      repositoryContext,
+      { maxRequestInputTokens: 2000 }
+    );
+
+    expect(
+      await countCommitPublicSummaryRequestTokens(compacted)
+    ).toBeLessThanOrEqual(2000);
+    expect(compacted).toContain("token-weighted 6:2:1");
+    expect(compacted).toContain(productSignal);
+    expect(compacted).toContain('"partiallyCompacted": 1');
+    expect(compacted).toMatch(/\[\d+ UTF-8 bytes omitted from this line\]/u);
+  });
+
+  test("does not count pre-hunk diff headers as changed lines", async () => {
+    const contextTail = "PRE_HUNK_CONTEXT_TAIL";
+    const patch = `diff --git a/src/feed.ts b/src/feed.ts
+index 1111111..2222222 100644
+--- a/src/feed.ts
++++ b/src/feed.ts
+@@ -1,2 +1,2 @@ buildFeed()
+-oldFilter
++newFilter
+${` unchanged context\n`.repeat(900)} ${contextTail}`;
+    const source = commit([file("src/feed.ts", 1, 1, patch)]);
+    const full = await buildCommitPublicSummaryModelInput(
+      source,
+      repositoryContext
+    );
+    const compacted = await buildCommitPublicSummaryModelInput(
+      source,
+      repositoryContext,
+      {
+        maxRequestInputTokens:
+          (await countCommitPublicSummaryRequestTokens(full)) - 1,
+      }
+    );
+
+    expect(compacted).toContain("LARGE COMMIT COMPACTION MANIFEST");
+    expect(compacted).toContain(
+      '"uniquePatchChangedLines": {\n    "available": 2'
+    );
+    expect(compacted).toContain("-oldFilter");
+    expect(compacted).toContain("+newFilter");
+    expect(compacted).not.toContain(contextTail);
+  });
+
+  test("renders sampled chunks in source order with explicit changed-line gaps", async () => {
+    const changedLines = Array.from(
+      { length: 360 },
+      (_, index) =>
+        `+ORDER_${String(index).padStart(3, "0")}_${"detail ".repeat(4)}`
+    );
+    const source = commit([
+      file(
+        "src/order.ts",
+        changedLines.length,
+        0,
+        `@@ -0,0 +1,360 @@ preserveSourceOrder()\n${changedLines.join("\n")}`
+      ),
+    ]);
+    const compacted = await buildCommitPublicSummaryModelInput(
+      source,
+      repositoryContext,
+      { maxRequestInputTokens: 2400 }
+    );
+    const start = compacted.indexOf("ORDER_000");
+    const middle = compacted.indexOf("ORDER_162");
+    const end = compacted.indexOf("ORDER_342");
+
+    expect(start).toBeGreaterThanOrEqual(0);
+    expect(middle).toBeGreaterThan(start);
+    expect(end).toBeGreaterThan(middle);
+    expect(compacted).toMatch(
+      /(?:gap|omitted)[^\n]*changed lines|changed lines[^\n]*(?:gap|omitted)/iu
+    );
+  });
+
+  test("keeps both sides of a large replacement in its breadth sample", async () => {
+    const removed = Array.from(
+      { length: 180 },
+      (_, index) => `-OLD_VALUE_${String(index).padStart(3, "0")}`
+    );
+    const added = Array.from(
+      { length: 180 },
+      (_, index) => `+NEW_VALUE_${String(index).padStart(3, "0")}`
+    );
+    const source = commit([
+      file(
+        "src/replacement.ts",
+        added.length,
+        removed.length,
+        `@@ -1,180 +1,180 @@ replaceValues()\n${[...removed, ...added].join("\n")}`
+      ),
+    ]);
+    const compacted = await buildCommitPublicSummaryModelInput(
+      source,
+      repositoryContext,
+      { maxRequestInputTokens: 1500 }
+    );
+
+    expect(compacted).toContain("token-weighted 6:2:1");
+    expect(compacted).toContain("-OLD_VALUE_000");
+    expect(compacted).toContain("+NEW_VALUE_000");
+    expect(compacted.indexOf("-OLD_VALUE_000")).toBeLessThan(
+      compacted.indexOf("+NEW_VALUE_000")
+    );
+  });
+
+  test("never emits a one-sided residual sample for an unbalanced replacement", async () => {
+    const added = Array.from(
+      { length: 60 },
+      (_, index) => `+NEW_VALUE_${String(index).padStart(2, "0")}`
+    );
+    const source = commit([
+      file(
+        "src/unbalanced.ts",
+        added.length,
+        1,
+        `@@ -1 +1,60 @@ replaceGeneratedValue()\n-${"old".repeat(10_000)}\n${added.join("\n")}`
+      ),
+    ]);
+    const compacted = await buildCommitPublicSummaryModelInput(
+      source,
+      repositoryContext,
+      { maxRequestInputTokens: 1800 }
+    );
+
+    expect(compacted).toContain("+NEW_VALUE_");
+    expect(compacted).toContain("-old");
+    expect(compacted).toContain("UTF-8 bytes omitted from this line");
+  });
+
+  test("marks wholly omitted hunks and their context", async () => {
+    const hunks = Array.from({ length: 5 }, (_, hunkIndex) => {
+      const additions = Array.from(
+        { length: 100 },
+        (_, lineIndex) =>
+          `+HUNK_${hunkIndex}_${String(lineIndex).padStart(3, "0")}`
+      );
+      return `@@ -${hunkIndex + 1} +${hunkIndex * 100 + 1},100 @@ hunk${hunkIndex}()\n context\n${additions.join("\n")}`;
+    });
+    const source = commit([file("src/hunks.ts", 500, 0, hunks.join("\n"))]);
+    const compacted = await buildCommitPublicSummaryModelInput(
+      source,
+      repositoryContext,
+      { maxRequestInputTokens: 1700 }
+    );
+
+    expect(compacted).toMatch(
+      /\[OMITTED \d+ HUNKS WITH \d+ CHANGED LINES AND \d+ UNCHANGED CONTEXT LINES\]/u
+    );
+  });
+
+  test("reports byte-compacted patch metadata lines", async () => {
+    const source = commit([
+      file(
+        "src/binary.patch",
+        0,
+        0,
+        `GIT binary patch\nliteral 100000\n${"encoded".repeat(10_000)}`
+      ),
+    ]);
+    const compacted = await buildCommitPublicSummaryModelInput(
+      source,
+      repositoryContext,
+      { maxRequestInputTokens: 1700 }
+    );
+
+    expect(compacted).toContain('"uniquePatchMetadataLines": {');
+    expect(compacted).toContain('"partiallyCompacted": 1');
+    expect(compacted).toContain("UTF-8 bytes omitted from this line");
+  });
+
+  test("raw-compacts a giant single-line patch before exact tokenization", async () => {
+    const giantLine = "x".repeat(4_100_000);
+    const source = commit([
+      file(
+        "dist/bundle.min.js",
+        1,
+        0,
+        `@@ -0,0 +1 @@ generatedBundle()\n+${giantLine}`
+      ),
+    ]);
+    const compacted = await buildCommitPublicSummaryModelInput(
+      source,
+      repositoryContext,
+      { maxRequestInputTokens: 2500 }
+    );
+
+    expect(compacted).toContain("LOCAL RAW PATCH COMPACTION");
+    expect(compacted).toContain("OVERSIZED RAW PATCH HEAD/TAIL EVIDENCE");
+    expect(compacted).toContain('"locallyRawCompacted": 1');
+    expect(compacted).toContain(
+      '"patchCounterComparisonUnavailableDueToLocalRawCompaction": 1'
+    );
+    expect(compacted).not.toContain('"patchCounterMismatch": 1');
+    expect(
+      await countCommitPublicSummaryRequestTokens(compacted)
+    ).toBeLessThanOrEqual(2500);
+  });
+
+  test("does not exact-tokenize a large unbroken patch below the global byte guard", async () => {
+    const source = commit([
+      file(
+        "src/binary.patch",
+        0,
+        0,
+        `GIT binary patch\nliteral 280000\n${"encoded".repeat(40_000)}`
+      ),
+    ]);
+    const compacted = await buildCommitPublicSummaryModelInput(
+      source,
+      repositoryContext
+    );
+
+    expect(compacted).toContain("LARGE COMMIT COMPACTION MANIFEST");
+    expect(compacted).toContain("UTF-8 bytes omitted from this line");
+    expect(
+      await countCommitPublicSummaryRequestTokens(compacted)
+    ).toBeLessThanOrEqual(240_000);
+  });
+
+  test("keeps an unbroken line whole when UTF-8 bytes already prove it fits", async () => {
+    const tail = "UNBROKEN_BYTE_PROVEN_TAIL";
+    const input = await buildCommitPublicSummaryModelInput(
+      commit([
+        file(
+          "src/generated.ts",
+          1,
+          0,
+          `@@ -0,0 +1 @@ generatedValue()\n+${"x".repeat(70_000)}${tail}`
+        ),
+      ]),
+      repositoryContext
+    );
+
+    expect(input).not.toContain("LARGE COMMIT COMPACTION MANIFEST");
+    expect(input).toContain(tail);
+  });
+
+  test("keeps a large ordinary multiline patch whole when its tokens fit", async () => {
+    const patch = `@@ -0,0 +1,35000 @@ generatedValues()\n${"+encoded\n".repeat(35_000)}+MULTILINE_TAIL`;
+    const input = await buildCommitPublicSummaryModelInput(
+      commit([file("src/values.ts", 35_001, 0, patch)]),
+      repositoryContext
+    );
+
+    expect(input).not.toContain("LARGE COMMIT COMPACTION MANIFEST");
+    expect(input).toContain("+MULTILINE_TAIL");
+    expect(
+      await countCommitPublicSummaryRequestTokens(input)
+    ).toBeLessThanOrEqual(240_000);
+  });
+
+  test("bounds semantic parsing across extremely line-dense patches", async () => {
+    const densePatch = `@@ -0,0 +1,100010 @@ denseGeneratedFile()\n${"+x\n".repeat(100_010)}`;
+    const compacted = await buildCommitPublicSummaryModelInput(
+      commit([file("dist/dense.js", 100_010, 0, densePatch)]),
+      repositoryContext,
+      { maxRequestInputTokens: 2500 }
+    );
+
+    expect(compacted).toContain("LOCAL RAW PATCH COMPACTION");
+    expect(compacted).toContain('"originalLines": 100012');
+    expect(compacted).toContain('"uniquePatches": 1');
+    expect(compacted).toContain("UTF-8 bytes omitted from this patch");
+    expect(compacted).not.toContain("bytes omitted from this line");
+    expect(
+      await countCommitPublicSummaryRequestTokens(compacted)
+    ).toBeLessThanOrEqual(2500);
+  });
+
+  test("uses stable non-locale filename ordering", async () => {
+    const files = [
+      file("src/á.ts", 1, 0, "+COMBINING_FORM"),
+      file("src/á.ts", 1, 0, "+COMPOSED_FORM"),
+    ];
+    const forward = await buildCommitPublicSummaryModelInput(
+      commit(files),
+      repositoryContext
+    );
+    const reversed = await buildCommitPublicSummaryModelInput(
+      commit(files.toReversed()),
+      repositoryContext
+    );
+
+    expect(forward).toBe(reversed);
+  });
+
+  test("hard-fits pathological metadata with an explicit marker", async () => {
+    const source = commit(
+      [file("src/index.ts", 1, 0, "+change")],
+      `feat: ${Array.from({ length: 4000 }, (_, index) => `intent_${index}`).join(" ")}`
+    );
+    const compacted = await buildCommitPublicSummaryModelInput(
+      source,
+      repositoryContext,
+      { maxRequestInputTokens: 512 }
+    );
+    expect(compacted).toContain("EXTREME METADATA COMPACTION");
+    expect(compacted).toContain('"stats"');
+    expect(compacted).toContain('"totalReturned":1');
+    expect(
+      await countCommitPublicSummaryRequestTokens(compacted)
+    ).toBeLessThanOrEqual(512);
+  });
+
+  test("byte-bounds a pathological commit message before extreme tokenization", async () => {
+    const compacted = await buildCommitPublicSummaryModelInput(
+      commit([], "encoded".repeat(40_000)),
+      repositoryContext,
+      { maxRequestInputTokens: 512 }
+    );
+
+    expect(compacted).toContain("EXTREME METADATA COMPACTION");
+    expect(compacted).toMatch(/"messageUtf8BytesOmitted":26\d{4,}/u);
+    expect(
+      await countCommitPublicSummaryRequestTokens(compacted)
+    ).toBeLessThanOrEqual(512);
+  });
+
+  test("treats tokenizer special-token text as ordinary commit evidence", async () => {
+    const input = await buildCommitPublicSummaryModelInput(
+      commit([file("src/index.ts", 1, 0, "+const marker = '<|endoftext|>';")]),
+      repositoryContext
+    );
+    expect(input).toContain("<|endoftext|>");
   });
 
   test("derives languages and substantive LOC from GitHub file counters", () => {


### PR DESCRIPTION
## Summary

- deterministically compact oversized GitHub commit evidence into one bounded Nano request
- preserve truthful coverage and provenance for missing, sampled, raw-compacted, and provider-capped evidence
- persist and display GitHub’s 3,000-file cap as a lower bound
- repair the two previously failed 780-file summaries without adding retries

## Validation

- `bun run lint`
- `bun run typecheck`
- `bun test` (56 tests)
- `bun run build`
- real 780-file dry run: 238,612 request tokens, 374 MB peak RSS, no model call