### PR TITLE
fix(github): omit merge commits from activity

### DIFF
--- a/docs/github-activity-public-commit-summaries.md
+++ b/docs/github-activity-public-commit-summaries.md
@@ -10,7 +10,7 @@ the unit sent to Nano or the identity of the stored source activity.
 ## Per-commit processing
 
 ```text
-verified tracked-author commit
+verified tracked-author non-merge commit
   -> fetch the repository and commit evidence exposed by the GitHub path
   -> read commit-wide and per-file additions/deletions from GitHub
   -> derive languages and substantive churn from the per-file counters
@@ -175,9 +175,10 @@ published after the first page. Pagination never splits one day across pages.
 
 Canonical commits with the same primary GitHub PR and UTC day render as one PR
 slice containing their individual headlines/disclosures. A PR spanning several
-days produces one slice per day. The PR merge is a separate milestone. Daily
+days produces one slice per day. Stored multi-parent merge commits are omitted
+from both Nano and the timeline. The PR merge is a separate milestone. Daily
 totals include repositories, additions, deletions, merged PRs, and opened
-issues; proven aliases do not add duplicate churn.
+issues; proven aliases and omitted merge commits do not add duplicate churn.
 
 Language logos use version-pinned Simple Icons SVGs from the npm distribution.
 Repository owner avatars and durable repository/PR display facts come from the

--- a/docs/github-activity-public-commit-summaries.md
+++ b/docs/github-activity-public-commit-summaries.md
@@ -14,7 +14,7 @@ verified tracked-author commit
   -> fetch the repository and commit evidence exposed by the GitHub path
   -> read commit-wide and per-file additions/deletions from GitHub
   -> derive languages and substantive churn from the per-file counters
-  -> discover GitHub PR membership and suppress only proven integration copies
+  -> discover GitHub PR membership and suppress exact-evidence integration copies
   -> one gpt-5-nano call producing both public summary lengths
   -> persist one revision-scoped attempt, both summaries, recipe/model/input
      hash, languages, and churn

--- a/docs/github-commits.md
+++ b/docs/github-commits.md
@@ -53,9 +53,14 @@ The intake boundary is intentionally cheap:
 - A push observation records its source, account, repository, ref, before/after
   SHAs, expected commit count, and any SHA list GitHub supplied. The worker can
   later expand a truncated push with authenticated GitHub APIs.
-- The Events poll persists all newly seen push observations, PR snapshots, and
-  tracked-author issue-opened milestones, then advances that account's event
-  checkpoint in the same transaction.
+- The Events poll persists all newly seen push observations, complete PR
+  snapshots when GitHub supplies them, and tracked-author issue-opened
+  milestones, then advances that account's event checkpoint in the same
+  transaction. GitHub currently returns a sparse PR shape from this feed. A
+  strictly validated sparse event can schedule reconciliation only for an
+  already-known PR belonging to the polled account; it cannot create a PR or
+  cross account boundaries. Stale event timestamps cannot overwrite or
+  reschedule newer provider state.
 - Checkpoint updates use compare-and-swap. A concurrent winner causes the
   loser to reread and retry instead of overwriting newer progress.
 
@@ -184,18 +189,33 @@ specific canonical activity and persist the reason plus evidence:
 - A GitHub-reported merge SHA is aliased to an existing source member only when
   that PR has complete membership. Parent count distinguishes regular merge
   commits from squash integration commits.
+- A multi-parent commit with a complete exact fingerprint is aliased when the
+  matching commit SHA is literally one of its parents. If that parent is
+  already an alias, the new copy resolves to the same canonical activity.
 - A rebase/force-push copy is aliased only when both commits have complete,
   identical changed-line fingerprints and belong to distinct complete versions
   of the same PR.
 - A cherry-pick is aliased only with the explicit `cherry picked from commit`
   trailer and the same complete fingerprint.
+- The provider can omit PR association for squash/rebase flows, especially on
+  non-default target branches. Two single-parent commits can therefore be
+  aliased without PR membership only when they have the same repository,
+  complete exact fingerprint, non-null GitHub author ID, and normalized first
+  message line. Normalization removes only GitHub's terminal ` (#123)` suffix;
+  the earlier committer timestamp wins, with observation time and SHA used only
+  as deterministic ties.
 
 The fingerprint hashes stable hunk bodies—including unchanged context—and
 file-change metadata. It excludes commit identity and numeric hunk coordinates.
 A missing patch, counter mismatch, binary/provider omission, or GitHub file cap
-makes the fingerprint incomplete, so it cannot prove an alias. There is no
-global same-diff deduplication and no title-, time-, filename-, or
-similarity-based guess. Unproven commits remain visible.
+makes the fingerprint incomplete, so it cannot prove an alias. Exact counters,
+filenames, a headline, or timing by themselves never hide a commit. The
+same-author/headline fallback is admitted only after complete byte-identical
+patch evidence and single-parent shape. Unproven commits remain visible. The
+known ambiguity is an intentional revert-and-reapply of the same exact patch
+with the same headline by the same author; for this achievement timeline it is
+deliberately collapsed, and the stored alias evidence keeps the decision
+auditable and reversible.
 
 ## One-shot Nano summaries
 

--- a/docs/github-commits.md
+++ b/docs/github-commits.md
@@ -112,8 +112,16 @@ order:
 3. Ask GitHub which PRs are associated with each newly enriched commit and
    persist those PR snapshots. Reconcile known PRs that are due.
 4. Canonicalize only copies supported by complete, deterministic evidence.
-5. Create and claim one summary attempt for each still-canonical commit, make
-   one Nano call, and publish the activity only after it succeeds.
+5. Create and claim one summary attempt for each still-canonical, non-merge
+   commit, make one Nano call, and publish the activity only after it succeeds.
+
+A commit with more than one parent is a regular merge commit. It remains fully
+stored for intake, ancestry, and alias evidence, but it is excluded from summary
+creation, summary claims, the public activity projection, pagination days, and
+daily LOC/repository totals. A merged pull request remains visible as its
+separate PR milestone. This intentionally omits even a merge commit with unique
+conflict-resolution changes: the public surface describes authored work and PR
+outcomes, not integration mechanics.
 
 An issue opened by a tracked account needs no enrichment or model call. Intake
 persists its stable node/repository IDs, original title/link snapshots, creation
@@ -219,11 +227,11 @@ auditable and reversible.
 
 ## One-shot Nano summaries
 
-Every canonical commit gets one revision-scoped summary-attempt row and, when
-claimed, one `gpt-5-nano-2025-08-07` request with `maxRetries: 0` and
+Every canonical non-merge commit gets one revision-scoped summary-attempt row
+and, when claimed, one `gpt-5-nano-2025-08-07` request with `maxRetries: 0` and
 `store: false`. The request produces both the compact headline and expandable
-short summary. Languages and line counts are procedural and are not inferred by
-the model.
+short summary. Languages and line counts are procedural and are not inferred
+by the model.
 
 If the worker reaches its deadline before issuing the model request, it releases
 the claim back to `pending`; no attempt was consumed. Once the request starts,
@@ -241,8 +249,9 @@ for the prompt, compaction, and output contract.
 ## Public timeline
 
 The homepage reads a server-side projection of published, non-aliased
-activities. The initial render is a React Server Component; only the pagination
-control is a client component. Subsequent pages use
+activities, excluding stored multi-parent merge commits. The initial render is
+a React Server Component; only the pagination control is a client component.
+Subsequent pages use
 `GET /api/github/activity?cursor=...`.
 
 Pagination is by complete UTC day, not by item. A page contains five days by

--- a/src/lib/github-activity-feed.ts
+++ b/src/lib/github-activity-feed.ts
@@ -21,7 +21,7 @@ const readCachedActivity = unstable_cache(
       cursor,
       PUBLIC_GITHUB_ACTIVITY_DAY_PAGE_SIZE
     ),
-  ["public-github-activity-v6"],
+  ["public-github-activity-v7"],
   { revalidate: 900, tags: ["github-activity"] }
 );
 

--- a/src/lib/github-activity-processor.ts
+++ b/src/lib/github-activity-processor.ts
@@ -381,17 +381,28 @@ const commitEvidenceFrom = (
       "GitHub returned an invalid commit date."
     );
   }
-  const parents = Array.isArray(root.parents)
-    ? root.parents.map((parent) => {
-        if (!isObject(parent)) {
-          throw new ActivityProcessingError(
-            "source_invalid",
-            "GitHub returned an invalid commit parent."
-          );
-        }
-        return requiredString(parent.sha, "parent SHA").toLowerCase();
-      })
-    : [];
+  if (!Array.isArray(root.parents)) {
+    throw new ActivityProcessingError(
+      "source_invalid",
+      "GitHub returned incomplete commit ancestry."
+    );
+  }
+  const parents = root.parents.map((parent) => {
+    if (!isObject(parent)) {
+      throw new ActivityProcessingError(
+        "source_invalid",
+        "GitHub returned an invalid commit parent."
+      );
+    }
+    const parentSha = commitShaFrom(parent.sha);
+    if (parentSha === null) {
+      throw new ActivityProcessingError(
+        "source_invalid",
+        "GitHub returned an invalid commit parent SHA."
+      );
+    }
+    return parentSha;
+  });
   const additions = requiredInteger(root.stats.additions, "commit additions");
   const deletions = requiredInteger(root.stats.deletions, "commit deletions");
   const total = requiredInteger(root.stats.total, "commit changed lines");

--- a/src/lib/github-activity-store.ts
+++ b/src/lib/github-activity-store.ts
@@ -519,6 +519,10 @@ const readActivitySourceRows = async (
             and(
               eq(githubPublicActivities.kind, "commit"),
               eq(
+                githubPublicActivities.publicId,
+                githubCommits.activityPublicId
+              ),
+              eq(
                 githubPublicActivities.repositoryId,
                 githubCommits.repositoryId
               ),
@@ -595,6 +599,18 @@ export const readPublicGitHubActivityPage = async (
     lte(githubPublicActivities.publishedAt, snapshotDate),
     isNull(githubPublicActivities.hiddenAt),
     isNull(githubPublicActivities.canonicalPublicId),
+    sql<boolean>`(
+      ${githubPublicActivities.kind} <> 'commit'
+      OR EXISTS (
+        SELECT 1
+        FROM ${githubCommits}
+        WHERE ${githubCommits.activityPublicId} = ${githubPublicActivities.publicId}
+          AND ${githubCommits.repositoryId} = ${githubPublicActivities.repositoryId}
+          AND ${githubCommits.sha} = ${githubPublicActivities.sourceNodeId}
+          AND ${githubCommits.parentShas} IS NOT NULL
+          AND jsonb_array_length(${githubCommits.parentShas}) <= 1
+      )
+    )`,
     beforeDate === null
       ? undefined
       : lt(githubPublicActivities.occurredAt, beforeDate)

--- a/src/lib/github-activity-worker-store.ts
+++ b/src/lib/github-activity-worker-store.ts
@@ -59,6 +59,16 @@ type DatabaseTransaction = Parameters<
 
 const DEFAULT_LEASE_MS = 5 * 60 * 1000;
 const DEFAULT_DEFER_MS = 15 * 60 * 1000;
+const isNonMergeCommit = sql<boolean>`
+  ${githubCommits.parentShas} IS NOT NULL
+  AND jsonb_array_length(${githubCommits.parentShas}) <= 1
+`;
+const commitActivityIdentity = and(
+  eq(githubPublicActivities.kind, "commit"),
+  eq(githubCommits.activityPublicId, githubPublicActivities.publicId),
+  eq(githubCommits.repositoryId, githubPublicActivities.repositoryId),
+  eq(githubCommits.sha, githubPublicActivities.sourceNodeId)
+);
 
 const commitIdentity = (commit: { repositoryId: string; sha: string }) =>
   and(
@@ -1435,10 +1445,7 @@ const canonicalSourceForPullRequest = async (
         eq(githubCommits.sha, githubPullRequestMemberships.commitSha)
       )
     )
-    .innerJoin(
-      githubPublicActivities,
-      eq(githubPublicActivities.publicId, githubCommits.activityPublicId)
-    )
+    .innerJoin(githubPublicActivities, commitActivityIdentity)
     .where(
       and(
         eq(githubPullRequestVersions.pullRequestNodeId, pullRequestNodeId),
@@ -1446,6 +1453,7 @@ const canonicalSourceForPullRequest = async (
         eq(githubPullRequestVersions.mergeSnapshot, true),
         eq(githubPullRequestVersions.membershipComplete, true),
         eq(githubCommits.enrichmentState, "complete"),
+        isNonMergeCommit,
         ne(githubCommits.sha, excludedSha),
         isNull(githubPublicActivities.canonicalPublicId),
         isNull(githubPublicActivities.hiddenAt)
@@ -1543,10 +1551,7 @@ const publishCompletedSummaryForCommit = async (
   const [ready] = await transaction
     .select({ publicId: githubPublicActivities.publicId })
     .from(githubCommits)
-    .innerJoin(
-      githubPublicActivities,
-      eq(githubPublicActivities.publicId, githubCommits.activityPublicId)
-    )
+    .innerJoin(githubPublicActivities, commitActivityIdentity)
     .innerJoin(
       githubSummaryAttempts,
       and(
@@ -1563,6 +1568,7 @@ const publishCompletedSummaryForCommit = async (
         eq(githubCommits.repositoryId, repositoryId),
         eq(githubCommits.sha, sha),
         isNotNull(githubCommits.canonicalizedAt),
+        isNonMergeCommit,
         isNull(githubPublicActivities.canonicalPublicId),
         isNull(githubPublicActivities.hiddenAt)
       )
@@ -1627,10 +1633,7 @@ export const canonicalizeGitHubCommitActivity = async (
         publicId: githubPublicActivities.publicId,
       })
       .from(githubCommits)
-      .innerJoin(
-        githubPublicActivities,
-        eq(githubPublicActivities.publicId, githubCommits.activityPublicId)
-      )
+      .innerJoin(githubPublicActivities, commitActivityIdentity)
       .where(
         and(
           eq(githubCommits.repositoryId, repositoryId),
@@ -1725,19 +1728,34 @@ export const canonicalizeGitHubCommitActivity = async (
         sha: githubCommits.sha,
       })
       .from(githubCommits)
-      .innerJoin(
-        githubPublicActivities,
-        eq(githubPublicActivities.publicId, githubCommits.activityPublicId)
-      )
+      .innerJoin(githubPublicActivities, commitActivityIdentity)
       .where(
         and(
           eq(githubCommits.repositoryId, repositoryId),
           eq(githubCommits.changeFingerprint, candidate.changeFingerprint),
           eq(githubCommits.fingerprintComplete, true),
           eq(githubCommits.enrichmentState, "complete"),
+          isNonMergeCommit,
           or(
             isNull(githubPublicActivities.hiddenAt),
             isNotNull(githubPublicActivities.canonicalPublicId)
+          ),
+          or(
+            isNull(githubPublicActivities.canonicalPublicId),
+            sql<boolean>`EXISTS (
+              SELECT 1
+              FROM ${githubPublicActivities} AS canonical_activity
+              INNER JOIN ${githubCommits} AS canonical_commit
+                ON canonical_commit.activity_public_id = canonical_activity.public_id
+                AND canonical_commit.repository_id = canonical_activity.repository_id
+                AND canonical_commit.sha = canonical_activity.source_node_id
+              WHERE canonical_activity.public_id = ${githubPublicActivities.canonicalPublicId}
+                AND canonical_activity.kind = 'commit'
+                AND canonical_activity.canonical_public_id IS NULL
+                AND canonical_activity.hidden_at IS NULL
+                AND canonical_commit.parent_shas IS NOT NULL
+                AND jsonb_array_length(canonical_commit.parent_shas) <= 1
+            )`
           )
         )
       )
@@ -1868,10 +1886,7 @@ export const canonicalizePendingGitHubActivities = async (
       sha: githubCommits.sha,
     })
     .from(githubCommits)
-    .innerJoin(
-      githubPublicActivities,
-      eq(githubPublicActivities.publicId, githubCommits.activityPublicId)
-    )
+    .innerJoin(githubPublicActivities, commitActivityIdentity)
     .where(
       and(
         eq(githubCommits.enrichmentState, "complete"),
@@ -1911,11 +1926,13 @@ export const ensureGitHubSummaryAttempt = async (
         revision: githubPublicActivities.revision,
       })
       .from(githubPublicActivities)
+      .innerJoin(githubCommits, commitActivityIdentity)
       .where(
         and(
           eq(githubPublicActivities.publicId, activityPublicId),
           isNull(githubPublicActivities.canonicalPublicId),
-          isNull(githubPublicActivities.hiddenAt)
+          isNull(githubPublicActivities.hiddenAt),
+          isNonMergeCommit
         )
       )
       .limit(1);
@@ -1947,13 +1964,7 @@ export const ensureMissingGitHubSummaryAttempts = async (
   const rows = await getDatabase()
     .select({ publicId: githubPublicActivities.publicId })
     .from(githubPublicActivities)
-    .innerJoin(
-      githubCommits,
-      and(
-        eq(githubCommits.repositoryId, githubPublicActivities.repositoryId),
-        eq(githubCommits.sha, githubPublicActivities.sourceNodeId)
-      )
-    )
+    .innerJoin(githubCommits, commitActivityIdentity)
     .leftJoin(
       githubSummaryAttempts,
       and(
@@ -1971,7 +1982,8 @@ export const ensureMissingGitHubSummaryAttempts = async (
         isNull(githubPublicActivities.hiddenAt),
         isNull(githubSummaryAttempts.activityPublicId),
         eq(githubCommits.enrichmentState, "complete"),
-        isNotNull(githubCommits.canonicalizedAt)
+        isNotNull(githubCommits.canonicalizedAt),
+        isNonMergeCommit
       )
     )
     .orderBy(asc(githubCommits.firstObservedAt), asc(githubCommits.sha))
@@ -2034,13 +2046,7 @@ export const claimGitHubSummaryAttempts = async (
           eq(githubPublicActivities.revision, githubSummaryAttempts.revision)
         )
       )
-      .innerJoin(
-        githubCommits,
-        and(
-          eq(githubCommits.repositoryId, githubPublicActivities.repositoryId),
-          eq(githubCommits.sha, githubPublicActivities.sourceNodeId)
-        )
-      )
+      .innerJoin(githubCommits, commitActivityIdentity)
       .where(
         and(
           eq(githubSummaryAttempts.state, "pending"),
@@ -2049,7 +2055,8 @@ export const claimGitHubSummaryAttempts = async (
           isNull(githubPublicActivities.hiddenAt),
           inArray(githubCommits.author, [...activeAccounts]),
           eq(githubCommits.enrichmentState, "complete"),
-          isNotNull(githubCommits.canonicalizedAt)
+          isNotNull(githubCommits.canonicalizedAt),
+          isNonMergeCommit
         )
       )
       .orderBy(
@@ -2127,17 +2134,13 @@ export const completeGitHubSummaryAttempt = async (
         revision: githubPublicActivities.revision,
       })
       .from(githubPublicActivities)
-      .innerJoin(
-        githubCommits,
-        and(
-          eq(githubCommits.repositoryId, githubPublicActivities.repositoryId),
-          eq(githubCommits.sha, githubPublicActivities.sourceNodeId)
-        )
-      )
+      .innerJoin(githubCommits, commitActivityIdentity)
       .where(
         and(
           eq(githubPublicActivities.publicId, attempt.activityPublicId),
-          eq(githubPublicActivities.revision, attempt.revision)
+          eq(githubPublicActivities.revision, attempt.revision),
+          eq(githubPublicActivities.kind, "commit"),
+          isNonMergeCommit
         )
       )
       .for("update");

--- a/tests/github-activity-feed-postgres.test.mjs
+++ b/tests/github-activity-feed-postgres.test.mjs
@@ -29,17 +29,23 @@ const activityIds = {
   canonical: "00000000-0000-4000-8000-000000000001",
   direct: "00000000-0000-4000-8000-000000000002",
   issue: "00000000-0000-4000-8000-000000000005",
+  mergeCommit: "00000000-0000-4000-8000-000000000018",
+  mergeOnlyDay: "00000000-0000-4000-8000-000000000019",
   mergedPullRequest: "00000000-0000-4000-8000-000000000004",
   previousDay: "00000000-0000-4000-8000-000000000006",
   postSnapshot: "00000000-0000-4000-8000-000000000007",
+  summaryEligible: "00000000-0000-4000-8000-000000000020",
 };
 
 const shas = {
   alias: "b".repeat(40),
   canonical: "a".repeat(40),
   direct: "c".repeat(40),
+  mergeCommit: "f".repeat(40),
+  mergeOnlyDay: `${"0".repeat(39)}1`,
   previousDay: "d".repeat(40),
   postSnapshot: "e".repeat(40),
+  summaryEligible: `${"0".repeat(39)}2`,
 };
 
 const versionIds = {
@@ -63,11 +69,14 @@ describe.skipIf(!dockerAvailable)(
     let admin;
     let canonicalizeGitHubCommitActivity;
     let claimDueGitHubPullRequests;
+    let claimGitHubSummaryAttempts;
     let closeDatabase;
     let completeGitHubPullRequestReconciliation;
     let completeGitHubSummaryAttempt;
     let containerId;
     let databaseUrl;
+    let ensureGitHubSummaryAttempt;
+    let ensureMissingGitHubSummaryAttempts;
     let originalCronSecret;
     let originalDatabaseUrl;
     let persistAccountIntake;
@@ -143,8 +152,11 @@ describe.skipIf(!dockerAvailable)(
       ({
         canonicalizeGitHubCommitActivity,
         claimDueGitHubPullRequests,
+        claimGitHubSummaryAttempts,
         completeGitHubPullRequestReconciliation,
         completeGitHubSummaryAttempt,
+        ensureGitHubSummaryAttempt,
+        ensureMissingGitHubSummaryAttempts,
       } = await import("../src/lib/github-activity-worker-store.ts"));
       ({ persistAccountIntake } =
         await import("../src/lib/github-commits-store.ts"));
@@ -221,7 +233,68 @@ describe.skipIf(!dockerAvailable)(
             '2026-08-27T08:00:00.000Z', '2026-08-27T08:00:00.000Z',
             1, 1, 'complete', '[]'::jsonb,
             'Previous day', 'f0rr0/source', '101', ${shas.previousDay}, 4
+          ),
+          (
+            ${activityIds.mergeCommit}, 100, 'f0rr0',
+            '2026-08-28T12:30:00.000Z', '2026-08-28T12:30:00.000Z',
+            10, 50, 'complete', '[]'::jsonb,
+            'Merge branch next into feature', 'f0rr0/source', '101',
+            ${shas.mergeCommit}, 150
+          ),
+          (
+            ${activityIds.mergeOnlyDay}, 200, 'f0rr0',
+            '2026-08-26T12:30:00.000Z', '2026-08-26T12:30:00.000Z',
+            20, 75, 'complete', '[]'::jsonb,
+            'Octopus merge on an otherwise empty day', 'f0rr0/source', '101',
+            ${shas.mergeOnlyDay}, 275
+          ),
+          (
+            ${activityIds.summaryEligible}, 1, 'f0rr0',
+            '2026-08-28T08:30:00.000Z', '2026-08-28T08:30:00.000Z',
+            1, 0, 'complete', '[]'::jsonb,
+            'Ordinary summary candidate', 'f0rr0/source', '101',
+            ${shas.summaryEligible}, 1
           )
+      `;
+
+        await transaction`
+        update github_commits
+        set parent_shas = ${JSON.stringify(["7".repeat(40)])}::jsonb,
+          canonicalized_at = '2026-08-28T12:45:00.000Z'
+        where activity_public_id in (
+          ${activityIds.canonical}, ${activityIds.direct}, ${activityIds.alias}
+        )
+      `;
+        await transaction`
+        update github_commits
+        set parent_shas = '[]'::jsonb,
+          canonicalized_at = '2026-08-28T12:45:00.000Z'
+        where activity_public_id = ${activityIds.previousDay}
+      `;
+        await transaction`
+        update github_commits
+        set parent_shas = ${JSON.stringify([
+          "1".repeat(40),
+          "2".repeat(40),
+        ])}::jsonb,
+          canonicalized_at = '2026-08-28T12:45:00.000Z'
+        where repository_id = '101' and sha = ${shas.mergeCommit}
+      `;
+        await transaction`
+        update github_commits
+        set parent_shas = ${JSON.stringify([
+          "3".repeat(40),
+          "4".repeat(40),
+          "5".repeat(40),
+        ])}::jsonb,
+          canonicalized_at = '2026-08-26T12:45:00.000Z'
+        where repository_id = '101' and sha = ${shas.mergeOnlyDay}
+      `;
+        await transaction`
+        update github_commits
+        set parent_shas = '[]'::jsonb,
+          canonicalized_at = '2026-08-28T08:45:00.000Z'
+        where repository_id = '101' and sha = ${shas.summaryEligible}
       `;
 
         await transaction`
@@ -316,6 +389,21 @@ describe.skipIf(!dockerAvailable)(
           (
             ${activityIds.previousDay}, 'commit', '2026-08-27T08:00:00.000Z',
             '2026-08-28T13:00:00.000Z', '101', 1, ${shas.previousDay}
+          ),
+          (
+            ${activityIds.mergeCommit}, 'commit',
+            '2026-08-28T12:30:00.000Z', '2026-08-28T13:00:00.000Z', '101', 1,
+            ${shas.mergeCommit}
+          ),
+          (
+            ${activityIds.mergeOnlyDay}, 'commit',
+            '2026-08-26T12:30:00.000Z', '2026-08-28T13:00:00.000Z', '101', 1,
+            ${shas.mergeOnlyDay}
+          ),
+          (
+            ${activityIds.summaryEligible}, 'commit',
+            '2026-08-28T08:30:00.000Z', null, '101', 1,
+            ${shas.summaryEligible}
           )
       `;
 
@@ -348,6 +436,10 @@ describe.skipIf(!dockerAvailable)(
           (
             ${activityIds.previousDay}, '2026-08-28T13:00:00.000Z', 1,
             'complete', 'Previous-day headline', 'Previous-day summary'
+          ),
+          (
+            ${activityIds.mergeOnlyDay}, '2026-08-28T13:00:00.000Z', 1,
+            'complete', 'Octopus merge headline', 'Octopus merge summary'
           )
       `;
       });
@@ -377,6 +469,128 @@ describe.skipIf(!dockerAvailable)(
         "pull-request-merged",
         "pull-request-commits",
       ]);
+      expect(
+        firstPage.days[0]?.items.some(
+          (item) => item.id === activityIds.mergeCommit
+        )
+      ).toBe(false);
+      expect(
+        await ensureGitHubSummaryAttempt(
+          activityIds.mergeCommit,
+          new Date("2026-08-28T13:30:00.000Z")
+        )
+      ).toBe(false);
+      expect(
+        await ensureGitHubSummaryAttempt(
+          activityIds.summaryEligible,
+          new Date("2026-08-28T13:30:30.000Z")
+        )
+      ).toBe(true);
+      expect(
+        await ensureMissingGitHubSummaryAttempts(
+          50,
+          new Date("2026-08-28T13:31:00.000Z")
+        )
+      ).toBe(0);
+      await admin`
+        insert into github_summary_attempts (
+          activity_public_id, revision, state
+        ) values (${activityIds.mergeCommit}, 1, 'pending')
+      `;
+      const summaryClaims = await claimGitHubSummaryAttempts(
+        8,
+        ["f0rr0", "yuppiestechdev"],
+        new Date("2026-08-28T13:32:00.000Z")
+      );
+      expect(
+        summaryClaims.map(({ activityPublicId }) => activityPublicId)
+      ).toEqual([activityIds.summaryEligible]);
+      const claimedSummaries = await admin`
+        select activity_public_id, state
+        from github_summary_attempts
+        where activity_public_id in (
+          ${activityIds.mergeCommit}, ${activityIds.summaryEligible}
+        )
+        order by activity_public_id
+      `;
+      expect(claimedSummaries).toEqual([
+        {
+          activity_public_id: activityIds.mergeCommit,
+          state: "pending",
+        },
+        {
+          activity_public_id: activityIds.summaryEligible,
+          state: "processing",
+        },
+      ]);
+      const mergeLeaseToken = "20000000-0000-4000-8000-000000000018";
+      await admin`
+        update github_public_activities
+        set published_at = null
+        where public_id = ${activityIds.mergeCommit}
+      `;
+      await admin`
+        update github_summary_attempts
+        set attempted_at = '2026-08-28T13:32:30.000Z',
+          lease_token = ${mergeLeaseToken},
+          lease_until = '2026-08-28T13:37:30.000Z', state = 'processing'
+        where activity_public_id = ${activityIds.mergeCommit} and revision = 1
+      `;
+      expect(
+        await completeGitHubSummaryAttempt(
+          {
+            activityPublicId: activityIds.mergeCommit,
+            author: "f0rr0",
+            committedAt: "2026-08-28T12:30:00.000Z",
+            leaseToken: mergeLeaseToken,
+            message: "Merge branch next into feature",
+            repository: "f0rr0/source",
+            repositoryId: "101",
+            revision: 1,
+            sha: shas.mergeCommit,
+          },
+          {
+            headline: "A stale merge summary",
+            inputHash: "b".repeat(64),
+            model: "test-model",
+            recipe: "test-recipe",
+            short: "This pre-existing in-flight result must not be published.",
+          },
+          new Date("2026-08-28T13:33:00.000Z")
+        )
+      ).toBe(true);
+      const [completedMerge] = await admin`
+        select github_public_activities.published_at,
+          github_summary_attempts.state
+        from github_public_activities
+        join github_summary_attempts
+          on github_summary_attempts.activity_public_id = github_public_activities.public_id
+        where github_public_activities.public_id = ${activityIds.mergeCommit}
+      `;
+      expect(completedMerge).toEqual({ published_at: null, state: "complete" });
+      await admin`
+        update github_commits
+        set canonicalized_at = null, pr_discovery_state = 'complete'
+        where repository_id = '101' and sha = ${shas.mergeCommit}
+      `;
+      expect(
+        await canonicalizeGitHubCommitActivity(
+          "101",
+          shas.mergeCommit,
+          new Date("2026-08-28T13:34:00.000Z")
+        )
+      ).toEqual({ aliased: false, publicId: activityIds.mergeCommit });
+      const [canonicalizedMerge] = await admin`
+        select github_commits.canonicalized_at,
+          github_public_activities.published_at
+        from github_commits
+        join github_public_activities
+          on github_public_activities.public_id = github_commits.activity_public_id
+        where github_commits.repository_id = '101'
+          and github_commits.sha = ${shas.mergeCommit}
+      `;
+      expect(canonicalizedMerge.canonicalized_at).not.toBeNull();
+      expect(canonicalizedMerge.published_at).toBeNull();
 
       const snapshot = new Date(firstPage.snapshotAt);
       const postSnapshotPublishedAt = new Date(snapshot.getTime() + 1000);
@@ -386,12 +600,13 @@ describe.skipIf(!dockerAvailable)(
         insert into github_commits (
           activity_public_id, additions, author_login, committed_at,
           committer_at, changed_files, deletions, enrichment_state, languages,
-          message, repository, repository_id, sha, substantive_loc
+          message, parent_shas, repository, repository_id, sha, substantive_loc
         ) values (
           ${activityIds.postSnapshot}, 99, 'f0rr0',
           '2026-08-26T08:00:00.000Z', '2026-08-26T08:00:00.000Z', 1, 99,
           'complete', '[]'::jsonb, 'Published after the snapshot',
-          'f0rr0/source', '101', ${shas.postSnapshot}, 198
+          ${JSON.stringify(["8".repeat(40)])}::jsonb, 'f0rr0/source', '101',
+          ${shas.postSnapshot}, 198
         )
       `;
         await transaction`
@@ -797,13 +1012,14 @@ describe.skipIf(!dockerAvailable)(
       await admin`
         insert into github_commits (
           activity_public_id, author_login, canonicalized_at, committed_at,
-          committer_at, enrichment_state, languages, message, repository,
-          repository_id, sha
+          committer_at, enrichment_state, languages, message, parent_shas,
+          repository, repository_id, sha
         ) values (
           ${summaryActivityId}, 'f0rr0', '2026-08-28T21:30:00.000Z',
           '2026-08-28T21:00:00.000Z', '2026-08-28T21:00:00.000Z',
-          'complete', '[]'::jsonb, 'Publish typed timestamp', 'f0rr0/source',
-          '101', ${summarySha}
+          'complete', '[]'::jsonb, 'Publish typed timestamp',
+          ${JSON.stringify(["9".repeat(40)])}::jsonb, 'f0rr0/source', '101',
+          ${summarySha}
         )
       `;
       await admin`
@@ -1142,6 +1358,46 @@ describe.skipIf(!dockerAvailable)(
           public_id: exactCopyIds.headlineCandidate,
         },
       ]);
+
+      await admin`
+        update github_public_activities
+        set alias_evidence = null, alias_reason = null,
+          canonical_public_id = null, hidden_at = null
+        where public_id = ${exactCopyIds.merge}
+      `;
+      await admin`
+        update github_public_activities
+        set alias_evidence = '{"preexistingInvalidTarget":true}'::jsonb,
+          alias_reason = 'same_authored_exact_copy',
+          canonical_public_id = ${exactCopyIds.merge},
+          hidden_at = '2026-08-28T16:03:00.000Z'
+        where public_id = ${exactCopyIds.controlSource}
+      `;
+      await admin`
+        update github_commits
+        set canonicalized_at = null, full_message = 'First intentional edit',
+          message = 'First intentional edit'
+        where activity_public_id = ${exactCopyIds.controlCandidate}
+      `;
+      expect(
+        await canonicalizeGitHubCommitActivity(
+          "303",
+          exactCopyShas.controlCandidate,
+          new Date("2026-08-28T16:04:00.000Z")
+        )
+      ).toEqual({
+        aliased: false,
+        publicId: exactCopyIds.controlCandidate,
+      });
+      const [candidateProtectedFromMergeAlias] = await admin`
+        select canonical_public_id, hidden_at
+        from github_public_activities
+        where public_id = ${exactCopyIds.controlCandidate}
+      `;
+      expect(candidateProtectedFromMergeAlias).toEqual({
+        canonical_public_id: null,
+        hidden_at: null,
+      });
     });
   }
 );

--- a/tests/github-activity-processor.test.mjs
+++ b/tests/github-activity-processor.test.mjs
@@ -129,6 +129,67 @@ describe("GitHub activity commit acquisition", () => {
     expect(source.commit.files.at(-1)?.filename).toBe("é.ts");
   });
 
+  test("requires explicit valid ancestry while accepting a root commit", async () => {
+    const sha = "d".repeat(40);
+    const ancestryResponses = [undefined, [{ sha: "not-a-sha" }], []];
+    let commitReads = 0;
+    process.env.GITHUB_F0RR0_TOKEN = "test-token";
+    globalThis.fetch = async (input) => {
+      const url =
+        input instanceof Request ? new URL(input.url) : new URL(input);
+      if (url.pathname === "/repos/example-org/example-repo") {
+        return Response.json({
+          description: null,
+          full_name: "example-org/example-repo",
+          homepage: null,
+          id: 123,
+          owner: {
+            avatar_url: "https://avatars.githubusercontent.com/u/123?v=4",
+            id: 123,
+            login: "example-org",
+            type: "Organization",
+          },
+          private: false,
+          topics: [],
+          visibility: "public",
+        });
+      }
+      const parents = ancestryResponses[commitReads];
+      commitReads += 1;
+      return Response.json({
+        author: { id: 100, login: "f0rr0" },
+        commit: {
+          author: { date: "2026-08-28T12:00:00Z" },
+          committer: { date: "2026-08-28T12:01:00Z" },
+          message: "feat: preserve authoritative ancestry",
+          tree: { sha: "e".repeat(40) },
+        },
+        committer: { id: 200, login: "github" },
+        files: [],
+        ...(parents === undefined ? {} : { parents }),
+        sha,
+        stats: { additions: 0, deletions: 0, total: 0 },
+      });
+    };
+    const reference = {
+      author: "f0rr0",
+      committedAt: "2026-08-28T12:00:00.000Z",
+      message: "feat: preserve authoritative ancestry",
+      repository: "example-org/example-repo",
+      repositoryId: "123",
+      sha,
+    };
+
+    await expect(
+      fetchGitHubActivityCommitSource(reference)
+    ).rejects.toMatchObject({ code: "source_invalid" });
+    await expect(
+      fetchGitHubActivityCommitSource(reference)
+    ).rejects.toMatchObject({ code: "source_invalid" });
+    const root = await fetchGitHubActivityCommitSource(reference);
+    expect(root.commit.parents).toEqual([]);
+  });
+
   test("expands a push durably while retaining only tracked-authored commits", async () => {
     const beforeSha = "1".repeat(40);
     const trackedSha = "3".repeat(40);


### PR DESCRIPTION
## Summary

- keep multi-parent merge commits in durable ingestion while excluding them from Nano summaries, the public timeline, pagination days, and daily LOC/repository totals
- retain separate merged-PR milestones and keep root, squash, rebase, cherry-pick, and ordinary single-parent commits eligible
- fail closed on missing or malformed GitHub ancestry and prevent canonical aliases from resolving to excluded merge commits
- identity-match commit/activity joins and invalidate the cached public projection
- document sparse PR signals, exact-copy evidence, merge suppression, and the reversible alias trail

## Validation

- `bun test` (107 tests, 492 assertions)
- `bun run lint`
- `bun run typecheck`
- `bun run format:check`
- `bunx drizzle-kit check`
- `bun run build`
- production read-only invariant check: zero non-merge aliases target a merge; `83957d55…` is absent under the new projection