### PR TITLE
feat(github): show every commit headline

### DIFF
--- a/docs/github-activity-public-commit-summaries.md
+++ b/docs/github-activity-public-commit-summaries.md
@@ -15,7 +15,7 @@ verified tracked-author commit
   -> derive languages and substantive churn from the per-file counters
   -> one gpt-5-nano call producing both public summary lengths
   -> persist both Nano summaries, recipe/model/input hash, languages, and churn
-  -> show the headline for low-churn commits; otherwise show short
+  -> always show the headline; add short for higher-churn commits
 ```
 
 The model runs once per commit with no retry and `store: false`. The generic
@@ -30,11 +30,12 @@ Nano is asked to use inline Markdown backticks for exact code terms and no other
 Markdown. A deterministic final pass formats unmistakable identifiers, HTTP
 methods, flags, package names, calls, and common commands that Nano misses.
 
-Both variants describe the same central change. The page selects between them
-procedurally; a model does not decide presentation length. The initial low-churn
-boundary is 25 substantive additions plus deletions and remains an evaluated,
-configurable product threshold. Generated output, lockfiles, vendored files,
-and binary assets do not inflate that decision.
+Both variants describe the same central change. Every timeline item shows its
+headline. The page also shows the short explanation above the procedural churn
+threshold; a model does not decide presentation length. The initial boundary is
+25 substantive additions plus deletions and remains an evaluated, configurable
+product threshold. Generated output, lockfiles, vendored files, and binary
+assets do not inflate that decision.
 
 Languages are derived exclusively from changed filename extensions, ordered by
 substantive changed lines, and stored separately from model prose. The model is
@@ -137,8 +138,8 @@ rejection, response-length rejection, shape rejection, or display truncation.
 Any response containing at least one non-whitespace character succeeds. When
 both labels are recognizable, their values are stored separately. Otherwise,
 the complete response is preserved as both variants, so unexpected formatting
-does not discard model output. Whichever stored variant the page selects is
-shown in full. The deterministic final pass only adds missing Markdown
+does not discard model output. Every displayed stored variant is shown in full.
+The deterministic final pass only adds missing Markdown
 backticks to unmistakable code references and capitalizes the first headline
 character; it does not remove text.
 
@@ -155,8 +156,9 @@ still be excluded procedurally. Missing or truncated patch text does not make
 these counts partial. Patch text is used only as Nano evidence.
 
 Both Nano outputs are persisted in `summary_headline` and `summary_short` along
-with their exact model snapshot, prompt recipe, and input hash. The page chooses
-between the two stored values without another model call.
+with their exact model snapshot, prompt recipe, and input hash. The page always
+uses the headline and conditionally adds the short value without another model
+call.
 
 When a prompt recipe changes, `bun run github:refresh-summaries` makes one new
 Nano attempt for each stale completed row. Successful outputs replace only the

--- a/docs/github-commits.md
+++ b/docs/github-commits.md
@@ -285,7 +285,8 @@ Repository presentation is deliberately separate from stored source data:
 The client never receives repository IDs, SHAs, full repository names, author
 handles, raw commit messages, file paths, or patches. Each UTC date is rendered
 as a section. Commits with at most 25 substantive GitHub-reported changed lines
-use the stored headline; larger commits use the stored detailed summary.
+show only the stored headline; larger or provider-capped commits also show the
+stored detailed summary.
 
 ## Deliberate limits
 

--- a/src/components/github-timeline.tsx
+++ b/src/components/github-timeline.tsx
@@ -137,15 +137,14 @@ function ActivityEntry({ item }: Readonly<{ item: PublicGitHubActivityItem }>) {
           </time>
         </div>
 
-        {item.summaryKind === "headline" ? (
-          <h4 className="github-activity-headline">
-            <InlineSummary>{item.summary}</InlineSummary>
-          </h4>
-        ) : (
+        <h4 className="github-activity-headline">
+          <InlineSummary>{item.headline}</InlineSummary>
+        </h4>
+        {item.summaryKind === "short" ? (
           <p className="github-activity-summary">
             <InlineSummary>{item.summary}</InlineSummary>
           </p>
-        )}
+        ) : null}
 
         <div className="github-activity-facts">
           <span

--- a/src/lib/github-activity-feed.ts
+++ b/src/lib/github-activity-feed.ts
@@ -16,7 +16,7 @@ const EMPTY_PAGE: PublicGitHubActivityPage = {
 
 const readCachedInitialActivity = unstable_cache(
   async () => await readPublicGitHubActivityPage(null),
-  ["public-github-activity-v2"],
+  ["public-github-activity-v3"],
   { revalidate: 900, tags: ["github-activity"] }
 );
 

--- a/src/lib/github-activity-store.ts
+++ b/src/lib/github-activity-store.ts
@@ -382,6 +382,7 @@ export const readPublicGitHubActivityPage = async (
       changedFiles: row.changedFiles,
       committedAt: row.committedAt.toISOString(),
       deletions: row.deletions,
+      headline: row.summaryHeadline,
       id: row.activityPublicId,
       languages: (row.languages ?? []).map((language) => ({
         ...language,

--- a/src/lib/github-activity-types.ts
+++ b/src/lib/github-activity-types.ts
@@ -11,6 +11,7 @@ export interface PublicGitHubActivityItem {
   changedFiles: number;
   committedAt: string;
   deletions: number;
+  headline: string;
   id: string;
   languages: readonly PublicGitHubActivityLanguage[];
   providerFileCapReached: boolean;

--- a/tests/github-activity-feed.test.mjs
+++ b/tests/github-activity-feed.test.mjs
@@ -39,6 +39,7 @@ describe("public GitHub activity projection", () => {
               changedFiles: 3000,
               committedAt: "2026-08-28T08:30:00.000Z",
               deletions: 2,
+              headline: "Improve the large change",
               id: "provider-capped-commit",
               languages: [
                 {
@@ -61,6 +62,11 @@ describe("public GitHub activity projection", () => {
     );
 
     expect(html).toContain("3000+ files");
+    expect(html).toContain("Improve the large change");
+    expect(html).toContain("Improves a large change.");
+    expect(html.indexOf("Improve the large change")).toBeLessThan(
+      html.indexOf("Improves a large change.")
+    );
     expect(html).toContain(
       "3000 or more changed files; GitHub caps returned file details at 3,000 files"
     );


### PR DESCRIPTION
## Summary

- render the stored headline for every timeline commit
- keep the detailed short summary underneath for larger and provider-capped commits
- include the headline in the public activity payload and invalidate the initial-page cache

## Validation

- `bun run lint`
- `bun run typecheck`
- `bun test` (56 tests)
- `bun run build`