### PR TITLE
fix(github): collapse rewritten commits

### DIFF
--- a/docs/github-activity-public-commit-summaries.md
+++ b/docs/github-activity-public-commit-summaries.md
@@ -137,20 +137,20 @@ OpenAI's [conversation compaction](https://developers.openai.com/api/docs/guides
 which manages multi-turn state rather than a single commit diff.
 
 There is no content disclosure validator, privacy-term filter, word-count
-rejection, response-length rejection, shape rejection, or display truncation.
-Any response containing at least one non-whitespace character succeeds. When
-both labels are recognizable, their values are stored separately. Otherwise,
-the complete response is preserved as both variants, so unexpected formatting
-does not discard model output. Every displayed stored variant is shown in full.
-The deterministic final pass only adds missing Markdown
+rejection, response-length rejection, or display truncation. The response must
+contain non-empty `HEADLINE` and `SHORT` labels in the requested order; malformed
+protocol text fails instead of being copied into both public fields. Once parsed,
+both values—including a multiline `SHORT`—are stored and displayed in full. The
+deterministic final pass only adds missing Markdown
 backticks to unmistakable code references and capitalizes the first headline
 character; it does not remove text.
 
-Only a source-fetch failure, model request or transport failure, or empty Nano
-response fails processing. Such a failure is terminal for explicit operational
-inspection and omitted from the public feed. The call is not retried inside or
-after the request. Repository descriptions and other display facts are persisted
-as repository snapshots; raw per-file and patch evidence is not.
+A source-fetch failure, model request or transport failure, empty Nano response,
+or malformed labelled output fails processing. Such a failure is terminal for
+explicit operational inspection and omitted from the public feed. The call is
+not retried inside or after the request. Repository descriptions and other
+display facts are persisted as repository snapshots; raw per-file and patch
+evidence is not.
 
 The displayed additions and deletions are GitHub's commit-wide `stats` values.
 The headline threshold and language weights use GitHub's per-file additions and

--- a/docs/github-commits.md
+++ b/docs/github-commits.md
@@ -194,6 +194,13 @@ clear its reconciliation schedule.
 The public feed hides an integration copy only when the database can point to a
 specific canonical activity and persist the reason plus evidence:
 
+- Amendments, rebases, force-push rewrites, and same-repository cherry-picks
+  that preserve the exact non-null GitHub author ID, authored timestamp, and
+  full commit message form one non-merge rewrite lineage. The latest committer
+  timestamp wins, followed by observation time and SHA as deterministic ties.
+  Fingerprints and parent SHAs may differ because rewriting is allowed to change
+  the patch and its base. Existing aliases are retargeted directly to the winner
+  so the public graph never contains an alias chain.
 - A GitHub-reported merge SHA is aliased to an existing source member only when
   that PR has complete membership. Parent count distinguishes regular merge
   commits from squash integration commits.
@@ -235,8 +242,9 @@ by the model.
 
 If the worker reaches its deadline before issuing the model request, it releases
 the claim back to `pending`; no attempt was consumed. Once the request starts,
-an API/transport error, empty response, or other processing error is terminal
-`failed`. A lost lease becomes `indeterminate` and is not automatically
+an API/transport error, empty response, output that lacks the requested
+`HEADLINE`/`SHORT` labels, or other processing error is terminal `failed`. A
+lost lease becomes `indeterminate` and is not automatically
 reclaimed, avoiding duplicate billing when the remote outcome is unknown.
 There are no automatic model retries. PR reconciliation, including title/body
 updates, does not create a new commit-summary revision.

--- a/src/lib/github-activity-feed.ts
+++ b/src/lib/github-activity-feed.ts
@@ -21,7 +21,7 @@ const readCachedActivity = unstable_cache(
       cursor,
       PUBLIC_GITHUB_ACTIVITY_DAY_PAGE_SIZE
     ),
-  ["public-github-activity-v7"],
+  ["public-github-activity-v8"],
   { revalidate: 900, tags: ["github-activity"] }
 );
 

--- a/src/lib/github-activity-public-summary.ts
+++ b/src/lib/github-activity-public-summary.ts
@@ -1,4 +1,4 @@
-export const PUBLIC_COMMIT_SUMMARY_RECIPE = "public-commit-product-context-v35";
+export const PUBLIC_COMMIT_SUMMARY_RECIPE = "public-commit-product-context-v36";
 export const DEFAULT_PUBLIC_COMMIT_SUMMARY_LOW_LOC_THRESHOLD = 25;
 
 export const PUBLIC_COMMIT_SUMMARY_SYSTEM_PROMPT = `Summarize one software commit for a public engineering portfolio. The reader is casually technical and has no repository context.
@@ -162,7 +162,7 @@ export const parseCommitPublicSummary = (
     short === undefined ||
     short.length === 0
   ) {
-    return { headline: value, short: value };
+    throw new Error("Nano returned an invalid public summary shape.");
   }
   return { headline, short };
 };

--- a/src/lib/github-activity-worker-store.ts
+++ b/src/lib/github-activity-worker-store.ts
@@ -1613,6 +1613,187 @@ const comparableCommitHeadline = (message: string | null) => {
   return headline.replace(/\s+\(#[1-9]\d*\)$/u, "");
 };
 
+interface AuthoredRewriteCandidate {
+  authoredAt: Date | null;
+  authorUserId: string | null;
+  committedAt: Date;
+  committerAt: Date | null;
+  firstObservedAt: Date;
+  fullMessage: string | null;
+  parentShas: readonly string[] | null;
+  publicId: string;
+  sha: string;
+}
+
+const authoredRewriteOrder = (commit: AuthoredRewriteCandidate) =>
+  (commit.committerAt ?? commit.committedAt).getTime();
+
+const compareAuthoredRewriteCandidates = (
+  left: AuthoredRewriteCandidate,
+  right: AuthoredRewriteCandidate
+) => {
+  const byCommitter = authoredRewriteOrder(left) - authoredRewriteOrder(right);
+  if (byCommitter !== 0) {
+    return byCommitter;
+  }
+  const byObservation =
+    left.firstObservedAt.getTime() - right.firstObservedAt.getTime();
+  if (byObservation !== 0) {
+    return byObservation;
+  }
+  if (left.sha === right.sha) {
+    return 0;
+  }
+  return left.sha < right.sha ? -1 : 1;
+};
+
+const canonicalizeAuthoredRewriteLineage = async (
+  transaction: DatabaseTransaction,
+  repositoryId: string,
+  candidate: AuthoredRewriteCandidate,
+  now: Date,
+  allowedMemberMergeSha: string | null = null
+) => {
+  if (
+    candidate.authorUserId === null ||
+    candidate.authoredAt === null ||
+    candidate.fullMessage === null ||
+    candidate.parentShas === null ||
+    candidate.parentShas.length > 1
+  ) {
+    return { aliases: 0, candidateAliased: false };
+  }
+  const lineage = await transaction
+    .select({
+      authoredAt: githubCommits.authoredAt,
+      authorUserId: githubCommits.authorUserId,
+      committedAt: githubCommits.committedAt,
+      committerAt: githubCommits.committerAt,
+      firstObservedAt: githubCommits.firstObservedAt,
+      fullMessage: githubCommits.fullMessage,
+      parentShas: githubCommits.parentShas,
+      publicId: githubPublicActivities.publicId,
+      sha: githubCommits.sha,
+    })
+    .from(githubCommits)
+    .innerJoin(githubPublicActivities, commitActivityIdentity)
+    .where(
+      and(
+        eq(githubCommits.repositoryId, repositoryId),
+        eq(githubCommits.authorUserId, candidate.authorUserId),
+        eq(githubCommits.authoredAt, candidate.authoredAt),
+        eq(githubCommits.fullMessage, candidate.fullMessage),
+        eq(githubCommits.enrichmentState, "complete"),
+        inArray(githubCommits.pullRequestDiscoveryState, [
+          "complete",
+          "unavailable",
+        ]),
+        isNonMergeCommit,
+        isNull(githubPublicActivities.canonicalPublicId),
+        isNull(githubPublicActivities.hiddenAt),
+        or(
+          allowedMemberMergeSha === null
+            ? undefined
+            : eq(githubCommits.sha, allowedMemberMergeSha),
+          sql<boolean>`NOT EXISTS (
+            SELECT 1
+            FROM ${githubPullRequests} AS rewrite_merge_pr
+            WHERE rewrite_merge_pr.repository_id = ${githubCommits.repositoryId}
+              AND rewrite_merge_pr.merge_sha = ${githubCommits.sha}
+              AND rewrite_merge_pr.state = 'merged'
+          )`
+        )
+      )
+    )
+    .orderBy(asc(githubCommits.sha))
+    .for("update");
+  if (lineage.length < 2) {
+    return { aliases: 0, candidateAliased: false };
+  }
+
+  const winner = lineage.toSorted(compareAuthoredRewriteCandidates).at(-1);
+  if (winner === undefined) {
+    throw new Error("The authored rewrite lineage has no canonical commit.");
+  }
+  const losers = lineage.filter(({ publicId }) => publicId !== winner.publicId);
+  const loserPublicIds = losers.map(({ publicId }) => publicId);
+
+  await transaction.execute(sql`
+    WITH RECURSIVE rewrite_alias_descendants AS (
+      SELECT alias_activity.public_id
+      FROM ${githubPublicActivities} AS alias_activity
+      WHERE alias_activity.canonical_public_id IN (
+        ${sql.join(
+          loserPublicIds.map((publicId) => sql`${publicId}`),
+          sql`, `
+        )}
+      )
+      UNION
+      SELECT child_activity.public_id
+      FROM ${githubPublicActivities} AS child_activity
+      INNER JOIN rewrite_alias_descendants AS parent_activity
+        ON child_activity.canonical_public_id = parent_activity.public_id
+    )
+    UPDATE ${githubPublicActivities} AS rewrite_alias
+    SET
+      alias_evidence = COALESCE(rewrite_alias.alias_evidence, '{}'::jsonb)
+        || jsonb_build_object(
+          'canonicalRetargetReason', 'same_authored_rewrite',
+          'canonicalRetargetedFrom', rewrite_alias.canonical_public_id
+        ),
+      canonical_public_id = ${winner.publicId}
+    WHERE rewrite_alias.public_id IN (
+      SELECT public_id FROM rewrite_alias_descendants
+    )
+      AND rewrite_alias.public_id <> ${winner.publicId}
+  `);
+
+  let aliases = 0;
+  for (const loser of losers) {
+    if (
+      await setCanonicalAlias(
+        transaction,
+        loser.publicId,
+        winner.publicId,
+        "same_authored_rewrite",
+        {
+          authoredAt: candidate.authoredAt.toISOString(),
+          authorUserId: candidate.authorUserId,
+          canonicalCommitterAt: (
+            winner.committerAt ?? winner.committedAt
+          ).toISOString(),
+          sourceSha: winner.sha,
+        },
+        now
+      )
+    ) {
+      aliases += 1;
+    }
+  }
+  await transaction
+    .update(githubCommits)
+    .set({ canonicalizedAt: now })
+    .where(
+      and(
+        eq(githubCommits.repositoryId, repositoryId),
+        inArray(
+          githubCommits.activityPublicId,
+          lineage.map(({ publicId }) => publicId)
+        )
+      )
+    );
+  await publishCompletedSummaryForCommit(
+    transaction,
+    repositoryId,
+    winner.sha,
+    now
+  );
+  return {
+    aliases,
+    candidateAliased: candidate.publicId !== winner.publicId,
+  };
+};
+
 export const canonicalizeGitHubCommitActivity = async (
   repositoryId: string,
   sha: string,
@@ -1620,11 +1801,15 @@ export const canonicalizeGitHubCommitActivity = async (
 ) =>
   // oxlint-disable-next-line complexity -- Evidence classes deliberately fail open independently.
   await getDatabase().transaction(async (transaction) => {
+    await transaction.execute(
+      sql`SELECT pg_advisory_xact_lock(hashtextextended(${repositoryId}, 0))`
+    );
     const [candidate] = await transaction
       .select({
         authoredAt: githubCommits.authoredAt,
         authorUserId: githubCommits.authorUserId,
         changeFingerprint: githubCommits.changeFingerprint,
+        committedAt: githubCommits.committedAt,
         committerAt: githubCommits.committerAt,
         fingerprintComplete: githubCommits.fingerprintComplete,
         firstObservedAt: githubCommits.firstObservedAt,
@@ -1649,7 +1834,7 @@ export const canonicalizeGitHubCommitActivity = async (
       )
       .for("update");
     if (candidate === undefined) {
-      return { aliased: false, publicId: null };
+      return { aliased: false, aliases: 0, publicId: null };
     }
 
     const mergePullRequests = await transaction
@@ -1673,13 +1858,27 @@ export const canonicalizeGitHubCommitActivity = async (
         sha
       );
       if (mergeEvidence.integrationIsMember) {
+        const rewrite = await canonicalizeAuthoredRewriteLineage(
+          transaction,
+          repositoryId,
+          { ...candidate, sha },
+          now,
+          sha
+        );
+        if (rewrite.aliases > 0) {
+          return {
+            aliased: rewrite.candidateAliased,
+            aliases: rewrite.aliases,
+            publicId: candidate.publicId,
+          };
+        }
         await markGitHubCommitCanonicalized(
           transaction,
           repositoryId,
           sha,
           now
         );
-        return { aliased: false, publicId: candidate.publicId };
+        return { aliased: false, aliases: 0, publicId: candidate.publicId };
       }
       if (mergeEvidence.source !== null) {
         const { source } = mergeEvidence;
@@ -1704,8 +1903,26 @@ export const canonicalizeGitHubCommitActivity = async (
           sha,
           now
         );
-        return { aliased, publicId: candidate.publicId };
+        return {
+          aliased,
+          aliases: aliased ? 1 : 0,
+          publicId: candidate.publicId,
+        };
       }
+    }
+
+    const rewrite = await canonicalizeAuthoredRewriteLineage(
+      transaction,
+      repositoryId,
+      { ...candidate, sha },
+      now
+    );
+    if (rewrite.aliases > 0) {
+      return {
+        aliased: rewrite.candidateAliased,
+        aliases: rewrite.aliases,
+        publicId: candidate.publicId,
+      };
     }
 
     if (
@@ -1713,7 +1930,7 @@ export const canonicalizeGitHubCommitActivity = async (
       candidate.changeFingerprint === null
     ) {
       await markGitHubCommitCanonicalized(transaction, repositoryId, sha, now);
-      return { aliased: false, publicId: candidate.publicId };
+      return { aliased: false, aliases: 0, publicId: candidate.publicId };
     }
     const copies = await transaction
       .select({
@@ -1870,10 +2087,14 @@ export const canonicalizeGitHubCommitActivity = async (
         now
       );
       await markGitHubCommitCanonicalized(transaction, repositoryId, sha, now);
-      return { aliased, publicId: candidate.publicId };
+      return {
+        aliased,
+        aliases: aliased ? 1 : 0,
+        publicId: candidate.publicId,
+      };
     }
     await markGitHubCommitCanonicalized(transaction, repositoryId, sha, now);
-    return { aliased: false, publicId: candidate.publicId };
+    return { aliased: false, aliases: 0, publicId: candidate.publicId };
   });
 
 export const canonicalizePendingGitHubActivities = async (
@@ -1908,9 +2129,7 @@ export const canonicalizePendingGitHubActivities = async (
       candidate.sha,
       now
     );
-    if (result.aliased) {
-      aliased += 1;
-    }
+    aliased += result.aliases;
   }
   return aliased;
 };

--- a/tests/github-activity-feed-postgres.test.mjs
+++ b/tests/github-activity-feed-postgres.test.mjs
@@ -579,7 +579,11 @@ describe.skipIf(!dockerAvailable)(
           shas.mergeCommit,
           new Date("2026-08-28T13:34:00.000Z")
         )
-      ).toEqual({ aliased: false, publicId: activityIds.mergeCommit });
+      ).toEqual({
+        aliased: false,
+        aliases: 0,
+        publicId: activityIds.mergeCommit,
+      });
       const [canonicalizedMerge] = await admin`
         select github_commits.canonicalized_at,
           github_public_activities.published_at
@@ -1087,6 +1091,8 @@ describe.skipIf(!dockerAvailable)(
         mergeParent: "00000000-0000-4000-8000-000000000011",
         mergeRoot: "00000000-0000-4000-8000-000000000015",
         rebased: "00000000-0000-4000-8000-000000000010",
+        rebasedAlias: "00000000-0000-4000-8000-000000000021",
+        rebasedAliasAncestor: "00000000-0000-4000-8000-000000000022",
         rebasedSource: "00000000-0000-4000-8000-000000000009",
       };
       const exactCopyShas = {
@@ -1124,6 +1130,16 @@ describe.skipIf(!dockerAvailable)(
           (
             ${exactCopyIds.rebased}, 'commit', '2026-08-28T12:00:00.000Z',
             '303', 1, ${exactCopyShas.rebased}
+          ),
+          (
+            ${exactCopyIds.rebasedAlias}, 'commit',
+            '2026-08-28T11:00:00.000Z', '303', 1,
+            ${`${"8".repeat(39)}b`}
+          ),
+          (
+            ${exactCopyIds.rebasedAliasAncestor}, 'commit',
+            '2026-08-28T11:30:00.000Z', '303', 1,
+            ${`${"9".repeat(39)}b`}
           ),
           (
             ${exactCopyIds.mergeRoot}, 'commit',
@@ -1179,7 +1195,7 @@ describe.skipIf(!dockerAvailable)(
           ),
           (
             ${exactCopyIds.rebased}, 'f0rr0', '2026-08-28T08:00:00.000Z',
-            '101', ${"a".repeat(64)}, '2026-08-28T12:00:00.000Z',
+            '101', ${"9".repeat(64)}, '2026-08-28T12:00:00.000Z',
             '2026-08-28T12:00:00.000Z', 'complete', true,
             '2026-08-28T14:00:00.000Z', 'Preserve exact authored metadata',
             'Preserve exact authored metadata',
@@ -1255,6 +1271,36 @@ describe.skipIf(!dockerAvailable)(
           )
       `;
       await admin`
+        update github_commits
+        set canonicalized_at = '2026-08-28T15:40:00.000Z'
+        where activity_public_id in (
+          ${exactCopyIds.rebasedSource}, ${exactCopyIds.rebased}
+        )
+      `;
+      await admin`
+        update github_public_activities
+        set
+          alias_evidence = '{"preexistingAlias":true}'::jsonb,
+          alias_reason = 'same_authored_exact_copy',
+          canonical_public_id = ${exactCopyIds.rebasedSource},
+          hidden_at = '2026-08-28T15:41:00.000Z'
+        where public_id = ${exactCopyIds.rebasedAlias}
+      `;
+      await admin`
+        update github_public_activities
+        set
+          alias_evidence = '{"preexistingAlias":true}'::jsonb,
+          alias_reason = 'same_authored_exact_copy',
+          canonical_public_id = ${exactCopyIds.rebasedAlias},
+          hidden_at = '2026-08-28T15:42:00.000Z'
+        where public_id = ${exactCopyIds.rebasedAliasAncestor}
+      `;
+      await admin`
+        insert into github_summary_attempts (
+          activity_public_id, revision, state
+        ) values (${exactCopyIds.rebasedSource}, 1, 'pending')
+      `;
+      await admin`
         update github_public_activities
         set
           alias_evidence = '{"preexistingAlias":true}'::jsonb,
@@ -1270,14 +1316,22 @@ describe.skipIf(!dockerAvailable)(
           exactCopyShas.rebased,
           new Date("2026-08-28T16:00:00.000Z")
         )
-      ).toEqual({ aliased: true, publicId: exactCopyIds.rebased });
+      ).toEqual({
+        aliased: false,
+        aliases: 1,
+        publicId: exactCopyIds.rebased,
+      });
       expect(
         await canonicalizeGitHubCommitActivity(
           "303",
           exactCopyShas.merge,
           new Date("2026-08-28T16:01:00.000Z")
         )
-      ).toEqual({ aliased: true, publicId: exactCopyIds.merge });
+      ).toEqual({
+        aliased: true,
+        aliases: 1,
+        publicId: exactCopyIds.merge,
+      });
       expect(
         await canonicalizeGitHubCommitActivity(
           "303",
@@ -1286,6 +1340,7 @@ describe.skipIf(!dockerAvailable)(
         )
       ).toEqual({
         aliased: true,
+        aliases: 1,
         publicId: exactCopyIds.headlineCandidate,
       });
       expect(
@@ -1296,6 +1351,7 @@ describe.skipIf(!dockerAvailable)(
         )
       ).toEqual({
         aliased: false,
+        aliases: 0,
         publicId: exactCopyIds.controlCandidate,
       });
 
@@ -1303,7 +1359,8 @@ describe.skipIf(!dockerAvailable)(
         select alias_evidence, alias_reason, canonical_public_id, public_id
         from github_public_activities
         where public_id in (
-          ${exactCopyIds.rebased}, ${exactCopyIds.merge},
+          ${exactCopyIds.rebasedSource}, ${exactCopyIds.rebased},
+          ${exactCopyIds.merge},
           ${exactCopyIds.controlCandidate}, ${exactCopyIds.headlineCandidate}
         )
         order by public_id
@@ -1312,15 +1369,18 @@ describe.skipIf(!dockerAvailable)(
         {
           alias_evidence: {
             authoredAt: "2026-08-28T08:00:00.000Z",
-            directMergeParent: false,
-            fingerprint: "a".repeat(64),
-            fingerprintComplete: true,
-            headline: null,
-            pullRequestNodeId: null,
-            sourceSha: exactCopyShas.rebasedSource,
+            authorUserId: "101",
+            canonicalCommitterAt: "2026-08-28T12:00:00.000Z",
+            sourceSha: exactCopyShas.rebased,
           },
-          alias_reason: "same_authored_exact_copy",
-          canonical_public_id: exactCopyIds.rebasedSource,
+          alias_reason: "same_authored_rewrite",
+          canonical_public_id: exactCopyIds.rebased,
+          public_id: exactCopyIds.rebasedSource,
+        },
+        {
+          alias_evidence: null,
+          alias_reason: null,
+          canonical_public_id: null,
           public_id: exactCopyIds.rebased,
         },
         {
@@ -1359,6 +1419,46 @@ describe.skipIf(!dockerAvailable)(
         },
       ]);
 
+      const retargetedRewriteAliases = await admin`
+        select alias_evidence, canonical_public_id, public_id
+        from github_public_activities
+        where public_id in (
+          ${exactCopyIds.rebasedAlias},
+          ${exactCopyIds.rebasedAliasAncestor}
+        )
+        order by public_id
+      `;
+      expect(retargetedRewriteAliases).toEqual([
+        {
+          alias_evidence: {
+            canonicalRetargetedFrom: exactCopyIds.rebasedSource,
+            canonicalRetargetReason: "same_authored_rewrite",
+            preexistingAlias: true,
+          },
+          canonical_public_id: exactCopyIds.rebased,
+          public_id: exactCopyIds.rebasedAlias,
+        },
+        {
+          alias_evidence: {
+            canonicalRetargetedFrom: exactCopyIds.rebasedAlias,
+            canonicalRetargetReason: "same_authored_rewrite",
+            preexistingAlias: true,
+          },
+          canonical_public_id: exactCopyIds.rebased,
+          public_id: exactCopyIds.rebasedAliasAncestor,
+        },
+      ]);
+      const [supersededSummaryAttempt] = await admin`
+        select error_code, state
+        from github_summary_attempts
+        where activity_public_id = ${exactCopyIds.rebasedSource}
+          and revision = 1
+      `;
+      expect(supersededSummaryAttempt).toEqual({
+        error_code: "canonical_alias",
+        state: "indeterminate",
+      });
+
       await admin`
         update github_public_activities
         set alias_evidence = null, alias_reason = null,
@@ -1387,6 +1487,7 @@ describe.skipIf(!dockerAvailable)(
         )
       ).toEqual({
         aliased: false,
+        aliases: 0,
         publicId: exactCopyIds.controlCandidate,
       });
       const [candidateProtectedFromMergeAlias] = await admin`
@@ -1398,6 +1499,251 @@ describe.skipIf(!dockerAvailable)(
         canonical_public_id: null,
         hidden_at: null,
       });
+
+      const memberRewriteIds = {
+        latest: "00000000-0000-4000-8000-000000000024",
+        old: "00000000-0000-4000-8000-000000000023",
+        version: "10000000-0000-4000-8000-000000000023",
+      };
+      const memberRewriteShas = {
+        latest: `${"d".repeat(39)}b`,
+        old: `${"c".repeat(39)}b`,
+      };
+      await admin`
+        insert into github_public_activities (
+          public_id, kind, occurred_at, repository_id, revision, source_node_id
+        ) values
+          (
+            ${memberRewriteIds.old}, 'commit',
+            '2026-08-28T17:00:00.000Z', '303', 1,
+            ${memberRewriteShas.old}
+          ),
+          (
+            ${memberRewriteIds.latest}, 'commit',
+            '2026-08-28T18:00:00.000Z', '303', 1,
+            ${memberRewriteShas.latest}
+          )
+      `;
+      await admin`
+        insert into github_commits (
+          activity_public_id, author_login, authored_at, author_user_id,
+          canonicalized_at, change_fingerprint, committed_at, committer_at,
+          enrichment_state, fingerprint_complete, first_observed_at,
+          full_message, message, parent_shas, pr_discovery_state, repository,
+          repository_id, sha
+        ) values
+          (
+            ${memberRewriteIds.old}, 'f0rr0',
+            '2026-08-28T16:00:00.000Z', '101',
+            '2026-08-28T18:30:00.000Z', ${"1".repeat(64)},
+            '2026-08-28T17:00:00.000Z', '2026-08-28T17:00:00.000Z',
+            'complete', true, '2026-08-28T18:30:00.000Z',
+            'Keep a rebase-merge member canonical',
+            'Keep a rebase-merge member canonical',
+            ${JSON.stringify(["1".repeat(40)])}::jsonb, 'complete',
+            'f0rr0/exact-copies', '303', ${memberRewriteShas.old}
+          ),
+          (
+            ${memberRewriteIds.latest}, 'f0rr0',
+            '2026-08-28T16:00:00.000Z', '101', null, ${"2".repeat(64)},
+            '2026-08-28T18:00:00.000Z', '2026-08-28T18:00:00.000Z',
+            'complete', true, '2026-08-28T18:30:00.000Z',
+            'Keep a rebase-merge member canonical',
+            'Keep a rebase-merge member canonical',
+            ${JSON.stringify(["2".repeat(40)])}::jsonb, 'complete',
+            'f0rr0/exact-copies', '303', ${memberRewriteShas.latest}
+          )
+      `;
+      await admin`
+        insert into github_pull_requests (
+          account, author_login, author_user_id, created_at, merged_at,
+          merge_sha, node_id, number, provider_updated_at, repository_id,
+          state, terminal_at, title, title_snapshot, url
+        ) values (
+          'f0rr0', 'f0rr0', '101', '2026-08-28T16:00:00.000Z',
+          '2026-08-28T18:00:00.000Z', ${memberRewriteShas.latest},
+          'PR_rebase_member', 99, '2026-08-28T18:00:00.000Z', '303',
+          'merged', '2026-08-28T18:00:00.000Z',
+          'Keep a rebase-merge member canonical',
+          'Keep a rebase-merge member canonical',
+          'https://github.com/f0rr0/exact-copies/pull/99'
+        )
+      `;
+      await admin`
+        insert into github_pull_request_versions (
+          base_sha, head_sha, id, is_current, membership_complete,
+          merge_snapshot, provider_updated_at, pull_request_node_id
+        ) values (
+          ${"1".repeat(40)}, ${memberRewriteShas.latest},
+          ${memberRewriteIds.version}, true, true, true,
+          '2026-08-28T18:00:00.000Z', 'PR_rebase_member'
+        )
+      `;
+      await admin`
+        insert into github_pull_request_memberships (
+          commit_repository_id, commit_sha, is_head, position, version_id
+        ) values (
+          '303', ${memberRewriteShas.latest}, true, 0,
+          ${memberRewriteIds.version}
+        )
+      `;
+      expect(
+        await canonicalizeGitHubCommitActivity(
+          "303",
+          memberRewriteShas.latest,
+          new Date("2026-08-28T19:00:00.000Z")
+        )
+      ).toEqual({
+        aliased: false,
+        aliases: 1,
+        publicId: memberRewriteIds.latest,
+      });
+      const memberRewriteActivities = await admin`
+        select alias_reason, canonical_public_id, public_id
+        from github_public_activities
+        where public_id in (
+          ${memberRewriteIds.old}, ${memberRewriteIds.latest}
+        )
+        order by public_id
+      `;
+      expect(memberRewriteActivities).toEqual([
+        {
+          alias_reason: "same_authored_rewrite",
+          canonical_public_id: memberRewriteIds.latest,
+          public_id: memberRewriteIds.old,
+        },
+        {
+          alias_reason: null,
+          canonical_public_id: null,
+          public_id: memberRewriteIds.latest,
+        },
+      ]);
+
+      const evolvingRewriteIds = [
+        "00000000-0000-4000-8000-000000000025",
+        "00000000-0000-4000-8000-000000000026",
+        "00000000-0000-4000-8000-000000000027",
+      ];
+      const evolvingRewriteShas = [
+        `${"1".repeat(39)}c`,
+        `${"2".repeat(39)}c`,
+        `${"3".repeat(39)}c`,
+      ];
+      await admin`
+        insert into github_public_activities (
+          public_id, kind, occurred_at, published_at, repository_id, revision,
+          source_node_id
+        ) values
+          (
+            ${evolvingRewriteIds[0]}, 'commit',
+            '2026-08-25T08:00:00.000Z', '2026-08-28T19:00:00.000Z',
+            '303', 1, ${evolvingRewriteShas[0]}
+          ),
+          (
+            ${evolvingRewriteIds[1]}, 'commit',
+            '2026-08-25T09:00:00.000Z', '2026-08-28T19:00:00.000Z',
+            '303', 1, ${evolvingRewriteShas[1]}
+          ),
+          (
+            ${evolvingRewriteIds[2]}, 'commit',
+            '2026-08-25T10:00:00.000Z', '2026-08-28T19:00:00.000Z',
+            '303', 1, ${evolvingRewriteShas[2]}
+          )
+      `;
+      await admin`
+        insert into github_commits (
+          activity_public_id, additions, author_login, authored_at,
+          author_user_id, canonicalized_at, changed_files, committed_at,
+          committer_at, deletions, enrichment_state, fingerprint_complete,
+          first_observed_at, full_message, languages, message, parent_shas,
+          pr_discovery_state, repository, repository_id, sha, substantive_loc
+        ) values
+          (
+            ${evolvingRewriteIds[0]}, 100, 'f0rr0',
+            '2026-08-25T07:00:00.000Z', '101',
+            '2026-08-28T19:00:00.000Z', 10,
+            '2026-08-25T08:00:00.000Z', '2026-08-25T08:00:00.000Z', 10,
+            'complete', false, '2026-08-28T19:00:00.000Z',
+            'Publish content with full-page ISR', '[]'::jsonb,
+            'Publish content with full-page ISR',
+            ${JSON.stringify(["1".repeat(40)])}::jsonb, 'complete',
+            'f0rr0/exact-copies', '303', ${evolvingRewriteShas[0]}, 110
+          ),
+          (
+            ${evolvingRewriteIds[1]}, 200, 'f0rr0',
+            '2026-08-25T07:00:00.000Z', '101',
+            '2026-08-28T19:00:00.000Z', 20,
+            '2026-08-25T09:00:00.000Z', '2026-08-25T09:00:00.000Z', 20,
+            'complete', false, '2026-08-28T19:01:00.000Z',
+            'Publish content with full-page ISR', '[]'::jsonb,
+            'Publish content with full-page ISR',
+            ${JSON.stringify(["2".repeat(40)])}::jsonb, 'complete',
+            'f0rr0/exact-copies', '303', ${evolvingRewriteShas[1]}, 220
+          ),
+          (
+            ${evolvingRewriteIds[2]}, 300, 'f0rr0',
+            '2026-08-25T07:00:00.000Z', '101', null, 30,
+            '2026-08-25T10:00:00.000Z', '2026-08-25T10:00:00.000Z', 30,
+            'complete', false, '2026-08-28T19:02:00.000Z',
+            'Publish content with full-page ISR', '[]'::jsonb,
+            'Publish content with full-page ISR',
+            ${JSON.stringify(["3".repeat(40)])}::jsonb, 'complete',
+            'f0rr0/exact-copies', '303', ${evolvingRewriteShas[2]}, 330
+          )
+      `;
+      await admin`
+        insert into github_summary_attempts (
+          activity_public_id, completed_at, revision, state, summary_headline,
+          summary_short
+        ) values
+          (
+            ${evolvingRewriteIds[0]}, '2026-08-28T19:00:00.000Z', 1,
+            'complete', 'Old ISR headline', 'Old ISR summary'
+          ),
+          (
+            ${evolvingRewriteIds[1]}, '2026-08-28T19:00:00.000Z', 1,
+            'complete', 'Middle ISR headline', 'Middle ISR summary'
+          ),
+          (
+            ${evolvingRewriteIds[2]}, '2026-08-28T19:00:00.000Z', 1,
+            'complete', 'Latest ISR headline', 'Latest ISR summary'
+          )
+      `;
+      expect(
+        await canonicalizeGitHubCommitActivity(
+          "303",
+          evolvingRewriteShas[2],
+          new Date("2026-08-28T19:05:00.000Z")
+        )
+      ).toEqual({
+        aliased: false,
+        aliases: 2,
+        publicId: evolvingRewriteIds[2],
+      });
+      const rewritePage = await readPublicGitHubActivityPage(
+        {
+          beforeDay: "2026-08-26",
+          snapshotAt: "2026-08-28T20:00:00.000Z",
+          version: 1,
+        },
+        1
+      );
+      expect(rewritePage.days).toHaveLength(1);
+      expect(rewritePage.days[0]?.day).toBe("2026-08-25");
+      expect(rewritePage.days[0]?.totals).toEqual({
+        additions: 300,
+        deletions: 30,
+        issuesOpened: 0,
+        pullRequestsMerged: 0,
+        repositories: 1,
+      });
+      expect(rewritePage.days[0]?.items).toMatchObject([
+        {
+          commit: { headline: "Latest ISR headline" },
+          id: evolvingRewriteIds[2],
+          kind: "commit",
+        },
+      ]);
     });
   }
 );

--- a/tests/github-activity-public-summary.test.mjs
+++ b/tests/github-activity-public-summary.test.mjs
@@ -60,7 +60,7 @@ const largePatch = (label) =>
   ).join("\n")}\n trailing context for ${label}`;
 
 describe("public commit summaries", () => {
-  test("parses the requested shape and preserves every other nonempty response", () => {
+  test("parses only the labelled summary shape without discarding detail", () => {
     const parsed = parseCommitPublicSummary(
       "HEADLINE: Refine `refreshSession` handling\n\nSHORT: Refined `refreshSession` handling. Expired sessions now follow the existing fallback."
     );
@@ -71,10 +71,9 @@ describe("public commit summaries", () => {
     });
     const malformed =
       "Here is the result:\nHEADLINE: Refine sessions\nSHORT: Refined sessions.\nExtra detail the model chose to include.";
-    expect(parseCommitPublicSummary(malformed)).toEqual({
-      headline: malformed,
-      short: malformed,
-    });
+    expect(() => parseCommitPublicSummary(malformed)).toThrow(
+      "invalid public summary shape"
+    );
     const multilineShort =
       "HEADLINE: Refine sessions\nSHORT: Refined sessions.\nExtra detail the model chose to include.";
     expect(parseCommitPublicSummary(multilineShort)).toEqual({
@@ -82,15 +81,19 @@ describe("public commit summaries", () => {
       short: "Refined sessions.\nExtra detail the model chose to include.",
     });
     const unlabelled = "Refined sessions without using the requested labels.";
-    expect(parseCommitPublicSummary(unlabelled)).toEqual({
-      headline: unlabelled,
-      short: unlabelled,
-    });
+    expect(() => parseCommitPublicSummary(unlabelled)).toThrow(
+      "invalid public summary shape"
+    );
     const surrounded = " \nUnlabelled response with surrounding whitespace.\n ";
-    expect(parseCommitPublicSummary(surrounded)).toEqual({
-      headline: surrounded,
-      short: surrounded,
-    });
+    expect(() => parseCommitPublicSummary(surrounded)).toThrow(
+      "invalid public summary shape"
+    );
+    expect(() => parseCommitPublicSummary("SHORT: Refined sessions.")).toThrow(
+      "invalid public summary shape"
+    );
+    expect(() =>
+      parseCommitPublicSummary("HEADLINE: Refine sessions\nSHORT:   ")
+    ).toThrow("invalid public summary shape");
     expect(() => parseCommitPublicSummary(" \n\t ")).toThrow(
       "empty public summary"
     );


### PR DESCRIPTION
## Summary
- collapse amended and rebased commit lineages onto the newest commit
- flatten aliases and preserve PR integration-member semantics
- reject malformed Nano response shapes instead of duplicating raw output
- cover newest-only timeline LOC totals and malformed-output regressions

## Validation
- bun test
- bun run typecheck
- bun run lint
- bun run build