### PR TITLE
feat(github): reconcile activity across repository refs

### DIFF
--- a/docs/github-commits.md
+++ b/docs/github-commits.md
@@ -17,8 +17,8 @@ GitHub push / pull_request / issues webhooks
 
 Supabase Cron every 3 hours
   -> Vercel /api/cron/github-sync
-  -> authenticated GitHub user Events feeds
-  -> transactionally persist observations + checkpoint
+  -> authenticated GitHub user Events feeds + accessible repository refs
+  -> hydrate sparse PRs, persist observations, reconcile ref checkpoints
 
 Supabase Cron every 5 minutes
   -> Vercel /api/cron/github-worker
@@ -30,17 +30,19 @@ Next.js server render / GET /api/github/activity
 ```
 
 The webhook is the low-latency path for repositories where the GitHub App is
-installed. Authenticated Events polling is the coverage path for pushes made by
-either account in any repository visible to that account. The two intake paths
-converge on the same durable observation and source-identity tables. Leases and
-unique constraints make overlapping webhook, polling, and worker invocations
-safe.
+installed. Authenticated Events polling accelerates discovery for pushes made
+by either account. A complete sweep of every accessible repository's branch and
+tag tips is the coverage path, including commits pushed to non-default branches
+without a PR. All three intake paths converge on the same durable observation
+and source-identity tables. Leases and unique constraints make overlapping
+webhook, polling, ref reconciliation, and worker invocations safe.
 
 The poller verifies each token with `/user` before requesting
 `/users/{account}/events`; a token mix-up cannot silently turn private activity
-into a public-only feed. Only pushes performed by the tracked account are
-observed, and a candidate commit is retained only after GitHub identifies its
-top-level commit author as one of the tracked accounts.
+into a public-only feed. The same token enumerates repositories through
+`/user/repos` and only the `refs/heads/*` and `refs/tags/*` namespaces. A
+candidate commit is retained only after GitHub identifies its top-level commit
+author as one of the tracked accounts.
 
 ## Durable intake and checkpoints
 
@@ -53,14 +55,18 @@ The intake boundary is intentionally cheap:
 - A push observation records its source, account, repository, ref, before/after
   SHAs, expected commit count, and any SHA list GitHub supplied. The worker can
   later expand a truncated push with authenticated GitHub APIs.
-- The Events poll persists all newly seen push observations, complete PR
-  snapshots when GitHub supplies them, and tracked-author issue-opened
-  milestones, then advances that account's event checkpoint in the same
-  transaction. GitHub currently returns a sparse PR shape from this feed. A
-  strictly validated sparse event can schedule reconciliation only for an
-  already-known PR belonging to the polled account; it cannot create a PR or
-  cross account boundaries. Stale event timestamps cannot overwrite or
+- The Events poll hydrates GitHub's sparse PR shape from the canonical pull
+  request endpoint before persistence. A newly authored PR can therefore be
+  created immediately; a 404 retains the strictly validated signal for
+  known-only reconciliation. The poll then persists push observations, PR
+  snapshots, and tracked-author issue milestones before advancing the event
+  checkpoint transactionally. Stale event timestamps cannot overwrite or
   reschedule newer provider state.
+- Repository reconciliation stores the last observed commit target for every
+  current branch and tag. A new or changed target creates the same durable push
+  observation used by Events and webhooks. Missing refs are marked inactive,
+  annotated tags are peeled to commits, and identical heads are not expanded
+  twice. Ref state and its observation are committed together.
 - Checkpoint updates use compare-and-swap. A concurrent winner causes the
   loser to reread and retry instead of overwriting newer progress.
 
@@ -71,8 +77,15 @@ available observation, advances to the newest event, and records the expected
 and oldest available event IDs as a durable `detected` gap. It does not loop
 forever on an unrecoverable checkpoint.
 
-There is no arbitrary 400-day scan. A first run assimilates only the activity
-currently exposed by GitHub; historical backfill is a separate operation.
+There is no time-window backfill. A first ref sweep walks the complete commit
+history currently reachable from accessible branch and tag tips. Later sweeps
+expand only ref movements. Commits remain keyed by repository ID and SHA after
+a branch is deleted or force-pushed.
+
+A ref created and deleted (or force-pushed away) between observations is not
+recoverable unless an Event, webhook, PR, or another surviving ref exposes its
+commit. This is the remaining observability boundary; polling cannot discover a
+Git object GitHub no longer exposes.
 
 ### Pause or resume an account
 
@@ -103,8 +116,10 @@ The five-minute worker is bounded and restart-safe. It runs these stages in
 order:
 
 1. Claim push observations and expand their complete pushed SHA set using the
-   compare endpoint (or branch commits for a newly created branch). Persist the
-   source membership, then create candidate rows only for tracked authors.
+   compare endpoint. For a newly observed ref or compact new-branch Event, walk
+   the GraphQL commit-history cursor to completion. Persist the source
+   membership, then create candidate rows only for tracked authors. Ref rewinds
+   with no newly reachable commits complete successfully.
 2. Claim candidate commits and fetch repository plus paginated commit evidence.
    Verify repository ID, SHA, and tracked author again; persist commit metadata,
    GitHub aggregate counters, file-derived languages, repository facts, and a
@@ -128,7 +143,8 @@ persists its stable node/repository IDs, original title/link snapshots, creation
 time, and a published issue milestone transactionally. Both `IssuesEvent` and
 an `issues` webhook converge on those same unique identities.
 
-Observation and commit fetches use retryable database states and honor GitHub
+Observation and commit fetches require GitHub's provider timestamp rather than
+substituting the poll time. They use retryable database states and honor GitHub
 rate-limit timing; permanent source failures become `unavailable`. Work is
 owned through conditional leases, so a timed-out Vercel invocation can be
 continued safely by a later worker. The worker stops starting expensive work

--- a/drizzle/0008_warm_bedlam.sql
+++ b/drizzle/0008_warm_bedlam.sql
@@ -1,0 +1,20 @@
+CREATE TABLE "github_repository_refs" (
+	"active" boolean DEFAULT true NOT NULL,
+	"first_observed_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"head_sha" varchar(40) NOT NULL,
+	"kind" varchar(8) NOT NULL,
+	"last_observed_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"ref_name" text NOT NULL,
+	"repository_id" varchar(32) NOT NULL,
+	CONSTRAINT "github_repository_refs_repository_id_ref_name_pk" PRIMARY KEY("repository_id","ref_name"),
+	CONSTRAINT "github_repository_refs_kind" CHECK ("github_repository_refs"."kind" IN ('head', 'tag')),
+	CONSTRAINT "github_repository_refs_name" CHECK (("github_repository_refs"."kind" = 'head' AND "github_repository_refs"."ref_name" LIKE 'refs/heads/%') OR ("github_repository_refs"."kind" = 'tag' AND "github_repository_refs"."ref_name" LIKE 'refs/tags/%')),
+	CONSTRAINT "github_repository_refs_sha_shape" CHECK ("github_repository_refs"."head_sha" ~ '^[a-f0-9]{40}$'),
+	CONSTRAINT "github_repository_refs_observation_order" CHECK ("github_repository_refs"."last_observed_at" >= "github_repository_refs"."first_observed_at")
+);
+--> statement-breakpoint
+ALTER TABLE "github_repository_refs" ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
+ALTER TABLE "github_push_observations" DROP CONSTRAINT "github_push_observations_source";--> statement-breakpoint
+ALTER TABLE "github_repository_refs" ADD CONSTRAINT "github_repository_refs_repository_fk" FOREIGN KEY ("repository_id") REFERENCES "public"."github_repositories"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "github_repository_refs_active_idx" ON "github_repository_refs" USING btree ("repository_id","active");--> statement-breakpoint
+ALTER TABLE "github_push_observations" ADD CONSTRAINT "github_push_observations_source" CHECK ("github_push_observations"."source" IN ('webhook', 'events', 'refs'));

--- a/drizzle/meta/0008_snapshot.json
+++ b/drizzle/meta/0008_snapshot.json
@@ -1,0 +1,2336 @@
+{
+  "id": "cd0e24d6-a056-45f5-ae79-d6a9b4e8f910",
+  "prevId": "c130839a-41f2-47a1-8f81-4b1b6806ebe5",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.github_account_checkpoints": {
+      "name": "github_account_checkpoints",
+      "schema": "",
+      "columns": {
+        "account": {
+          "name": "account",
+          "type": "varchar(39)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "gap_detected_at": {
+          "name": "gap_detected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gap_expected_event_id": {
+          "name": "gap_expected_event_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gap_oldest_available_event_id": {
+          "name": "gap_oldest_available_event_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gap_state": {
+          "name": "gap_state",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'clear'"
+        },
+        "latest_event_id": {
+          "name": "latest_event_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "paused": {
+          "name": "paused",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "github_account_checkpoints_tracked_account": {
+          "name": "github_account_checkpoints_tracked_account",
+          "value": "\"github_account_checkpoints\".\"account\" IN ('f0rr0', 'yuppiestechdev')"
+        },
+        "github_account_checkpoints_event_id_shape": {
+          "name": "github_account_checkpoints_event_id_shape",
+          "value": "(\"github_account_checkpoints\".\"latest_event_id\" IS NULL OR \"github_account_checkpoints\".\"latest_event_id\" ~ '^[0-9]{1,64}$') AND (\"github_account_checkpoints\".\"gap_expected_event_id\" IS NULL OR \"github_account_checkpoints\".\"gap_expected_event_id\" ~ '^[0-9]{1,64}$') AND (\"github_account_checkpoints\".\"gap_oldest_available_event_id\" IS NULL OR \"github_account_checkpoints\".\"gap_oldest_available_event_id\" ~ '^[0-9]{1,64}$')"
+        },
+        "github_account_checkpoints_gap_state": {
+          "name": "github_account_checkpoints_gap_state",
+          "value": "\"github_account_checkpoints\".\"gap_state\" IN ('clear', 'detected')"
+        },
+        "github_account_checkpoints_gap_details": {
+          "name": "github_account_checkpoints_gap_details",
+          "value": "(\"github_account_checkpoints\".\"gap_state\" = 'detected' AND \"github_account_checkpoints\".\"gap_detected_at\" IS NOT NULL) OR (\"github_account_checkpoints\".\"gap_state\" = 'clear' AND \"github_account_checkpoints\".\"gap_detected_at\" IS NULL AND \"github_account_checkpoints\".\"gap_expected_event_id\" IS NULL AND \"github_account_checkpoints\".\"gap_oldest_available_event_id\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.github_commits": {
+      "name": "github_commits",
+      "schema": "",
+      "columns": {
+        "activity_public_id": {
+          "name": "activity_public_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "additions": {
+          "name": "additions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_login": {
+          "name": "author_login",
+          "type": "varchar(39)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "authored_at": {
+          "name": "authored_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_user_id": {
+          "name": "author_user_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canonicalized_at": {
+          "name": "canonicalized_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "changed_files": {
+          "name": "changed_files",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "change_fingerprint": {
+          "name": "change_fingerprint",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "committed_at": {
+          "name": "committed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "committer_at": {
+          "name": "committer_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "committer_user_id": {
+          "name": "committer_user_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deletions": {
+          "name": "deletions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enrichment_error": {
+          "name": "enrichment_error",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enrichment_lease_token": {
+          "name": "enrichment_lease_token",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enrichment_lease_until": {
+          "name": "enrichment_lease_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enrichment_state": {
+          "name": "enrichment_state",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "fingerprint_complete": {
+          "name": "fingerprint_complete",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "first_observed_at": {
+          "name": "first_observed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "full_message": {
+          "name": "full_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "languages": {
+          "name": "languages",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_shas": {
+          "name": "parent_shas",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_file_cap_reached": {
+          "name": "provider_file_cap_reached",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "pr_discovery_error": {
+          "name": "pr_discovery_error",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_discovery_lease_token": {
+          "name": "pr_discovery_lease_token",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_discovery_lease_until": {
+          "name": "pr_discovery_lease_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_discovery_state": {
+          "name": "pr_discovery_state",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "repository": {
+          "name": "repository",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository_owner_avatar_url": {
+          "name": "repository_owner_avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repository_owner_login": {
+          "name": "repository_owner_login",
+          "type": "varchar(39)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repository_owner_type": {
+          "name": "repository_owner_type",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repository_private": {
+          "name": "repository_private",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sha": {
+          "name": "sha",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "substantive_loc": {
+          "name": "substantive_loc",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary_attempted_at": {
+          "name": "summary_attempted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary_error": {
+          "name": "summary_error",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary_headline": {
+          "name": "summary_headline",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary_input_hash": {
+          "name": "summary_input_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary_model": {
+          "name": "summary_model",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary_recipe": {
+          "name": "summary_recipe",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary_short": {
+          "name": "summary_short",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tree_sha": {
+          "name": "tree_sha",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "github_commits_activity_public_id_unique": {
+          "name": "github_commits_activity_public_id_unique",
+          "columns": [
+            {
+              "expression": "activity_public_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_commits_activity_cursor_idx": {
+          "name": "github_commits_activity_cursor_idx",
+          "columns": [
+            {
+              "expression": "committed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "activity_public_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_commits_committed_at_idx": {
+          "name": "github_commits_committed_at_idx",
+          "columns": [
+            {
+              "expression": "committed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_commits_summary_pending_idx": {
+          "name": "github_commits_summary_pending_idx",
+          "columns": [
+            {
+              "expression": "summary_attempted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "committed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_commits_enrichment_pending_idx": {
+          "name": "github_commits_enrichment_pending_idx",
+          "columns": [
+            {
+              "expression": "enrichment_state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "enrichment_lease_until",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "committed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_commits_canonicalization_pending_idx": {
+          "name": "github_commits_canonicalization_pending_idx",
+          "columns": [
+            {
+              "expression": "canonicalized_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "first_observed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_commits_pr_discovery_pending_idx": {
+          "name": "github_commits_pr_discovery_pending_idx",
+          "columns": [
+            {
+              "expression": "pr_discovery_state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pr_discovery_lease_until",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "first_observed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "github_commits_repository_id_sha_pk": {
+          "name": "github_commits_repository_id_sha_pk",
+          "columns": ["repository_id", "sha"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "github_commits_sha_shape": {
+          "name": "github_commits_sha_shape",
+          "value": "\"github_commits\".\"sha\" ~ '^[a-f0-9]{40}$'"
+        },
+        "github_commits_tree_sha_shape": {
+          "name": "github_commits_tree_sha_shape",
+          "value": "\"github_commits\".\"tree_sha\" IS NULL OR \"github_commits\".\"tree_sha\" ~ '^[a-f0-9]{40}$'"
+        },
+        "github_commits_fingerprint_shape": {
+          "name": "github_commits_fingerprint_shape",
+          "value": "\"github_commits\".\"change_fingerprint\" IS NULL OR \"github_commits\".\"change_fingerprint\" ~ '^[a-f0-9]{64}$'"
+        },
+        "github_commits_fingerprint_completeness": {
+          "name": "github_commits_fingerprint_completeness",
+          "value": "NOT \"github_commits\".\"fingerprint_complete\" OR \"github_commits\".\"change_fingerprint\" IS NOT NULL"
+        },
+        "github_commits_parent_shas_array": {
+          "name": "github_commits_parent_shas_array",
+          "value": "\"github_commits\".\"parent_shas\" IS NULL OR jsonb_typeof(\"github_commits\".\"parent_shas\") = 'array'"
+        },
+        "github_commits_enrichment_state": {
+          "name": "github_commits_enrichment_state",
+          "value": "\"github_commits\".\"enrichment_state\" IN ('pending', 'processing', 'complete', 'unavailable')"
+        },
+        "github_commits_enrichment_lease": {
+          "name": "github_commits_enrichment_lease",
+          "value": "(\"github_commits\".\"enrichment_state\" = 'processing') = (\"github_commits\".\"enrichment_lease_token\" IS NOT NULL) AND (\"github_commits\".\"enrichment_state\" <> 'processing' OR \"github_commits\".\"enrichment_lease_until\" IS NOT NULL) AND (\"github_commits\".\"enrichment_state\" NOT IN ('complete', 'unavailable') OR \"github_commits\".\"enrichment_lease_until\" IS NULL)"
+        },
+        "github_commits_pr_discovery_state": {
+          "name": "github_commits_pr_discovery_state",
+          "value": "\"github_commits\".\"pr_discovery_state\" IN ('pending', 'processing', 'complete', 'unavailable')"
+        },
+        "github_commits_pr_discovery_lease": {
+          "name": "github_commits_pr_discovery_lease",
+          "value": "(\"github_commits\".\"pr_discovery_state\" = 'processing') = (\"github_commits\".\"pr_discovery_lease_token\" IS NOT NULL) AND (\"github_commits\".\"pr_discovery_state\" <> 'processing' OR \"github_commits\".\"pr_discovery_lease_until\" IS NOT NULL) AND (\"github_commits\".\"pr_discovery_state\" NOT IN ('complete', 'unavailable') OR \"github_commits\".\"pr_discovery_lease_until\" IS NULL)"
+        },
+        "github_commits_tracked_author": {
+          "name": "github_commits_tracked_author",
+          "value": "\"github_commits\".\"author_login\" IN ('f0rr0', 'yuppiestechdev')"
+        },
+        "github_commits_nonnegative_activity_counts": {
+          "name": "github_commits_nonnegative_activity_counts",
+          "value": "(\"github_commits\".\"changed_files\" IS NULL OR \"github_commits\".\"changed_files\" >= 0) AND (\"github_commits\".\"additions\" IS NULL OR \"github_commits\".\"additions\" >= 0) AND (\"github_commits\".\"deletions\" IS NULL OR \"github_commits\".\"deletions\" >= 0) AND (\"github_commits\".\"substantive_loc\" IS NULL OR \"github_commits\".\"substantive_loc\" >= 0)"
+        },
+        "github_commits_owner_type": {
+          "name": "github_commits_owner_type",
+          "value": "\"github_commits\".\"repository_owner_type\" IS NULL OR \"github_commits\".\"repository_owner_type\" IN ('Organization', 'User')"
+        },
+        "github_commits_summary_hash_shape": {
+          "name": "github_commits_summary_hash_shape",
+          "value": "\"github_commits\".\"summary_input_hash\" IS NULL OR \"github_commits\".\"summary_input_hash\" ~ '^[a-f0-9]{64}$'"
+        },
+        "github_commits_summary_pair": {
+          "name": "github_commits_summary_pair",
+          "value": "(\"github_commits\".\"summary_headline\" IS NULL) = (\"github_commits\".\"summary_short\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.github_issues": {
+      "name": "github_issues",
+      "schema": "",
+      "columns": {
+        "account": {
+          "name": "account",
+          "type": "varchar(39)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_login": {
+          "name": "author_login",
+          "type": "varchar(39)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_user_id": {
+          "name": "author_user_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_observed_at": {
+          "name": "first_observed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "varchar(128)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "number": {
+          "name": "number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title_snapshot": {
+          "name": "title_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url_snapshot": {
+          "name": "url_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "github_issues_repository_number_unique": {
+          "name": "github_issues_repository_number_unique",
+          "columns": [
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_issues_author_idx": {
+          "name": "github_issues_author_idx",
+          "columns": [
+            {
+              "expression": "author_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_issues_repository_id_github_repositories_id_fk": {
+          "name": "github_issues_repository_id_github_repositories_id_fk",
+          "tableFrom": "github_issues",
+          "tableTo": "github_repositories",
+          "columnsFrom": ["repository_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "github_issues_tracked_account": {
+          "name": "github_issues_tracked_account",
+          "value": "\"github_issues\".\"account\" IN ('f0rr0', 'yuppiestechdev')"
+        },
+        "github_issues_positive_number": {
+          "name": "github_issues_positive_number",
+          "value": "\"github_issues\".\"number\" > 0"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.github_public_activities": {
+      "name": "github_public_activities",
+      "schema": "",
+      "columns": {
+        "alias_evidence": {
+          "name": "alias_evidence",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alias_reason": {
+          "name": "alias_reason",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canonical_public_id": {
+          "name": "canonical_public_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "hidden_at": {
+          "name": "hidden_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_id": {
+          "name": "public_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revision": {
+          "name": "revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "source_node_id": {
+          "name": "source_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "github_public_activities_source_unique": {
+          "name": "github_public_activities_source_unique",
+          "columns": [
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_public_activities_cursor_idx": {
+          "name": "github_public_activities_cursor_idx",
+          "columns": [
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "public_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_public_activities_canonical_idx": {
+          "name": "github_public_activities_canonical_idx",
+          "columns": [
+            {
+              "expression": "canonical_public_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_public_activities_canonical_fk": {
+          "name": "github_public_activities_canonical_fk",
+          "tableFrom": "github_public_activities",
+          "tableTo": "github_public_activities",
+          "columnsFrom": ["canonical_public_id"],
+          "columnsTo": ["public_id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "github_public_activities_kind": {
+          "name": "github_public_activities_kind",
+          "value": "\"github_public_activities\".\"kind\" IN ('commit', 'pull_request', 'issue')"
+        },
+        "github_public_activities_not_self_canonical": {
+          "name": "github_public_activities_not_self_canonical",
+          "value": "\"github_public_activities\".\"canonical_public_id\" IS NULL OR \"github_public_activities\".\"canonical_public_id\" <> \"github_public_activities\".\"public_id\""
+        },
+        "github_public_activities_positive_revision": {
+          "name": "github_public_activities_positive_revision",
+          "value": "\"github_public_activities\".\"revision\" > 0"
+        },
+        "github_public_activities_alias_audit": {
+          "name": "github_public_activities_alias_audit",
+          "value": "(\"github_public_activities\".\"canonical_public_id\" IS NULL AND \"github_public_activities\".\"alias_reason\" IS NULL AND \"github_public_activities\".\"alias_evidence\" IS NULL) OR (\"github_public_activities\".\"canonical_public_id\" IS NOT NULL AND \"github_public_activities\".\"alias_reason\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.github_pull_request_memberships": {
+      "name": "github_pull_request_memberships",
+      "schema": "",
+      "columns": {
+        "commit_repository_id": {
+          "name": "commit_repository_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "commit_sha": {
+          "name": "commit_sha",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_head": {
+          "name": "is_head",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version_id": {
+          "name": "version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "github_pull_request_memberships_position_unique": {
+          "name": "github_pull_request_memberships_position_unique",
+          "columns": [
+            {
+              "expression": "version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_pull_request_memberships_commit_lookup_idx": {
+          "name": "github_pull_request_memberships_commit_lookup_idx",
+          "columns": [
+            {
+              "expression": "commit_repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "commit_sha",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gh_pr_memberships_version_fk": {
+          "name": "gh_pr_memberships_version_fk",
+          "tableFrom": "github_pull_request_memberships",
+          "tableTo": "github_pull_request_versions",
+          "columnsFrom": ["version_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "gh_pr_memberships_pk": {
+          "name": "gh_pr_memberships_pk",
+          "columns": ["version_id", "commit_repository_id", "commit_sha"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "github_pull_request_memberships_sha_shape": {
+          "name": "github_pull_request_memberships_sha_shape",
+          "value": "\"github_pull_request_memberships\".\"commit_sha\" ~ '^[a-f0-9]{40}$'"
+        },
+        "github_pull_request_memberships_nonnegative_position": {
+          "name": "github_pull_request_memberships_nonnegative_position",
+          "value": "\"github_pull_request_memberships\".\"position\" >= 0"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.github_pull_request_versions": {
+      "name": "github_pull_request_versions",
+      "schema": "",
+      "columns": {
+        "base_ref_name": {
+          "name": "base_ref_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_repository_id": {
+          "name": "base_repository_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_sha": {
+          "name": "base_sha",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "commit_count": {
+          "name": "commit_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "head_ref_name": {
+          "name": "head_ref_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "head_repository_id": {
+          "name": "head_repository_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "head_sha": {
+          "name": "head_sha",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "is_current": {
+          "name": "is_current",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "membership_complete": {
+          "name": "membership_complete",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "merge_snapshot": {
+          "name": "merge_snapshot",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "observed_at": {
+          "name": "observed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "provider_updated_at": {
+          "name": "provider_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pull_request_node_id": {
+          "name": "pull_request_node_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "github_pull_request_versions_head_unique": {
+          "name": "github_pull_request_versions_head_unique",
+          "columns": [
+            {
+              "expression": "pull_request_node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "head_sha",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_pull_request_versions_current_unique": {
+          "name": "github_pull_request_versions_current_unique",
+          "columns": [
+            {
+              "expression": "pull_request_node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"github_pull_request_versions\".\"is_current\"",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gh_pr_versions_pull_request_fk": {
+          "name": "gh_pr_versions_pull_request_fk",
+          "tableFrom": "github_pull_request_versions",
+          "tableTo": "github_pull_requests",
+          "columnsFrom": ["pull_request_node_id"],
+          "columnsTo": ["node_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "github_pull_request_versions_sha_shapes": {
+          "name": "github_pull_request_versions_sha_shapes",
+          "value": "\"github_pull_request_versions\".\"base_sha\" ~ '^[a-f0-9]{40}$' AND \"github_pull_request_versions\".\"head_sha\" ~ '^[a-f0-9]{40}$'"
+        },
+        "github_pull_request_versions_nonnegative_count": {
+          "name": "github_pull_request_versions_nonnegative_count",
+          "value": "\"github_pull_request_versions\".\"commit_count\" IS NULL OR \"github_pull_request_versions\".\"commit_count\" >= 0"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.github_pull_requests": {
+      "name": "github_pull_requests",
+      "schema": "",
+      "columns": {
+        "account": {
+          "name": "account",
+          "type": "varchar(39)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "additions": {
+          "name": "additions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_login": {
+          "name": "author_login",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_user_id": {
+          "name": "author_user_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "base_ref_name": {
+          "name": "base_ref_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_repository_id": {
+          "name": "base_repository_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_sha": {
+          "name": "base_sha",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body_snapshot": {
+          "name": "body_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "changed_files": {
+          "name": "changed_files",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commit_count": {
+          "name": "commit_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deletions": {
+          "name": "deletions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "draft": {
+          "name": "draft",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "first_observed_at": {
+          "name": "first_observed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "head_ref_name": {
+          "name": "head_ref_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "head_repository_id": {
+          "name": "head_repository_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "head_sha": {
+          "name": "head_sha",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_reconciled_at": {
+          "name": "last_reconciled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "merged_at": {
+          "name": "merged_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "merge_sha": {
+          "name": "merge_sha",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_reconcile_at": {
+          "name": "next_reconcile_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "varchar(128)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "number": {
+          "name": "number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_file_cap_reached": {
+          "name": "provider_file_cap_reached",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "provider_updated_at": {
+          "name": "provider_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "terminal_at": {
+          "name": "terminal_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title_snapshot": {
+          "name": "title_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "github_pull_requests_repository_number_unique": {
+          "name": "github_pull_requests_repository_number_unique",
+          "columns": [
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_pull_requests_reconciliation_idx": {
+          "name": "github_pull_requests_reconciliation_idx",
+          "columns": [
+            {
+              "expression": "account",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_reconcile_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_pull_requests_author_idx": {
+          "name": "github_pull_requests_author_idx",
+          "columns": [
+            {
+              "expression": "author_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_pull_requests_repository_id_github_repositories_id_fk": {
+          "name": "github_pull_requests_repository_id_github_repositories_id_fk",
+          "tableFrom": "github_pull_requests",
+          "tableTo": "github_repositories",
+          "columnsFrom": ["repository_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "github_pull_requests_tracked_account": {
+          "name": "github_pull_requests_tracked_account",
+          "value": "\"github_pull_requests\".\"account\" IN ('f0rr0', 'yuppiestechdev')"
+        },
+        "github_pull_requests_state": {
+          "name": "github_pull_requests_state",
+          "value": "\"github_pull_requests\".\"state\" IN ('open', 'closed', 'merged')"
+        },
+        "github_pull_requests_terminal_state": {
+          "name": "github_pull_requests_terminal_state",
+          "value": "(\"github_pull_requests\".\"state\" = 'open' AND \"github_pull_requests\".\"terminal_at\" IS NULL) OR (\"github_pull_requests\".\"state\" IN ('closed', 'merged') AND \"github_pull_requests\".\"terminal_at\" IS NOT NULL)"
+        },
+        "github_pull_requests_merged_state": {
+          "name": "github_pull_requests_merged_state",
+          "value": "(\"github_pull_requests\".\"state\" = 'merged') = (\"github_pull_requests\".\"merged_at\" IS NOT NULL)"
+        },
+        "github_pull_requests_sha_shapes": {
+          "name": "github_pull_requests_sha_shapes",
+          "value": "(\"github_pull_requests\".\"base_sha\" IS NULL OR \"github_pull_requests\".\"base_sha\" ~ '^[a-f0-9]{40}$') AND (\"github_pull_requests\".\"head_sha\" IS NULL OR \"github_pull_requests\".\"head_sha\" ~ '^[a-f0-9]{40}$') AND (\"github_pull_requests\".\"merge_sha\" IS NULL OR \"github_pull_requests\".\"merge_sha\" ~ '^[a-f0-9]{40}$')"
+        },
+        "github_pull_requests_positive_number": {
+          "name": "github_pull_requests_positive_number",
+          "value": "\"github_pull_requests\".\"number\" > 0"
+        },
+        "github_pull_requests_nonnegative_counts": {
+          "name": "github_pull_requests_nonnegative_counts",
+          "value": "(\"github_pull_requests\".\"changed_files\" IS NULL OR \"github_pull_requests\".\"changed_files\" >= 0) AND (\"github_pull_requests\".\"additions\" IS NULL OR \"github_pull_requests\".\"additions\" >= 0) AND (\"github_pull_requests\".\"deletions\" IS NULL OR \"github_pull_requests\".\"deletions\" >= 0) AND (\"github_pull_requests\".\"commit_count\" IS NULL OR \"github_pull_requests\".\"commit_count\" >= 0)"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.github_push_observation_commits": {
+      "name": "github_push_observation_commits",
+      "schema": "",
+      "columns": {
+        "observation_id": {
+          "name": "observation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sha": {
+          "name": "sha",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "github_push_observation_commits_position_unique": {
+          "name": "github_push_observation_commits_position_unique",
+          "columns": [
+            {
+              "expression": "observation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gh_push_observation_commits_observation_fk": {
+          "name": "gh_push_observation_commits_observation_fk",
+          "tableFrom": "github_push_observation_commits",
+          "tableTo": "github_push_observations",
+          "columnsFrom": ["observation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "gh_push_observation_commits_pk": {
+          "name": "gh_push_observation_commits_pk",
+          "columns": ["observation_id", "repository_id", "sha"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "github_push_observation_commits_sha_shape": {
+          "name": "github_push_observation_commits_sha_shape",
+          "value": "\"github_push_observation_commits\".\"sha\" ~ '^[a-f0-9]{40}$'"
+        },
+        "github_push_observation_commits_nonnegative_position": {
+          "name": "github_push_observation_commits_nonnegative_position",
+          "value": "\"github_push_observation_commits\".\"position\" >= 0"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.github_push_observations": {
+      "name": "github_push_observations",
+      "schema": "",
+      "columns": {
+        "account": {
+          "name": "account",
+          "type": "varchar(39)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "after_sha": {
+          "name": "after_sha",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "before_sha": {
+          "name": "before_sha",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expected_commit_count": {
+          "name": "expected_commit_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "lease_token": {
+          "name": "lease_token",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lease_until": {
+          "name": "lease_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "observed_at": {
+          "name": "observed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "provider_created_at": {
+          "name": "provider_created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ref_name": {
+          "name": "ref_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository_name_snapshot": {
+          "name": "repository_name_snapshot",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        }
+      },
+      "indexes": {
+        "github_push_observations_source_unique": {
+          "name": "github_push_observations_source_unique",
+          "columns": [
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_push_observations_push_unique": {
+          "name": "github_push_observations_push_unique",
+          "columns": [
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ref_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "before_sha",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "after_sha",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_push_observations_pending_idx": {
+          "name": "github_push_observations_pending_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lease_until",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "observed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_push_observations_account_idx": {
+          "name": "github_push_observations_account_idx",
+          "columns": [
+            {
+              "expression": "account",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "observed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gh_push_observations_repository_fk": {
+          "name": "gh_push_observations_repository_fk",
+          "tableFrom": "github_push_observations",
+          "tableTo": "github_repositories",
+          "columnsFrom": ["repository_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "github_push_observations_tracked_account": {
+          "name": "github_push_observations_tracked_account",
+          "value": "\"github_push_observations\".\"account\" IN ('f0rr0', 'yuppiestechdev')"
+        },
+        "github_push_observations_source": {
+          "name": "github_push_observations_source",
+          "value": "\"github_push_observations\".\"source\" IN ('webhook', 'events', 'refs')"
+        },
+        "github_push_observations_sha_shape": {
+          "name": "github_push_observations_sha_shape",
+          "value": "\"github_push_observations\".\"before_sha\" ~ '^[a-f0-9]{40}$' AND \"github_push_observations\".\"after_sha\" ~ '^[a-f0-9]{40}$'"
+        },
+        "github_push_observations_nonnegative_count": {
+          "name": "github_push_observations_nonnegative_count",
+          "value": "\"github_push_observations\".\"expected_commit_count\" IS NULL OR \"github_push_observations\".\"expected_commit_count\" >= 0"
+        },
+        "github_push_observations_state": {
+          "name": "github_push_observations_state",
+          "value": "\"github_push_observations\".\"state\" IN ('pending', 'processing', 'complete', 'deferred', 'unavailable')"
+        },
+        "github_push_observations_lease": {
+          "name": "github_push_observations_lease",
+          "value": "(\"github_push_observations\".\"state\" = 'processing') = (\"github_push_observations\".\"lease_token\" IS NOT NULL) AND (\"github_push_observations\".\"state\" <> 'processing' OR \"github_push_observations\".\"lease_until\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.github_repositories": {
+      "name": "github_repositories",
+      "schema": "",
+      "columns": {
+        "default_branch": {
+          "name": "default_branch",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_observed_at": {
+          "name": "first_observed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "homepage_url": {
+          "name": "homepage_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "html_url": {
+          "name": "html_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar(32)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "last_observed_at": {
+          "name": "last_observed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "owner_avatar_url": {
+          "name": "owner_avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_login": {
+          "name": "owner_login",
+          "type": "varchar(39)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_type": {
+          "name": "owner_type",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "topics": {
+          "name": "topics",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "github_repositories_full_name_idx": {
+          "name": "github_repositories_full_name_idx",
+          "columns": [
+            {
+              "expression": "full_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "github_repositories_owner_type": {
+          "name": "github_repositories_owner_type",
+          "value": "\"github_repositories\".\"owner_type\" IS NULL OR \"github_repositories\".\"owner_type\" IN ('Organization', 'User')"
+        },
+        "github_repositories_visibility": {
+          "name": "github_repositories_visibility",
+          "value": "\"github_repositories\".\"visibility\" IS NULL OR \"github_repositories\".\"visibility\" IN ('public', 'private', 'internal')"
+        },
+        "github_repositories_topics_array": {
+          "name": "github_repositories_topics_array",
+          "value": "\"github_repositories\".\"topics\" IS NULL OR jsonb_typeof(\"github_repositories\".\"topics\") = 'array'"
+        },
+        "github_repositories_observation_order": {
+          "name": "github_repositories_observation_order",
+          "value": "\"github_repositories\".\"last_observed_at\" >= \"github_repositories\".\"first_observed_at\""
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.github_repository_refs": {
+      "name": "github_repository_refs",
+      "schema": "",
+      "columns": {
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "first_observed_at": {
+          "name": "first_observed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "head_sha": {
+          "name": "head_sha",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_observed_at": {
+          "name": "last_observed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ref_name": {
+          "name": "ref_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "github_repository_refs_active_idx": {
+          "name": "github_repository_refs_active_idx",
+          "columns": [
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_repository_refs_repository_fk": {
+          "name": "github_repository_refs_repository_fk",
+          "tableFrom": "github_repository_refs",
+          "tableTo": "github_repositories",
+          "columnsFrom": ["repository_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "github_repository_refs_repository_id_ref_name_pk": {
+          "name": "github_repository_refs_repository_id_ref_name_pk",
+          "columns": ["repository_id", "ref_name"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "github_repository_refs_kind": {
+          "name": "github_repository_refs_kind",
+          "value": "\"github_repository_refs\".\"kind\" IN ('head', 'tag')"
+        },
+        "github_repository_refs_name": {
+          "name": "github_repository_refs_name",
+          "value": "(\"github_repository_refs\".\"kind\" = 'head' AND \"github_repository_refs\".\"ref_name\" LIKE 'refs/heads/%') OR (\"github_repository_refs\".\"kind\" = 'tag' AND \"github_repository_refs\".\"ref_name\" LIKE 'refs/tags/%')"
+        },
+        "github_repository_refs_sha_shape": {
+          "name": "github_repository_refs_sha_shape",
+          "value": "\"github_repository_refs\".\"head_sha\" ~ '^[a-f0-9]{40}$'"
+        },
+        "github_repository_refs_observation_order": {
+          "name": "github_repository_refs_observation_order",
+          "value": "\"github_repository_refs\".\"last_observed_at\" >= \"github_repository_refs\".\"first_observed_at\""
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.github_summary_attempts": {
+      "name": "github_summary_attempts",
+      "schema": "",
+      "columns": {
+        "activity_public_id": {
+          "name": "activity_public_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempted_at": {
+          "name": "attempted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_hash": {
+          "name": "input_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lease_token": {
+          "name": "lease_token",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lease_until": {
+          "name": "lease_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recipe": {
+          "name": "recipe",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revision": {
+          "name": "revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "summary_headline": {
+          "name": "summary_headline",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary_short": {
+          "name": "summary_short",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "github_summary_attempts_pending_idx": {
+          "name": "github_summary_attempts_pending_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gh_summary_attempts_activity_fk": {
+          "name": "gh_summary_attempts_activity_fk",
+          "tableFrom": "github_summary_attempts",
+          "tableTo": "github_public_activities",
+          "columnsFrom": ["activity_public_id"],
+          "columnsTo": ["public_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "gh_summary_attempts_pk": {
+          "name": "gh_summary_attempts_pk",
+          "columns": ["activity_public_id", "revision"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "github_summary_attempts_state": {
+          "name": "github_summary_attempts_state",
+          "value": "\"github_summary_attempts\".\"state\" IN ('pending', 'processing', 'complete', 'failed', 'indeterminate')"
+        },
+        "github_summary_attempts_positive_revision": {
+          "name": "github_summary_attempts_positive_revision",
+          "value": "\"github_summary_attempts\".\"revision\" > 0"
+        },
+        "github_summary_attempts_input_hash_shape": {
+          "name": "github_summary_attempts_input_hash_shape",
+          "value": "\"github_summary_attempts\".\"input_hash\" IS NULL OR \"github_summary_attempts\".\"input_hash\" ~ '^[a-f0-9]{64}$'"
+        },
+        "github_summary_attempts_summary_pair": {
+          "name": "github_summary_attempts_summary_pair",
+          "value": "(\"github_summary_attempts\".\"summary_headline\" IS NULL) = (\"github_summary_attempts\".\"summary_short\" IS NULL)"
+        },
+        "github_summary_attempts_complete_output": {
+          "name": "github_summary_attempts_complete_output",
+          "value": "\"github_summary_attempts\".\"state\" <> 'complete' OR (\"github_summary_attempts\".\"summary_headline\" IS NOT NULL AND \"github_summary_attempts\".\"completed_at\" IS NOT NULL)"
+        },
+        "github_summary_attempts_lease": {
+          "name": "github_summary_attempts_lease",
+          "value": "(\"github_summary_attempts\".\"state\" = 'processing') = (\"github_summary_attempts\".\"lease_token\" IS NOT NULL) AND (\"github_summary_attempts\".\"state\" <> 'processing' OR \"github_summary_attempts\".\"lease_until\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.github_webhook_deliveries": {
+      "name": "github_webhook_deliveries",
+      "schema": "",
+      "columns": {
+        "accepted": {
+          "name": "accepted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account": {
+          "name": "account",
+          "type": "varchar(39)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_id": {
+          "name": "delivery_id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event": {
+          "name": "event",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "observed_at": {
+          "name": "observed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "github_webhook_deliveries_audit_idx": {
+          "name": "github_webhook_deliveries_audit_idx",
+          "columns": [
+            {
+              "expression": "event",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "observed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "github_webhook_deliveries_id_shape": {
+          "name": "github_webhook_deliveries_id_shape",
+          "value": "\"github_webhook_deliveries\".\"delivery_id\" ~ '^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$'"
+        },
+        "github_webhook_deliveries_event_shape": {
+          "name": "github_webhook_deliveries_event_shape",
+          "value": "\"github_webhook_deliveries\".\"event\" ~ '^[a-z][a-z0-9_]{0,39}$'"
+        },
+        "github_webhook_deliveries_action_shape": {
+          "name": "github_webhook_deliveries_action_shape",
+          "value": "\"github_webhook_deliveries\".\"action\" IS NULL OR \"github_webhook_deliveries\".\"action\" ~ '^[a-z][a-z0-9_]{0,39}$'"
+        },
+        "github_webhook_deliveries_repository_id_shape": {
+          "name": "github_webhook_deliveries_repository_id_shape",
+          "value": "\"github_webhook_deliveries\".\"repository_id\" IS NULL OR \"github_webhook_deliveries\".\"repository_id\" ~ '^[0-9]{1,32}$'"
+        },
+        "github_webhook_deliveries_tracked_account": {
+          "name": "github_webhook_deliveries_tracked_account",
+          "value": "\"github_webhook_deliveries\".\"account\" IS NULL OR \"github_webhook_deliveries\".\"account\" IN ('f0rr0', 'yuppiestechdev')"
+        }
+      },
+      "isRLSEnabled": true
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -57,6 +57,13 @@
       "when": 1787949510936,
       "tag": "0007_rare_toad_men",
       "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "7",
+      "when": 1788014897142,
+      "tag": "0008_warm_bedlam",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -154,7 +154,7 @@
 
   .github-activity-entry {
     border-bottom: 1px solid var(--border);
-    padding-block: 1.5rem;
+    padding-block: 1.25rem;
     content-visibility: auto;
     contain-intrinsic-size: auto 11rem;
   }
@@ -173,20 +173,45 @@
     gap: 0.625rem;
   }
 
-  .github-activity-avatar,
-  .github-activity-avatar-fallback {
-    width: 1.75rem;
-    height: 1.75rem;
+  .github-activity-avatar-frame {
+    position: relative;
+    width: 1.375rem;
+    height: 1.375rem;
     flex: none;
-    border: 1px solid color-mix(in oklab, var(--border) 82%, transparent);
-    border-radius: 0.45rem;
+  }
+
+  .github-activity-avatar-image-frame {
+    display: block;
+    width: 100%;
+    height: 100%;
+    overflow: hidden;
+    border-radius: 9999px;
     background: var(--muted);
   }
 
-  .github-activity-avatar-fallback {
+  .github-activity-avatar {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+  }
+
+  .github-activity-avatar-private {
+    filter: blur(2px);
+    transform: scale(1.1);
+  }
+
+  .github-activity-avatar-lock {
+    position: absolute;
+    right: -0.175rem;
+    bottom: -0.175rem;
     display: grid;
+    width: 0.875rem;
+    height: 0.875rem;
     place-items: center;
+    border-radius: 9999px;
+    background: var(--background);
     color: var(--muted-foreground);
+    box-shadow: 0 0 0 1px var(--background);
   }
 
   .github-activity-repository-label,
@@ -195,13 +220,15 @@
     min-width: 0;
     align-items: center;
     gap: 0.3rem;
-    overflow: hidden;
     color: var(--muted-foreground);
     font-family: var(--font-site-mono);
     font-size: 0.75rem;
     line-height: 1.35;
-    text-overflow: ellipsis;
-    white-space: nowrap;
+  }
+
+  .github-activity-repository-name {
+    min-width: 0;
+    overflow-wrap: anywhere;
   }
 
   .github-activity-repository-link {
@@ -223,25 +250,25 @@
   .github-activity-headline,
   .github-activity-summary {
     max-width: 50rem;
-    margin-top: 1rem;
     color: var(--foreground);
     overflow-wrap: anywhere;
     white-space: pre-wrap;
   }
 
   .github-activity-headline {
-    font-family: var(--font-site-heading);
-    font-size: clamp(1.2rem, 3vw, 1.45rem);
-    font-weight: 700;
-    letter-spacing: -0.02em;
-    line-height: 1.25;
+    margin-top: 0.75rem;
+    font-family: var(--font-site-body);
+    font-size: 1rem;
+    font-weight: 400;
+    letter-spacing: normal;
+    line-height: 1.625;
   }
 
   .github-activity-kind {
     display: inline-flex;
     align-items: center;
     gap: 0.35rem;
-    margin-top: 1rem;
+    margin-top: 0.75rem;
     color: var(--primary);
     font-family: var(--font-site-ui);
     font-size: 0.6875rem;
@@ -252,23 +279,28 @@
 
   .github-activity-work-title {
     max-width: 50rem;
-    margin-top: 0.45rem;
+    margin-top: 0.35rem;
     color: var(--foreground);
-    font-family: var(--font-site-heading);
-    font-size: clamp(1.2rem, 3vw, 1.45rem);
-    font-weight: 700;
-    letter-spacing: -0.02em;
-    line-height: 1.25;
+    font-family: var(--font-site-body);
+    font-size: 1rem;
+    font-weight: 400;
+    letter-spacing: normal;
+    line-height: 1.625;
     overflow-wrap: anywhere;
   }
 
   .github-activity-disclosure > summary {
     display: grid;
-    grid-template-columns: minmax(0, 1fr) auto;
-    align-items: end;
-    gap: 1rem;
+    grid-template-columns: minmax(0, 1fr) auto auto;
+    align-items: center;
+    column-gap: 0.75rem;
+    row-gap: 0;
     list-style: none;
     cursor: pointer;
+  }
+
+  .github-activity-disclosure > summary.github-activity-timed-commit-row {
+    grid-template-columns: minmax(0, 1fr) auto auto auto;
   }
 
   .github-activity-disclosure > summary::-webkit-details-marker {
@@ -281,39 +313,74 @@
     outline-offset: 0.35rem;
   }
 
+  .github-activity-disclosure > summary .github-activity-headline {
+    min-width: 0;
+    margin-top: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .github-activity-commit-group {
+    border-bottom: 0;
+    padding-block: 1rem 1.125rem;
+  }
+
+  .github-activity-commit-group-header {
+    display: flex;
+    align-items: center;
+  }
+
+  .github-activity-grouped-commits {
+    display: grid;
+    margin-top: 0.35rem;
+  }
+
+  .github-activity-grouped-commits > li {
+    padding-block: 0.45rem;
+  }
+
   .github-activity-disclosure-label {
-    padding-bottom: 0.15rem;
+    display: inline-flex;
+    align-items: center;
     color: var(--muted-foreground);
-    font-family: var(--font-site-ui);
-    font-size: 0.6875rem;
-    font-weight: 600;
-    letter-spacing: 0.05em;
-    text-transform: uppercase;
   }
 
   .github-activity-disclosure[open] .github-activity-disclosure-label {
     color: var(--primary);
   }
 
+  .github-activity-disclosure-chevron {
+    width: 0.875rem;
+    height: 0.875rem;
+    transition: transform 160ms ease;
+  }
+
+  .github-activity-disclosure[open] .github-activity-disclosure-chevron {
+    transform: rotate(180deg);
+  }
+
   .github-activity-nested-commits {
     display: grid;
-    gap: 1.15rem;
-    margin-top: 1.25rem;
+    gap: 1rem;
+    margin-top: 1rem;
     border-left: 1px solid color-mix(in oklab, var(--border) 86%, transparent);
     padding-left: clamp(1rem, 3vw, 1.5rem);
   }
 
   .github-activity-nested-commits .github-activity-headline {
     margin-top: 0;
-    font-size: clamp(1rem, 2.4vw, 1.15rem);
+    font-size: 1rem;
   }
 
   .github-activity-nested-commits .github-activity-summary {
-    margin-top: 0.75rem;
+    margin-top: 0.5rem;
     font-size: 0.925rem;
   }
 
   .github-activity-summary {
+    margin-top: 0.625rem;
+    color: var(--muted-foreground);
     font-size: 0.975rem;
     line-height: 1.75;
   }
@@ -334,11 +401,15 @@
     flex-wrap: wrap;
     align-items: center;
     gap: 0.7rem 1rem;
-    margin-top: 1rem;
+    margin-top: 0.625rem;
     color: var(--muted-foreground);
     font-family: var(--font-site-mono);
     font-size: 0.6875rem;
     letter-spacing: 0.02em;
+  }
+
+  .github-activity-visible-facts {
+    margin-top: 0;
   }
 
   .github-activity-loc,
@@ -385,8 +456,8 @@
   }
 
   @media (prefers-reduced-motion: reduce) {
-    .github-activity-repository-link,
-    .group\/link svg {
+    .github-activity-disclosure-chevron,
+    .github-activity-repository-link {
       transition: none;
     }
   }

--- a/src/components/github-activity-days.tsx
+++ b/src/components/github-activity-days.tsx
@@ -1,8 +1,7 @@
 import {
-  ArrowUpRight,
+  ChevronDown,
   CircleDot,
   Code2,
-  GitBranch,
   GitMerge,
   GitPullRequest,
   LockKeyhole,
@@ -10,11 +9,13 @@ import {
 import Image from "next/image";
 import { Fragment } from "react";
 
+import { LocalTime } from "@/components/local-time";
 import type {
   PublicGitHubActivityCommit,
   PublicGitHubActivityDay,
   PublicGitHubActivityItem,
   PublicGitHubActivityRepository,
+  PublicGitHubStandaloneCommitActivity,
 } from "@/lib/github-activity-types";
 
 const dayFormatter = new Intl.DateTimeFormat("en-US", {
@@ -23,13 +24,6 @@ const dayFormatter = new Intl.DateTimeFormat("en-US", {
   timeZone: "UTC",
   weekday: "long",
   year: "numeric",
-});
-
-const timeFormatter = new Intl.DateTimeFormat("en-US", {
-  hour: "numeric",
-  minute: "2-digit",
-  timeZone: "UTC",
-  timeZoneName: "short",
 });
 
 const countFormatter = new Intl.NumberFormat("en-US");
@@ -47,6 +41,64 @@ function InlineSummary({ children }: Readonly<{ children: string }>) {
   });
 }
 
+function RepositoryIdentity({
+  repository,
+}: Readonly<{
+  repository: PublicGitHubActivityRepository;
+}>) {
+  const repositoryLabel = repository.label ?? "Private";
+  return (
+    <div className="github-activity-repository">
+      {repository.avatarUrl === null ? null : (
+        <span aria-hidden="true" className="github-activity-avatar-frame">
+          <span className="github-activity-avatar-image-frame">
+            <Image
+              alt=""
+              className={
+                repository.url === null
+                  ? "github-activity-avatar github-activity-avatar-private"
+                  : "github-activity-avatar"
+              }
+              height={22}
+              sizes="22px"
+              src={repository.avatarUrl}
+              unoptimized
+              width={22}
+            />
+          </span>
+          {repository.url === null ? (
+            <span className="github-activity-avatar-lock">
+              <LockKeyhole className="size-2.5" />
+            </span>
+          ) : null}
+        </span>
+      )}
+      {repository.url === null ? (
+        <span className="github-activity-repository-label">
+          {repository.avatarUrl === null ? (
+            <LockKeyhole aria-hidden="true" className="size-3" />
+          ) : null}
+          <span className="github-activity-repository-name">
+            {repositoryLabel}
+          </span>
+        </span>
+      ) : (
+        <a
+          className="github-activity-repository-link"
+          href={repository.url}
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          <span className="github-activity-repository-name">
+            {repositoryLabel}
+          </span>
+          <span className="sr-only"> (opens on GitHub in a new tab)</span>
+        </a>
+      )}
+    </div>
+  );
+}
+
 function RepositoryHeader({
   occurredAt,
   repository,
@@ -54,62 +106,19 @@ function RepositoryHeader({
   occurredAt: string;
   repository: PublicGitHubActivityRepository;
 }>) {
-  const repositoryLabel = repository.label ?? "Private contribution";
   return (
     <div className="github-activity-entry-header">
-      <div className="github-activity-repository">
-        {repository.avatarUrl === null ? (
-          <span aria-hidden="true" className="github-activity-avatar-fallback">
-            <GitBranch className="size-3.5" />
-          </span>
-        ) : (
-          <Image
-            alt=""
-            className="github-activity-avatar"
-            height={28}
-            sizes="28px"
-            src={repository.avatarUrl}
-            unoptimized
-            width={28}
-          />
-        )}
-        {repository.url === null ? (
-          <span className="github-activity-repository-label">
-            {repository.label === null ? (
-              <LockKeyhole aria-hidden="true" className="size-3" />
-            ) : null}
-            {repositoryLabel}
-          </span>
-        ) : (
-          <a
-            className="group/link github-activity-repository-link"
-            href={repository.url}
-            rel="noopener noreferrer"
-            target="_blank"
-          >
-            {repositoryLabel}
-            <ArrowUpRight
-              aria-hidden="true"
-              className="size-3 transition-transform group-hover/link:-translate-y-0.5 group-hover/link:translate-x-0.5"
-            />
-            <span className="sr-only"> (opens on GitHub in a new tab)</span>
-          </a>
-        )}
-      </div>
-      <time className="github-activity-time" dateTime={occurredAt}>
-        {timeFormatter.format(new Date(occurredAt))}
-      </time>
+      <RepositoryIdentity repository={repository} />
+      <LocalTime className="github-activity-time" dateTime={occurredAt} />
     </div>
   );
 }
 
-function CommitFacts({
+function CommitLoc({
   commit,
 }: Readonly<{ commit: PublicGitHubActivityCommit }>) {
-  const visibleLanguages = commit.languages.slice(0, 6);
-  const hiddenLanguageCount = commit.languages.length - visibleLanguages.length;
   return (
-    <div className="github-activity-facts">
+    <span className="github-activity-facts github-activity-visible-facts">
       <span
         className="github-activity-loc"
         title={
@@ -133,6 +142,17 @@ function CommitFacts({
             : null}
         </span>
       </span>
+    </span>
+  );
+}
+
+function CommitDetails({
+  commit,
+}: Readonly<{ commit: PublicGitHubActivityCommit }>) {
+  const visibleLanguages = commit.languages.slice(0, 6);
+  const hiddenLanguageCount = commit.languages.length - visibleLanguages.length;
+  return (
+    <div className="github-activity-facts github-activity-expanded-facts">
       <span
         title={
           commit.providerFileCapReached
@@ -201,36 +221,113 @@ function CommitFacts({
 function CommitDisclosure({
   commit,
   headingLevel,
+  occurredAt,
 }: Readonly<{
   commit: PublicGitHubActivityCommit;
   headingLevel: "h4" | "h5";
+  occurredAt?: string;
 }>) {
   const Heading = headingLevel;
-  if (commit.summary === null) {
-    return (
-      <div className="github-activity-commit">
-        <Heading className="github-activity-headline">
-          <InlineSummary>{commit.headline}</InlineSummary>
-        </Heading>
-        <CommitFacts commit={commit} />
-      </div>
-    );
-  }
   return (
     <details className="github-activity-commit github-activity-disclosure">
-      <summary>
+      <summary
+        className={
+          occurredAt === undefined
+            ? undefined
+            : "github-activity-timed-commit-row"
+        }
+      >
         <Heading className="github-activity-headline">
           <InlineSummary>{commit.headline}</InlineSummary>
         </Heading>
+        <CommitLoc commit={commit} />
+        {occurredAt === undefined ? null : (
+          <LocalTime className="github-activity-time" dateTime={occurredAt} />
+        )}
         <span className="github-activity-disclosure-label" aria-hidden="true">
-          Details
+          <ChevronDown className="github-activity-disclosure-chevron" />
         </span>
       </summary>
-      <p className="github-activity-summary">
-        <InlineSummary>{commit.summary}</InlineSummary>
-      </p>
-      <CommitFacts commit={commit} />
+      {commit.summary === null ? null : (
+        <p className="github-activity-summary">
+          <InlineSummary>{commit.summary}</InlineSummary>
+        </p>
+      )}
+      <CommitDetails commit={commit} />
     </details>
+  );
+}
+
+interface RepositoryCommitGroup {
+  commits: PublicGitHubStandaloneCommitActivity[];
+  id: string;
+  kind: "repository-commit-group";
+  repository: PublicGitHubActivityRepository;
+}
+
+type NonCommitActivityItem = Exclude<
+  PublicGitHubActivityItem,
+  PublicGitHubStandaloneCommitActivity
+>;
+
+type GroupedActivityItem = NonCommitActivityItem | RepositoryCommitGroup;
+
+function compareIsoTimestampsDescending(left: string, right: string) {
+  if (left === right) {
+    return 0;
+  }
+  return left < right ? 1 : -1;
+}
+
+function groupedActivityTimestamp(item: GroupedActivityItem) {
+  return item.kind === "repository-commit-group"
+    ? (item.commits[0]?.commit.committedAt ?? "")
+    : item.occurredAt;
+}
+
+function groupCommitsByRepository(
+  items: readonly PublicGitHubActivityItem[]
+): GroupedActivityItem[] {
+  const groupedItems: GroupedActivityItem[] = [];
+  const commitGroups = new Map<string, RepositoryCommitGroup>();
+
+  for (const item of items) {
+    if (item.kind !== "commit") {
+      groupedItems.push(item);
+      continue;
+    }
+
+    const repositoryKey = item.repository.label ?? "private";
+    const existingGroup = commitGroups.get(repositoryKey);
+    if (existingGroup !== undefined) {
+      existingGroup.commits.push(item);
+      continue;
+    }
+
+    const group: RepositoryCommitGroup = {
+      commits: [item],
+      id: `repository-commits:${item.id}`,
+      kind: "repository-commit-group",
+      repository: item.repository,
+    };
+    commitGroups.set(repositoryKey, group);
+    groupedItems.push(group);
+  }
+
+  for (const group of commitGroups.values()) {
+    group.commits.sort((left, right) =>
+      compareIsoTimestampsDescending(
+        left.commit.committedAt,
+        right.commit.committedAt
+      )
+    );
+  }
+
+  return groupedItems.toSorted((left, right) =>
+    compareIsoTimestampsDescending(
+      groupedActivityTimestamp(left),
+      groupedActivityTimestamp(right)
+    )
   );
 }
 
@@ -259,21 +356,7 @@ function ActivityKind({
   );
 }
 
-function ActivityEntry({ item }: Readonly<{ item: PublicGitHubActivityItem }>) {
-  if (item.kind === "commit") {
-    return (
-      <li className="github-activity-entry">
-        <article>
-          <RepositoryHeader
-            occurredAt={item.occurredAt}
-            repository={item.repository}
-          />
-          <CommitDisclosure commit={item.commit} headingLevel="h4" />
-        </article>
-      </li>
-    );
-  }
-
+function ActivityEntry({ item }: Readonly<{ item: NonCommitActivityItem }>) {
   if (item.kind === "pull-request-commits") {
     return (
       <li className="github-activity-entry">
@@ -305,6 +388,32 @@ function ActivityEntry({ item }: Readonly<{ item: PublicGitHubActivityItem }>) {
         />
         <ActivityKind kind={item.kind} />
         <h4 className="github-activity-work-title">{item.title}</h4>
+      </article>
+    </li>
+  );
+}
+
+function RepositoryCommitGroupEntry({
+  group,
+}: Readonly<{ group: RepositoryCommitGroup }>) {
+  const repositoryLabel = group.repository.label ?? "Private";
+  return (
+    <li className="github-activity-entry github-activity-commit-group">
+      <article aria-label={`${repositoryLabel} commits`}>
+        <div className="github-activity-commit-group-header">
+          <RepositoryIdentity repository={group.repository} />
+        </div>
+        <ol className="github-activity-grouped-commits">
+          {group.commits.map((item) => (
+            <li key={item.id}>
+              <CommitDisclosure
+                commit={item.commit}
+                headingLevel="h5"
+                occurredAt={item.occurredAt}
+              />
+            </li>
+          ))}
+        </ol>
       </article>
     </li>
   );
@@ -384,9 +493,13 @@ export function GitHubActivityDays({
         <DayTotals day={day} />
       </div>
       <ol className="github-activity-list">
-        {day.items.map((item) => (
-          <ActivityEntry item={item} key={item.id} />
-        ))}
+        {groupCommitsByRepository(day.items).map((item) =>
+          item.kind === "repository-commit-group" ? (
+            <RepositoryCommitGroupEntry group={item} key={item.id} />
+          ) : (
+            <ActivityEntry item={item} key={item.id} />
+          )
+        )}
       </ol>
     </section>
   ));

--- a/src/components/local-time.tsx
+++ b/src/components/local-time.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { useSyncExternalStore } from "react";
+
+const subscribe = () => () => null;
+
+const utcTimeFormatter = new Intl.DateTimeFormat("en-US", {
+  hour: "numeric",
+  minute: "2-digit",
+  timeZone: "UTC",
+});
+
+const localTimeFormatter = new Intl.DateTimeFormat("en-US", {
+  hour: "numeric",
+  minute: "2-digit",
+});
+
+export function LocalTime({
+  className,
+  dateTime,
+}: Readonly<{ className?: string; dateTime: string }>) {
+  const date = new Date(dateTime);
+  const localLabel = localTimeFormatter.format(date);
+  const serverLabel = utcTimeFormatter.format(date);
+  const label = useSyncExternalStore(
+    subscribe,
+    () => localLabel,
+    () => serverLabel
+  );
+
+  return (
+    <time className={className} dateTime={dateTime}>
+      {label}
+    </time>
+  );
+}

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -269,6 +269,54 @@ export const githubRepositories = pgTable(
   ]
 ).enableRLS();
 
+export const githubRepositoryRefs = pgTable(
+  "github_repository_refs",
+  {
+    active: boolean("active").default(true).notNull(),
+    firstObservedAt: timestamp("first_observed_at", {
+      mode: "date",
+      withTimezone: true,
+    })
+      .defaultNow()
+      .notNull(),
+    headSha: varchar("head_sha", { length: 40 }).notNull(),
+    kind: varchar("kind", { length: 8 }).notNull(),
+    lastObservedAt: timestamp("last_observed_at", {
+      mode: "date",
+      withTimezone: true,
+    })
+      .defaultNow()
+      .notNull(),
+    refName: text("ref_name").notNull(),
+    repositoryId: varchar("repository_id", { length: 32 }).notNull(),
+  },
+  (table) => [
+    primaryKey({ columns: [table.repositoryId, table.refName] }),
+    index("github_repository_refs_active_idx").on(
+      table.repositoryId,
+      table.active
+    ),
+    foreignKey({
+      columns: [table.repositoryId],
+      foreignColumns: [githubRepositories.id],
+      name: "github_repository_refs_repository_fk",
+    }).onDelete("cascade"),
+    check("github_repository_refs_kind", sql`${table.kind} IN ('head', 'tag')`),
+    check(
+      "github_repository_refs_name",
+      sql`(${table.kind} = 'head' AND ${table.refName} LIKE 'refs/heads/%') OR (${table.kind} = 'tag' AND ${table.refName} LIKE 'refs/tags/%')`
+    ),
+    check(
+      "github_repository_refs_sha_shape",
+      sql`${table.headSha} ~ '^[a-f0-9]{40}$'`
+    ),
+    check(
+      "github_repository_refs_observation_order",
+      sql`${table.lastObservedAt} >= ${table.firstObservedAt}`
+    ),
+  ]
+).enableRLS();
+
 export const githubWebhookDeliveries = pgTable(
   "github_webhook_deliveries",
   {
@@ -381,7 +429,7 @@ export const githubPushObservations = pgTable(
     ),
     check(
       "github_push_observations_source",
-      sql`${table.source} IN ('webhook', 'events')`
+      sql`${table.source} IN ('webhook', 'events', 'refs')`
     ),
     check(
       "github_push_observations_sha_shape",

--- a/src/lib/github-activity-display.ts
+++ b/src/lib/github-activity-display.ts
@@ -1,5 +1,3 @@
-import { trackedGitHubAccountFrom } from "@/lib/github-commits-core";
-
 const languageIconSlug: Readonly<Record<string, string>> = {
   c: "c",
   cpp: "cplusplus",
@@ -52,11 +50,11 @@ const repositoryLabel = (input: {
   private: boolean;
   repository: string;
 }) => {
-  const directlyOwned = trackedGitHubAccountFrom(input.ownerLogin) !== null;
-  const canName = !input.private || directlyOwned;
-  return canName
-    ? (input.repository.split("/").at(-1) ?? input.repository)
-    : null;
+  if (input.private) {
+    return "Private";
+  }
+  const repositoryName = input.repository.split("/").at(-1);
+  return `${input.ownerLogin}/${repositoryName ?? input.repository}`;
 };
 
 const safeGitHubUrl = (value: string) => {

--- a/src/lib/github-activity-feed.ts
+++ b/src/lib/github-activity-feed.ts
@@ -21,7 +21,7 @@ const readCachedActivity = unstable_cache(
       cursor,
       PUBLIC_GITHUB_ACTIVITY_DAY_PAGE_SIZE
     ),
-  ["public-github-activity-v8"],
+  ["public-github-activity-v11"],
   { revalidate: 900, tags: ["github-activity"] }
 );
 

--- a/src/lib/github-activity-processor.ts
+++ b/src/lib/github-activity-processor.ts
@@ -38,7 +38,6 @@ const MAXIMUM_GITHUB_FILE_PAGES = 30;
 const MAXIMUM_GITHUB_PULL_REQUEST_PAGES = 10;
 const MAXIMUM_GITHUB_PULL_REQUEST_COMMIT_PAGES = 3;
 const MAXIMUM_GITHUB_PULL_REQUEST_GRAPHQL_PAGES = 30;
-const MAXIMUM_GITHUB_PUSH_PAGES = 30;
 const ZERO_SHA = "0".repeat(40);
 
 type JsonObject = Record<string, unknown>;
@@ -535,20 +534,32 @@ const compareCommitValuesWithToken = async (
     )
   );
   url.searchParams.set("per_page", "100");
-
-  for (
-    let page = 0;
-    url !== null && page < MAXIMUM_GITHUB_PUSH_PAGES;
-    page += 1
-  ) {
+  const visited = new Set<string>();
+  let aheadBy: number | null = null;
+  while (url !== null) {
+    if (visited.has(url.href)) {
+      throw new ActivityProcessingError(
+        "source_invalid",
+        "GitHub returned cyclic compare pagination."
+      );
+    }
+    visited.add(url.href);
     const result = await fetchJsonWithResponse(url, token);
     const pageValues = isObject(result.payload) ? result.payload.commits : null;
-    if (!Array.isArray(pageValues)) {
+    const pageAheadBy = isObject(result.payload)
+      ? requiredInteger(result.payload.ahead_by, "compare ahead count")
+      : null;
+    if (
+      !Array.isArray(pageValues) ||
+      pageAheadBy === null ||
+      (aheadBy !== null && aheadBy !== pageAheadBy)
+    ) {
       throw new ActivityProcessingError(
         "source_invalid",
         "GitHub returned invalid push commit evidence."
       );
     }
+    aheadBy = pageAheadBy;
     values.push(...pageValues);
     url = nextGitHubPage(result.response);
     if (
@@ -563,7 +574,8 @@ const compareCommitValuesWithToken = async (
   }
 
   if (
-    url !== null ||
+    aheadBy === null ||
+    values.length !== aheadBy ||
     (row.expectedCommitCount !== null &&
       values.length !== row.expectedCommitCount)
   ) {
@@ -576,22 +588,19 @@ const compareCommitValuesWithToken = async (
 };
 
 // GitHub cannot compare the all-zero SHA used for a new branch. GraphQL's
-// cursor lets us request exactly the observed number of commits without
-// truncating an arbitrary REST history page.
+// cursor lets us request exactly the observed number of commits when legacy
+// payloads include it, or the complete reachable history for today's sparse
+// Events and a newly observed ref.
 // oxlint-disable-next-line complexity -- Every GraphQL history invariant fails closed.
 const newBranchCommitValuesWithToken = async (
   row: GitHubActivityPushObservationReference,
   token: string
 ) => {
   const { expectedCommitCount } = row;
-  if (
-    expectedCommitCount === null ||
-    expectedCommitCount < 1 ||
-    expectedCommitCount > MAXIMUM_GITHUB_PUSH_PAGES * 100
-  ) {
+  if (expectedCommitCount !== null && expectedCommitCount < 1) {
     throw new ActivityProcessingError(
       "source_incomplete",
-      "A new-branch push has no safely bounded commit range."
+      "A new-branch push has an invalid commit count."
     );
   }
   const [owner, name] = row.repository.split("/");
@@ -621,8 +630,12 @@ const newBranchCommitValuesWithToken = async (
   }`;
   const values: unknown[] = [];
   let cursor: string | null = null;
-  while (values.length < expectedCommitCount) {
-    const pageSize = Math.min(100, expectedCommitCount - values.length);
+  const visitedCursors = new Set<string>();
+  while (true) {
+    const pageSize =
+      expectedCommitCount === null
+        ? 100
+        : Math.min(100, expectedCommitCount - values.length);
     const response = await fetchGitHub(githubApiUrl("/graphql"), {
       body: JSON.stringify({
         query,
@@ -647,7 +660,9 @@ const newBranchCommitValuesWithToken = async (
     if (
       !isObject(history) ||
       !Array.isArray(history.nodes) ||
-      history.nodes.length !== pageSize ||
+      history.nodes.length === 0 ||
+      history.nodes.length > pageSize ||
+      (expectedCommitCount !== null && history.nodes.length !== pageSize) ||
       !isObject(history.pageInfo) ||
       typeof history.pageInfo.hasNextPage !== "boolean"
     ) {
@@ -674,19 +689,27 @@ const newBranchCommitValuesWithToken = async (
         sha: node.oid,
       });
     }
-    if (values.length < expectedCommitCount) {
+    const needsNextPage =
+      expectedCommitCount === null
+        ? history.pageInfo.hasNextPage
+        : values.length < expectedCommitCount;
+    if (needsNextPage) {
       const nextCursor = history.pageInfo.endCursor;
       if (
         !history.pageInfo.hasNextPage ||
         typeof nextCursor !== "string" ||
-        nextCursor.length === 0
+        nextCursor.length === 0 ||
+        visitedCursors.has(nextCursor)
       ) {
         throw new ActivityProcessingError(
           "source_incomplete",
           "GitHub ended new-branch history before the observed commit count."
         );
       }
+      visitedCursors.add(nextCursor);
       cursor = nextCursor;
+    } else {
+      break;
     }
   }
   return values.toReversed();
@@ -695,20 +718,44 @@ const newBranchCommitValuesWithToken = async (
 const pushCommitValuesWithToken = async (
   row: GitHubActivityPushObservationReference,
   token: string
-) =>
-  row.beforeSha === ZERO_SHA
-    ? await newBranchCommitValuesWithToken(row, token)
-    : await compareCommitValuesWithToken(row, token);
+) => {
+  if (row.beforeSha === ZERO_SHA) {
+    return await newBranchCommitValuesWithToken(row, token);
+  }
+  try {
+    return await compareCommitValuesWithToken(row, token);
+  } catch (error) {
+    if (
+      !(error instanceof GitHubResponseError) ||
+      ![404, 409].includes(error.status)
+    ) {
+      throw error;
+    }
+    try {
+      return await newBranchCommitValuesWithToken(
+        { ...row, beforeSha: ZERO_SHA, expectedCommitCount: null },
+        token
+      );
+    } catch {
+      // Preserve the response error so token fallback can try another identity.
+      throw error;
+    }
+  }
+};
 
 export const validateGitHubPushObservationCommitShas = (
   row: GitHubActivityPushObservationReference,
   commitShas: readonly string[]
 ) => {
+  const emptyRewind =
+    commitShas.length === 0 &&
+    row.expectedCommitCount === null &&
+    row.beforeSha !== ZERO_SHA;
   if (
-    commitShas.length === 0 ||
+    (!emptyRewind && commitShas.length === 0) ||
     (row.expectedCommitCount !== null &&
       commitShas.length !== row.expectedCommitCount) ||
-    commitShas.at(-1) !== row.afterSha ||
+    (commitShas.length > 0 && commitShas.at(-1) !== row.afterSha) ||
     new Set(commitShas).size !== commitShas.length ||
     commitShas.some((sha) => commitShaFrom(sha) === null)
   ) {
@@ -733,8 +780,7 @@ export const validateGitHubPushObservationCommitShas = (
 const trackedCommitFromPushValue = (
   value: unknown,
   sha: string,
-  repository: GitHubRepository,
-  observedAt: Date
+  repository: GitHubRepository
 ): GitHubCommit | null => {
   if (!isObject(value)) {
     return null;
@@ -753,9 +799,12 @@ const trackedCommitFromPushValue = (
       : null;
   const providerDate =
     typeof rawDate === "string" ? new Date(rawDate) : new Date(Number.NaN);
-  const committedAt = Number.isNaN(providerDate.getTime())
-    ? observedAt
-    : providerDate;
+  if (Number.isNaN(providerDate.getTime())) {
+    throw new ActivityProcessingError(
+      "source_invalid",
+      "GitHub returned an invalid commit author date."
+    );
+  }
   const message =
     typeof rawCommit?.message === "string"
       ? (rawCommit.message.split(/\r?\n/, 1)[0] ?? "")
@@ -765,7 +814,7 @@ const trackedCommitFromPushValue = (
       : "";
   return {
     author,
-    committedAt: committedAt.toISOString(),
+    committedAt: providerDate.toISOString(),
     message,
     repository: repository.fullName,
     repositoryId: repository.id,
@@ -796,12 +845,7 @@ const pushObservationSourceWithToken = async (
     }
     seen.add(sha);
     commitShas.push(sha);
-    const commit = trackedCommitFromPushValue(
-      value,
-      sha,
-      repository,
-      row.observedAt
-    );
+    const commit = trackedCommitFromPushValue(value, sha, repository);
     if (commit !== null) {
       commits.push(commit);
     }

--- a/src/lib/github-commits-core.ts
+++ b/src/lib/github-commits-core.ts
@@ -101,7 +101,7 @@ export interface GitHubPullRequestWebhookObservation {
 export interface GitHubPullRequestEventSignal {
   action: string;
   number: number;
-  repositoryId: string;
+  repository: GitHubRepository;
 }
 
 export interface GitHubEvent {
@@ -805,7 +805,7 @@ const sparsePullRequestEventSignalFrom = (
   ) {
     return null;
   }
-  return { action, number, repositoryId: repository.id };
+  return { action, number, repository };
 };
 
 const pullRequestEventFrom = (

--- a/src/lib/github-commits-store.ts
+++ b/src/lib/github-commits-store.ts
@@ -1,4 +1,17 @@
-import { and, eq, gt, isNull, lt, ne, or, sql } from "drizzle-orm";
+import { createHash } from "node:crypto";
+
+import {
+  and,
+  eq,
+  gt,
+  isNull,
+  lt,
+  lte,
+  ne,
+  notInArray,
+  or,
+  sql,
+} from "drizzle-orm";
 
 import { getDatabase } from "@/db/client";
 import {
@@ -10,6 +23,7 @@ import {
   githubPushObservationCommits,
   githubPushObservations,
   githubRepositories,
+  githubRepositoryRefs,
   githubWebhookDeliveries,
 } from "@/db/schema";
 import { trackedGitHubAccountFrom } from "@/lib/github-commits-core";
@@ -47,6 +61,18 @@ export interface GitHubWebhookIntakeResult extends GitHubIntakeResult {
   duplicate: boolean;
   ignored: boolean;
   paused: boolean;
+}
+
+export interface GitHubRepositoryRefSnapshot {
+  headSha: string;
+  kind: "head" | "tag";
+  refName: string;
+}
+
+export interface GitHubRepositoryRefIntakeResult {
+  knownCommits: number;
+  pushes: number;
+  refs: number;
 }
 
 type DatabaseTransaction = Parameters<
@@ -103,41 +129,7 @@ const upsertRepository = async (
         ownerType: sql`coalesce(excluded.owner_type, ${githubRepositories.ownerType})`,
         visibility: sql`coalesce(excluded.visibility, ${githubRepositories.visibility})`,
       },
-      target: githubRepositories.id,
-    });
-};
-
-const persistIssueRepository = async (
-  transaction: DatabaseTransaction,
-  issue: GitHubIssue,
-  observedAt: Date
-) => {
-  const { repository } = issue;
-  await transaction
-    .insert(githubRepositories)
-    .values({
-      firstObservedAt: observedAt,
-      fullName: repository.fullName,
-      htmlUrl: repository.htmlUrl,
-      id: repository.id,
-      lastObservedAt: observedAt,
-      ownerAvatarUrl: repository.ownerAvatarUrl,
-      ownerId: repository.ownerId,
-      ownerLogin: repository.ownerLogin,
-      ownerType: repository.ownerType,
-      visibility: repository.visibility,
-    })
-    .onConflictDoUpdate({
-      set: {
-        fullName: repository.fullName,
-        htmlUrl: sql`coalesce(excluded.html_url, ${githubRepositories.htmlUrl})`,
-        lastObservedAt: observedAt,
-        ownerAvatarUrl: sql`coalesce(excluded.owner_avatar_url, ${githubRepositories.ownerAvatarUrl})`,
-        ownerId: sql`coalesce(excluded.owner_id, ${githubRepositories.ownerId})`,
-        ownerLogin: sql`coalesce(excluded.owner_login, ${githubRepositories.ownerLogin})`,
-        ownerType: sql`coalesce(excluded.owner_type, ${githubRepositories.ownerType})`,
-        visibility: sql`coalesce(excluded.visibility, ${githubRepositories.visibility})`,
-      },
+      setWhere: lte(githubRepositories.lastObservedAt, observedAt),
       target: githubRepositories.id,
     });
 };
@@ -147,7 +139,7 @@ const persistIssue = async (
   issue: GitHubIssue,
   observedAt: Date
 ) => {
-  await persistIssueRepository(transaction, issue, observedAt);
+  await upsertRepository(transaction, issue.repository, observedAt);
   const [insertedIssue] = await transaction
     .insert(githubIssues)
     .values({
@@ -188,7 +180,7 @@ interface PushObservationInput {
   observedAt: Date;
   providerCreatedAt: Date | null;
   push: GitHubPush;
-  source: "events" | "webhook";
+  source: "events" | "refs" | "webhook";
   sourceId: string;
 }
 
@@ -224,6 +216,7 @@ const insertPushObservations = async (
         fullName: sql`excluded.full_name`,
         lastObservedAt: sql`excluded.last_observed_at`,
       },
+      setWhere: lte(githubRepositories.lastObservedAt, observedAt),
       target: githubRepositories.id,
     });
 
@@ -284,6 +277,137 @@ const insertPushObservations = async (
     pushes: inserted.length,
   };
 };
+
+const ZERO_SHA = "0".repeat(40);
+
+const refObservationSourceId = (input: {
+  afterSha: string;
+  beforeSha: string;
+  refName: string;
+  repositoryId: string;
+}) =>
+  `ref:${createHash("sha256")
+    .update(
+      [input.repositoryId, input.refName, input.beforeSha, input.afterSha].join(
+        "\0"
+      )
+    )
+    .digest("hex")}`;
+
+export const persistGitHubRepositoryRefs = async (input: {
+  account: TrackedGitHubAccount;
+  observedAt: Date;
+  refs: readonly GitHubRepositoryRefSnapshot[];
+  repository: GitHubRepositoryFacts;
+}): Promise<GitHubRepositoryRefIntakeResult> =>
+  await getDatabase().transaction(async (transaction) => {
+    await upsertRepository(transaction, input.repository, input.observedAt);
+    const existing = await transaction
+      .select({
+        active: githubRepositoryRefs.active,
+        headSha: githubRepositoryRefs.headSha,
+        lastObservedAt: githubRepositoryRefs.lastObservedAt,
+        refName: githubRepositoryRefs.refName,
+      })
+      .from(githubRepositoryRefs)
+      .where(eq(githubRepositoryRefs.repositoryId, input.repository.id));
+    const existingByName = new Map(existing.map((ref) => [ref.refName, ref]));
+    const knownActiveHeads = new Set(
+      existing.filter((ref) => ref.active).map((ref) => ref.headSha)
+    );
+    const observedRanges = new Set<string>();
+    const observations: PushObservationInput[] = [];
+
+    for (const ref of input.refs) {
+      const previous = existingByName.get(ref.refName);
+      if (
+        previous !== undefined &&
+        (previous.lastObservedAt > input.observedAt ||
+          (previous.active && previous.headSha === ref.headSha))
+      ) {
+        knownActiveHeads.add(ref.headSha);
+        continue;
+      }
+      const beforeSha = previous?.active === true ? previous.headSha : ZERO_SHA;
+      const range = `${beforeSha}:${ref.headSha}`;
+      if (!knownActiveHeads.has(ref.headSha) && !observedRanges.has(range)) {
+        const push: GitHubPush = {
+          before: beforeSha,
+          commitShas: [],
+          head: ref.headSha,
+          pushedBy: input.account,
+          ref: ref.refName,
+          repository: input.repository,
+          size: null,
+        };
+        observations.push({
+          observedAt: input.observedAt,
+          providerCreatedAt: null,
+          push,
+          source: "refs",
+          sourceId: refObservationSourceId({
+            afterSha: ref.headSha,
+            beforeSha,
+            refName: ref.refName,
+            repositoryId: input.repository.id,
+          }),
+        });
+        observedRanges.add(range);
+      }
+      knownActiveHeads.add(ref.headSha);
+    }
+
+    const persisted = await insertPushObservations(transaction, observations);
+    if (input.refs.length > 0) {
+      await transaction
+        .insert(githubRepositoryRefs)
+        .values(
+          input.refs.map((ref) => ({
+            active: true,
+            firstObservedAt: input.observedAt,
+            headSha: ref.headSha,
+            kind: ref.kind,
+            lastObservedAt: input.observedAt,
+            refName: ref.refName,
+            repositoryId: input.repository.id,
+          }))
+        )
+        .onConflictDoUpdate({
+          set: {
+            active: true,
+            headSha: sql`excluded.head_sha`,
+            kind: sql`excluded.kind`,
+            lastObservedAt: input.observedAt,
+          },
+          setWhere: lte(githubRepositoryRefs.lastObservedAt, input.observedAt),
+          target: [
+            githubRepositoryRefs.repositoryId,
+            githubRepositoryRefs.refName,
+          ],
+        });
+    }
+
+    const currentRefNames = input.refs.map((ref) => ref.refName);
+    await transaction
+      .update(githubRepositoryRefs)
+      .set({ active: false, lastObservedAt: input.observedAt })
+      .where(
+        and(
+          eq(githubRepositoryRefs.repositoryId, input.repository.id),
+          eq(githubRepositoryRefs.active, true),
+          lte(githubRepositoryRefs.lastObservedAt, input.observedAt),
+          ...(currentRefNames.length === 0
+            ? []
+            : [notInArray(githubRepositoryRefs.refName, currentRefNames)])
+        )
+      );
+
+    return {
+      knownCommits: persisted.knownCommits,
+      pushes: persisted.pushes,
+      refs: input.refs.length,
+    };
+  });
 
 const insertPushObservation = async (
   transaction: DatabaseTransaction,
@@ -550,7 +674,7 @@ const signalKnownPullRequestReconciliation = async (
     .where(
       and(
         eq(githubPullRequests.account, account),
-        eq(githubPullRequests.repositoryId, signal.repositoryId),
+        eq(githubPullRequests.repositoryId, signal.repository.id),
         eq(githubPullRequests.number, signal.number)
       )
     )

--- a/src/lib/github-commits.ts
+++ b/src/lib/github-commits.ts
@@ -15,6 +15,10 @@ import {
   persistAccountIntake,
   readGitHubAccountCheckpoint,
 } from "@/lib/github-commits-store";
+import {
+  hydrateSparseGitHubPullRequestEvents,
+  reconcileAccessibleGitHubRepositoryRefs,
+} from "@/lib/github-reconciliation";
 
 const ACCOUNT_TOKEN_VARIABLES = {
   f0rr0: "GITHUB_F0RR0_TOKEN",
@@ -34,6 +38,8 @@ export interface GitHubAccountSyncResult {
   paused: boolean;
   pullRequests: number;
   pushes: number;
+  refs: number;
+  repositories: number;
 }
 
 export interface GitHubSyncResult {
@@ -50,6 +56,8 @@ export interface GitHubSyncResult {
   paused: number;
   pullRequests: number;
   pushes: number;
+  refs: number;
+  repositories: number;
 }
 
 export class GitHubSyncConfigurationError extends Error {
@@ -170,6 +178,8 @@ export const syncGitHubAccount = async (
         paused: true,
         pullRequests: 0,
         pushes: 0,
+        refs: 0,
+        repositories: 0,
       };
     }
     if (token === null) {
@@ -181,15 +191,23 @@ export const syncGitHubAccount = async (
       token,
       checkpoint?.latestEventId ?? null
     );
+    const events = await hydrateSparseGitHubPullRequestEvents(
+      collected.events,
+      token
+    );
 
     try {
       const persisted = await persistAccountIntake({
         account,
-        events: collected.events,
+        events,
         expectedCheckpoint: checkpoint,
         gap: collected.gap,
         latestEventId: collected.latestEventId,
       });
+      const refs = await reconcileAccessibleGitHubRepositoryRefs(
+        account,
+        token
+      );
       return {
         account,
         checkpointChanged:
@@ -197,10 +215,12 @@ export const syncGitHubAccount = async (
         events: collected.events.length,
         gapRecorded: collected.gap !== null,
         issues: persisted.issues,
-        knownCommits: persisted.knownCommits,
+        knownCommits: persisted.knownCommits + refs.knownCommits,
         paused: false,
         pullRequests: persisted.pullRequests,
-        pushes: persisted.pushes,
+        pushes: persisted.pushes + refs.pushes,
+        refs: refs.refs,
+        repositories: refs.repositories,
       };
     } catch (error) {
       if (
@@ -261,5 +281,10 @@ export const syncGitHubAccounts = async (): Promise<GitHubSyncResult> => {
       0
     ),
     pushes: results.reduce((total, result) => total + result.pushes, 0),
+    refs: results.reduce((total, result) => total + result.refs, 0),
+    repositories: results.reduce(
+      (total, result) => total + result.repositories,
+      0
+    ),
   };
 };

--- a/src/lib/github-reconciliation.ts
+++ b/src/lib/github-reconciliation.ts
@@ -1,0 +1,341 @@
+import {
+  fetchGitHub,
+  GitHubResponseError,
+  githubApiUrl,
+  nextGitHubPage,
+} from "@/lib/github-api";
+import {
+  commitShaFrom,
+  pullRequestFromGitHub,
+  repositoryFactsFrom,
+  repositoryFrom,
+} from "@/lib/github-commits-core";
+import type {
+  GitHubEvent,
+  GitHubRepositoryFacts,
+  TrackedGitHubAccount,
+} from "@/lib/github-commits-core";
+import { persistGitHubRepositoryRefs } from "@/lib/github-commits-store";
+import type { GitHubRepositoryRefSnapshot } from "@/lib/github-commits-store";
+
+const GITHUB_PAGE_SIZE = 100;
+const GITHUB_REQUEST_CONCURRENCY = 4;
+
+type JsonObject = Record<string, unknown>;
+
+const isObject = (value: unknown): value is JsonObject =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const compareStrings = (left: string, right: string) =>
+  left < right ? -1 : left > right ? 1 : 0;
+
+const mapWithConcurrency = async <Input, Output>(
+  values: readonly Input[],
+  mapper: (value: Input) => Promise<Output>
+) => {
+  const outputs: Output[] = [];
+  for (
+    let offset = 0;
+    offset < values.length;
+    offset += GITHUB_REQUEST_CONCURRENCY
+  ) {
+    outputs.push(
+      ...(await Promise.all(
+        values.slice(offset, offset + GITHUB_REQUEST_CONCURRENCY).map(mapper)
+      ))
+    );
+  }
+  return outputs;
+};
+
+const repositoryApiPath = (repository: string, suffix: string) => {
+  const [owner, name, ...rest] = repository.split("/");
+  if (owner === undefined || name === undefined || rest.length > 0) {
+    throw new TypeError("GitHub returned an invalid repository name.");
+  }
+  return `/repos/${encodeURIComponent(owner)}/${encodeURIComponent(name)}${suffix}`;
+};
+
+const fetchJson = async (url: URL, token: string) => {
+  const response = await fetchGitHub(url, { token });
+  return { payload: (await response.json()) as unknown, response };
+};
+
+const fetchPaginatedArray = async (initialUrl: URL, token: string) => {
+  const values: unknown[] = [];
+  const visited = new Set<string>();
+  let url: URL | null = initialUrl;
+  while (url !== null) {
+    if (visited.has(url.href)) {
+      throw new TypeError("GitHub returned cyclic pagination links.");
+    }
+    visited.add(url.href);
+    const result = await fetchJson(url, token);
+    if (!Array.isArray(result.payload)) {
+      throw new TypeError("GitHub returned an invalid paginated response.");
+    }
+    values.push(...result.payload);
+    url = nextGitHubPage(result.response);
+  }
+  return values;
+};
+
+export const collectAccessibleGitHubRepositories = async (token: string) => {
+  const url = githubApiUrl("/user/repos");
+  url.searchParams.set("affiliation", "owner,collaborator,organization_member");
+  url.searchParams.set("direction", "asc");
+  url.searchParams.set("per_page", String(GITHUB_PAGE_SIZE));
+  url.searchParams.set("sort", "full_name");
+  url.searchParams.set("visibility", "all");
+  const values = await fetchPaginatedArray(url, token);
+  const repositories = new Map<string, GitHubRepositoryFacts>();
+  for (const value of values) {
+    const repository = repositoryFactsFrom(value);
+    if (repository === null) {
+      throw new TypeError("GitHub returned an invalid repository response.");
+    }
+    const existing = repositories.get(repository.id);
+    if (existing !== undefined && existing.fullName !== repository.fullName) {
+      throw new TypeError("GitHub returned conflicting repository identities.");
+    }
+    repositories.set(repository.id, repository);
+  }
+  return [...repositories.values()].toSorted((left, right) =>
+    compareStrings(left.fullName, right.fullName)
+  );
+};
+
+interface GitHubRefObject {
+  sha: string;
+  type: "blob" | "commit" | "tag" | "tree";
+}
+
+const containsControlCharacter = (value: string) => {
+  for (const character of value) {
+    const code = character.codePointAt(0) ?? 0;
+    if (code <= 31 || code === 127) {
+      return true;
+    }
+  }
+  return false;
+};
+
+const refObjectFrom = (value: unknown): GitHubRefObject | null => {
+  if (!isObject(value)) {
+    return null;
+  }
+  const { sha: rawSha, type } = value;
+  const sha = commitShaFrom(rawSha);
+  return sha !== null &&
+    (type === "blob" || type === "commit" || type === "tag" || type === "tree")
+    ? { sha, type }
+    : null;
+};
+
+const refFrom = (value: unknown, kind: GitHubRepositoryRefSnapshot["kind"]) => {
+  if (!isObject(value) || typeof value.ref !== "string") {
+    throw new TypeError("GitHub returned an invalid Git reference.");
+  }
+  const prefix = kind === "head" ? "refs/heads/" : "refs/tags/";
+  const refName = value.ref;
+  const object = refObjectFrom(value.object);
+  if (
+    object === null ||
+    !refName.startsWith(prefix) ||
+    refName.length <= prefix.length ||
+    refName.length > 1024 ||
+    containsControlCharacter(refName) ||
+    (kind === "head" && object.type !== "commit")
+  ) {
+    throw new TypeError("GitHub returned an invalid Git reference.");
+  }
+  return { kind, object, refName };
+};
+
+const peelTagToCommit = async (
+  repository: GitHubRepositoryFacts,
+  initial: GitHubRefObject,
+  token: string
+) => {
+  const visited = new Set<string>();
+  let object = initial;
+  while (object.type === "tag") {
+    if (visited.has(object.sha)) {
+      throw new TypeError("GitHub returned a cyclic annotated tag.");
+    }
+    visited.add(object.sha);
+    const { payload } = await fetchJson(
+      githubApiUrl(
+        repositoryApiPath(
+          repository.fullName,
+          `/git/tags/${encodeURIComponent(object.sha)}`
+        )
+      ),
+      token
+    );
+    if (!isObject(payload)) {
+      throw new TypeError("GitHub returned an invalid annotated tag.");
+    }
+    const target = refObjectFrom(payload.object);
+    if (target === null) {
+      throw new TypeError("GitHub returned an invalid annotated tag target.");
+    }
+    object = target;
+  }
+  return object.type === "commit" ? object.sha : null;
+};
+
+const collectMatchingRefs = async (
+  repository: GitHubRepositoryFacts,
+  kind: GitHubRepositoryRefSnapshot["kind"],
+  token: string
+) => {
+  const namespace = kind === "head" ? "heads" : "tags";
+  const url = githubApiUrl(
+    repositoryApiPath(repository.fullName, `/git/matching-refs/${namespace}/`)
+  );
+  url.searchParams.set("per_page", String(GITHUB_PAGE_SIZE));
+  let values: readonly unknown[];
+  try {
+    values = await fetchPaginatedArray(url, token);
+  } catch (error) {
+    if (error instanceof GitHubResponseError && error.status === 409) {
+      return [];
+    }
+    throw error;
+  }
+
+  const refs: GitHubRepositoryRefSnapshot[] = [];
+  for (const value of values) {
+    const ref = refFrom(value, kind);
+    const headSha = await peelTagToCommit(repository, ref.object, token);
+    if (headSha !== null) {
+      refs.push({ headSha, kind, refName: ref.refName });
+    }
+  }
+  return refs;
+};
+
+export const collectGitHubRepositoryRefs = async (
+  repository: GitHubRepositoryFacts,
+  token: string
+): Promise<readonly GitHubRepositoryRefSnapshot[] | null> => {
+  try {
+    const heads = await collectMatchingRefs(repository, "head", token);
+    const tags = await collectMatchingRefs(repository, "tag", token);
+    const refs = new Map<string, GitHubRepositoryRefSnapshot>();
+    for (const ref of [...heads, ...tags]) {
+      const existing = refs.get(ref.refName);
+      if (
+        existing !== undefined &&
+        (existing.headSha !== ref.headSha || existing.kind !== ref.kind)
+      ) {
+        throw new TypeError("GitHub returned conflicting Git references.");
+      }
+      refs.set(ref.refName, ref);
+    }
+    return [...refs.values()].toSorted((left, right) =>
+      compareStrings(left.refName, right.refName)
+    );
+  } catch (error) {
+    if (error instanceof GitHubResponseError && error.status === 404) {
+      return null;
+    }
+    throw error;
+  }
+};
+
+export const hydrateSparseGitHubPullRequestEvents = async (
+  events: readonly GitHubEvent[],
+  token: string
+): Promise<readonly GitHubEvent[]> =>
+  await mapWithConcurrency(events, async (event) => {
+    const signal = event.pullRequestSignal;
+    if (signal === undefined) {
+      return event;
+    }
+    let payload: unknown;
+    try {
+      ({ payload } = await fetchJson(
+        githubApiUrl(
+          repositoryApiPath(
+            signal.repository.fullName,
+            `/pulls/${signal.number}`
+          )
+        ),
+        token
+      ));
+    } catch (error) {
+      if (error instanceof GitHubResponseError && error.status === 404) {
+        return event;
+      }
+      throw error;
+    }
+    const base =
+      isObject(payload) && isObject(payload.base) ? payload.base : null;
+    const currentRepository = base === null ? null : repositoryFrom(base.repo);
+    const pullRequest =
+      currentRepository?.id === signal.repository.id
+        ? pullRequestFromGitHub(payload, currentRepository, signal.action)
+        : null;
+    if (
+      pullRequest === null ||
+      pullRequest.number !== signal.number ||
+      pullRequest.repository.id !== signal.repository.id
+    ) {
+      throw new TypeError("GitHub returned an invalid pull request response.");
+    }
+    return {
+      id: event.id,
+      issue: event.issue,
+      occurredAt: event.occurredAt,
+      pullRequest,
+      push: event.push,
+    };
+  });
+
+export interface GitHubRefReconciliationResult {
+  knownCommits: number;
+  pushes: number;
+  refs: number;
+  repositories: number;
+}
+
+export const reconcileAccessibleGitHubRepositoryRefs = async (
+  account: TrackedGitHubAccount,
+  token: string
+): Promise<GitHubRefReconciliationResult> => {
+  const repositories = await collectAccessibleGitHubRepositories(token);
+  const result: GitHubRefReconciliationResult = {
+    knownCommits: 0,
+    pushes: 0,
+    refs: 0,
+    repositories: 0,
+  };
+
+  const reconciled = await mapWithConcurrency(
+    repositories,
+    async (repository) => {
+      const observedAt = new Date();
+      const refs = await collectGitHubRepositoryRefs(repository, token);
+      return refs === null
+        ? null
+        : await persistGitHubRepositoryRefs({
+            account,
+            observedAt,
+            refs,
+            repository,
+          });
+    }
+  );
+  for (const repository of reconciled) {
+    if (repository === null) {
+      continue;
+    }
+    result.knownCommits += repository.knownCommits;
+    result.pushes += repository.pushes;
+    result.refs += repository.refs;
+    result.repositories += 1;
+  }
+  return result;
+};

--- a/tests/github-activity-feed-postgres.test.mjs
+++ b/tests/github-activity-feed-postgres.test.mjs
@@ -80,6 +80,7 @@ describe.skipIf(!dockerAvailable)(
     let originalCronSecret;
     let originalDatabaseUrl;
     let persistAccountIntake;
+    let persistGitHubRepositoryRefs;
     let readPublicGitHubActivityPage;
 
     beforeAll(async () => {
@@ -158,7 +159,7 @@ describe.skipIf(!dockerAvailable)(
         ensureGitHubSummaryAttempt,
         ensureMissingGitHubSummaryAttempts,
       } = await import("../src/lib/github-activity-worker-store.ts"));
-      ({ persistAccountIntake } =
+      ({ persistAccountIntake, persistGitHubRepositoryRefs } =
         await import("../src/lib/github-commits-store.ts"));
     });
 
@@ -181,6 +182,83 @@ describe.skipIf(!dockerAvailable)(
           stdout: "ignore",
         });
       }
+    });
+
+    test("checkpoints repository refs and emits only new reachable ranges", async () => {
+      const repository = {
+        fullName: "example-org/ref-checkpoints",
+        htmlUrl: "https://github.com/example-org/ref-checkpoints",
+        id: "404",
+        ownerAvatarUrl: null,
+        ownerId: "202",
+        ownerLogin: "example-org",
+        ownerType: "Organization",
+        visibility: "private",
+      };
+      const firstSha = "6".repeat(40);
+      const secondSha = "7".repeat(40);
+      const first = await persistGitHubRepositoryRefs({
+        account: "f0rr0",
+        observedAt: new Date("2026-08-29T08:00:00.000Z"),
+        refs: [
+          { headSha: firstSha, kind: "head", refName: "refs/heads/main" },
+          { headSha: firstSha, kind: "tag", refName: "refs/tags/v1" },
+        ],
+        repository,
+      });
+      expect(first).toEqual({ knownCommits: 0, pushes: 1, refs: 2 });
+
+      const unchanged = await persistGitHubRepositoryRefs({
+        account: "f0rr0",
+        observedAt: new Date("2026-08-29T09:00:00.000Z"),
+        refs: [
+          { headSha: firstSha, kind: "head", refName: "refs/heads/main" },
+          { headSha: firstSha, kind: "tag", refName: "refs/tags/v1" },
+        ],
+        repository,
+      });
+      expect(unchanged.pushes).toBe(0);
+
+      const moved = await persistGitHubRepositoryRefs({
+        account: "f0rr0",
+        observedAt: new Date("2026-08-29T10:00:00.000Z"),
+        refs: [
+          { headSha: secondSha, kind: "head", refName: "refs/heads/main" },
+        ],
+        repository,
+      });
+      expect(moved.pushes).toBe(1);
+
+      const refs = await admin`
+        select active, head_sha, ref_name
+        from github_repository_refs
+        where repository_id = '404'
+        order by ref_name
+      `;
+      expect(refs).toEqual([
+        { active: true, head_sha: secondSha, ref_name: "refs/heads/main" },
+        { active: false, head_sha: firstSha, ref_name: "refs/tags/v1" },
+      ]);
+      const observations = await admin`
+        select after_sha, before_sha, ref_name, source
+        from github_push_observations
+        where repository_id = '404'
+        order by observed_at
+      `;
+      expect(observations).toEqual([
+        {
+          after_sha: firstSha,
+          before_sha: "0".repeat(40),
+          ref_name: "refs/heads/main",
+          source: "refs",
+        },
+        {
+          after_sha: secondSha,
+          before_sha: firstSha,
+          ref_name: "refs/heads/main",
+          source: "refs",
+        },
+      ]);
     });
 
     test("pages complete UTC days and projects only current complete PR membership", async () => {
@@ -882,7 +960,10 @@ describe.skipIf(!dockerAvailable)(
       const sparseTerminalSignal = {
         action: "merged",
         number: 80,
-        repositoryId: "202",
+        repository: {
+          fullName: "example-org/upstream",
+          id: "202",
+        },
       };
       const crossAccount = await persistAccountIntake({
         account: "yuppiestechdev",

--- a/tests/github-activity-feed.test.mjs
+++ b/tests/github-activity-feed.test.mjs
@@ -1,9 +1,5 @@
 import { describe, expect, test } from "bun:test";
 
-import { createElement } from "react";
-import { renderToStaticMarkup } from "react-dom/server";
-
-import { GitHubTimeline } from "../src/components/github-timeline.tsx";
 import { githubCommits, githubSummaryAttempts } from "../src/db/schema.ts";
 import {
   decodeGitHubActivityCursor,
@@ -28,73 +24,6 @@ describe("public GitHub activity projection", () => {
     expect(githubCommits.providerFileCapReached.hasDefault).toBe(true);
   });
 
-  test("renders provider-capped evidence as a lower bound", () => {
-    const html = renderToStaticMarkup(
-      createElement(GitHubTimeline, {
-        initialPage: {
-          days: [
-            {
-              day: "2026-08-28",
-              items: [
-                {
-                  commit: {
-                    additions: 1,
-                    changedFiles: 3000,
-                    committedAt: "2026-08-28T08:30:00.000Z",
-                    deletions: 2,
-                    headline: "Improve the large change",
-                    id: "provider-capped-commit",
-                    languages: [
-                      {
-                        changedLines: 3,
-                        iconUrl: null,
-                        id: "typescript",
-                        label: "TypeScript",
-                      },
-                    ],
-                    providerFileCapReached: true,
-                    summary: "Improves a large change.",
-                  },
-                  id: "provider-capped-activity",
-                  kind: "commit",
-                  occurredAt: "2026-08-28T08:30:00.000Z",
-                  repository: {
-                    avatarUrl: null,
-                    label: null,
-                    url: null,
-                  },
-                },
-              ],
-              totals: {
-                additions: 1,
-                deletions: 2,
-                issuesOpened: 0,
-                pullRequestsMerged: 0,
-                repositories: 1,
-              },
-            },
-          ],
-          nextCursor: null,
-          snapshotAt: "2026-08-28T09:00:00.000Z",
-        },
-      })
-    );
-
-    expect(html).toContain("3,000+ files");
-    expect(html).toContain("Improve the large change");
-    expect(html).toContain("Improves a large change.");
-    expect(html.indexOf("Improve the large change")).toBeLessThan(
-      html.indexOf("Improves a large change.")
-    );
-    expect(html).toContain("<details");
-    expect(html).toContain(
-      "3,000 or more changed files; GitHub caps returned file details at 3,000 files"
-    );
-    expect(html).toContain(
-      'aria-label="Languages found in the first 3,000 files returned by GitHub; the full commit may include more"'
-    );
-  });
-
   test("round trips an opaque cursor without repository identity", () => {
     const cursor = {
       beforeDay: "2026-08-28",
@@ -117,73 +46,7 @@ describe("public GitHub activity projection", () => {
     ).toThrow("cursor is invalid");
   });
 
-  test("renders complete day totals and PR/issue milestones without zero counts", () => {
-    const html = renderToStaticMarkup(
-      createElement(GitHubTimeline, {
-        initialPage: {
-          days: [
-            {
-              day: "2026-08-28",
-              items: [
-                {
-                  commits: [
-                    {
-                      additions: 12,
-                      changedFiles: 2,
-                      committedAt: "2026-08-28T08:00:00.000Z",
-                      deletions: 3,
-                      headline: "Add the daily projection",
-                      id: "commit-public-id",
-                      languages: [],
-                      providerFileCapReached: false,
-                      summary: "Builds complete UTC-day activity pages.",
-                    },
-                  ],
-                  id: "pr-slice-public-id",
-                  kind: "pull-request-commits",
-                  occurredAt: "2026-08-28T08:00:00.000Z",
-                  repository: {
-                    avatarUrl: null,
-                    label: "portfolio",
-                    url: "https://github.com/f0rr0/portfolio/pull/12",
-                  },
-                  title: "Build daily GitHub activity",
-                },
-                {
-                  id: "pr-merged-public-id",
-                  kind: "pull-request-merged",
-                  occurredAt: "2026-08-28T09:00:00.000Z",
-                  repository: {
-                    avatarUrl: null,
-                    label: "portfolio",
-                    url: "https://github.com/f0rr0/portfolio/pull/12",
-                  },
-                  title: "Build daily GitHub activity",
-                },
-              ],
-              totals: {
-                additions: 12,
-                deletions: 3,
-                issuesOpened: 0,
-                pullRequestsMerged: 1,
-                repositories: 1,
-              },
-            },
-          ],
-          nextCursor: null,
-          snapshotAt: "2026-08-28T10:00:00.000Z",
-        },
-      })
-    );
-
-    expect(html).toContain("Pull request work");
-    expect(html).toContain("Pull request merged");
-    expect(html).toContain("1 pull request merged");
-    expect(html).not.toContain("issues opened");
-    expect(html).toContain('aria-label="Summary for 2026-08-28"');
-  });
-
-  test("shows all public repositories and only directly owned private names", () => {
+  test("shows public owners while concealing private names and owners", () => {
     expect(
       publicRepositoryDisplay({
         ownerLogin: "another-org",
@@ -192,7 +55,7 @@ describe("public GitHub activity projection", () => {
         sha: "a".repeat(40),
       })
     ).toEqual({
-      repositoryLabel: "public-repo",
+      repositoryLabel: "another-org/public-repo",
       url: `https://github.com/another-org/public-repo/commit/${"a".repeat(40)}`,
     });
     expect(
@@ -202,7 +65,10 @@ describe("public GitHub activity projection", () => {
         repository: "another-org/private-repo",
         sha: "a".repeat(40),
       })
-    ).toEqual({ repositoryLabel: null, url: null });
+    ).toEqual({
+      repositoryLabel: "Private",
+      url: null,
+    });
     expect(
       publicRepositoryDisplay({
         ownerLogin: "f0rr0",
@@ -210,7 +76,7 @@ describe("public GitHub activity projection", () => {
         repository: "f0rr0/private-repo",
         sha: "a".repeat(40),
       })
-    ).toEqual({ repositoryLabel: "private-repo", url: null });
+    ).toEqual({ repositoryLabel: "Private", url: null });
   });
 
   test("maps deterministic language IDs to official logo URLs", () => {

--- a/tests/github-activity-processor.test.mjs
+++ b/tests/github-activity-processor.test.mjs
@@ -203,6 +203,7 @@ describe("GitHub activity commit acquisition", () => {
         `/repos/example-org/example-repo/compare/${beforeSha}...${afterSha}`
       );
       return Response.json({
+        ahead_by: 2,
         commits: [
           pushCommitValue(trackedSha, "f0rr0", 100),
           pushCommitValue(foreignSha, "octocat", 200),
@@ -234,6 +235,7 @@ describe("GitHub activity commit acquisition", () => {
     process.env.GITHUB_F0RR0_TOKEN = "test-token";
     globalThis.fetch = async () =>
       Response.json({
+        ahead_by: 3,
         commits: [
           pushCommitValue(firstSha, "f0rr0", 100),
           pushCommitValue(surplusSha, "octocat", 200),
@@ -263,6 +265,7 @@ describe("GitHub activity commit acquisition", () => {
     process.env.GITHUB_F0RR0_TOKEN = "test-token";
     globalThis.fetch = async () =>
       Response.json({
+        ahead_by: 2,
         commits: [
           pushCommitValue(firstSha, "f0rr0", 100),
           pushCommitValue(afterSha, "f0rr0", 100),
@@ -291,12 +294,13 @@ describe("GitHub activity commit acquisition", () => {
     process.env.GITHUB_F0RR0_TOKEN = "test-token";
     globalThis.fetch = async () =>
       Response.json({
+        ahead_by: 2,
         commits: [
           { author: { login: "octocat" }, commit: null, sha: foreignSha },
           {
             author: { login: "f0rr0" },
             commit: {
-              author: { date: "not-a-date" },
+              author: { date: "2026-08-28T12:01:00Z" },
               message: "",
             },
             sha: afterSha,
@@ -319,11 +323,123 @@ describe("GitHub activity commit acquisition", () => {
     expect(source.commitShas).toEqual([foreignSha, afterSha]);
     expect(source.commits).toEqual([
       expect.objectContaining({
-        committedAt: observedAt.toISOString(),
+        committedAt: "2026-08-28T12:01:00.000Z",
         message: "",
         sha: afterSha,
       }),
     ]);
+  });
+
+  test("rejects a tracked commit without a provider timestamp", async () => {
+    const beforeSha = "1".repeat(40);
+    const afterSha = "2".repeat(40);
+    process.env.GITHUB_F0RR0_TOKEN = "test-token";
+    globalThis.fetch = async () =>
+      Response.json({
+        ahead_by: 1,
+        commits: [
+          {
+            author: { login: "f0rr0" },
+            commit: { author: { date: "not-a-date" }, message: "change" },
+            sha: afterSha,
+          },
+        ],
+      });
+
+    await expect(
+      fetchGitHubPushObservationSource({
+        account: "f0rr0",
+        afterSha,
+        beforeSha,
+        expectedCommitCount: 1,
+        knownShas: [afterSha],
+        observedAt: new Date("2026-08-28T12:34:00.000Z"),
+        refName: "refs/heads/main",
+        repository: "example-org/example-repo",
+        repositoryId: "123",
+      })
+    ).rejects.toMatchObject({ code: "source_invalid" });
+  });
+
+  test("accepts a ref rewind with no newly reachable commits", async () => {
+    const beforeSha = "1".repeat(40);
+    const afterSha = "2".repeat(40);
+    process.env.GITHUB_F0RR0_TOKEN = "test-token";
+    globalThis.fetch = async () => Response.json({ ahead_by: 0, commits: [] });
+
+    const source = await fetchGitHubPushObservationSource({
+      account: "f0rr0",
+      afterSha,
+      beforeSha,
+      expectedCommitCount: null,
+      knownShas: [],
+      observedAt: new Date("2026-08-28T12:34:00.000Z"),
+      refName: "refs/heads/main",
+      repository: "example-org/example-repo",
+      repositoryId: "123",
+    });
+    expect(source).toEqual({ commitShas: [], commits: [] });
+  });
+
+  test("falls back to full reachable history when a force-push base is gone", async () => {
+    const beforeSha = "1".repeat(40);
+    const olderSha = "2".repeat(40);
+    const afterSha = "3".repeat(40);
+    const paths = [];
+    process.env.GITHUB_F0RR0_TOKEN = "test-token";
+    globalThis.fetch = async (input) => {
+      const url =
+        input instanceof Request ? new URL(input.url) : new URL(input);
+      paths.push(url.pathname);
+      if (url.pathname.includes("/compare/")) {
+        return new Response(null, { status: 404 });
+      }
+      return Response.json({
+        data: {
+          repository: {
+            object: {
+              history: {
+                nodes: [
+                  {
+                    author: { user: { login: "f0rr0" } },
+                    authoredDate: "2026-08-28T12:00:00Z",
+                    message: "head",
+                    oid: afterSha,
+                    url: `https://github.com/example-org/example-repo/commit/${afterSha}`,
+                  },
+                  {
+                    author: { user: { login: "octocat" } },
+                    authoredDate: "2026-08-28T11:00:00Z",
+                    message: "older",
+                    oid: olderSha,
+                    url: `https://github.com/example-org/example-repo/commit/${olderSha}`,
+                  },
+                ],
+                pageInfo: { endCursor: null, hasNextPage: false },
+              },
+            },
+          },
+        },
+      });
+    };
+
+    const source = await fetchGitHubPushObservationSource({
+      account: "f0rr0",
+      afterSha,
+      beforeSha,
+      expectedCommitCount: null,
+      knownShas: [],
+      observedAt: new Date("2026-08-28T12:34:00.000Z"),
+      refName: "refs/heads/main",
+      repository: "example-org/example-repo",
+      repositoryId: "123",
+    });
+    expect(paths).toEqual([
+      `/repos/example-org/example-repo/compare/${beforeSha}...${afterSha}`,
+      "/graphql",
+    ]);
+    expect(source.commitShas).toEqual([olderSha, afterSha]);
+    expect(source.commits.map(({ sha }) => sha)).toEqual([afterSha]);
   });
 
   test("bounds a new branch by the observed count without slicing history", async () => {
@@ -379,6 +495,78 @@ describe("GitHub activity commit acquisition", () => {
     });
     expect(source.commitShas).toEqual([olderSha, afterSha]);
     expect(source.commits.map(({ sha }) => sha)).toEqual([afterSha]);
+  });
+
+  test("walks complete new-ref history when the event has no commit count", async () => {
+    const olderSha = "1".repeat(40);
+    const middleSha = "2".repeat(40);
+    const afterSha = "3".repeat(40);
+    const cursors = [];
+    process.env.GITHUB_F0RR0_TOKEN = "test-token";
+    globalThis.fetch = async (_input, init) => {
+      const request = JSON.parse(init?.body);
+      cursors.push(request.variables.cursor);
+      expect(request.variables.pageSize).toBe(100);
+      const secondPage = request.variables.cursor === "page-2";
+      return Response.json({
+        data: {
+          repository: {
+            object: {
+              history: secondPage
+                ? {
+                    nodes: [
+                      {
+                        author: { user: { login: "octocat" } },
+                        authoredDate: "2026-08-28T10:00:00Z",
+                        message: "older",
+                        oid: olderSha,
+                        url: `https://github.com/example-org/example-repo/commit/${olderSha}`,
+                      },
+                    ],
+                    pageInfo: { endCursor: null, hasNextPage: false },
+                  }
+                : {
+                    nodes: [
+                      {
+                        author: { user: { login: "f0rr0" } },
+                        authoredDate: "2026-08-28T12:00:00Z",
+                        message: "head",
+                        oid: afterSha,
+                        url: `https://github.com/example-org/example-repo/commit/${afterSha}`,
+                      },
+                      {
+                        author: { user: { login: "f0rr0" } },
+                        authoredDate: "2026-08-28T11:00:00Z",
+                        message: "middle",
+                        oid: middleSha,
+                        url: `https://github.com/example-org/example-repo/commit/${middleSha}`,
+                      },
+                    ],
+                    pageInfo: {
+                      endCursor: "page-2",
+                      hasNextPage: true,
+                    },
+                  },
+            },
+          },
+        },
+      });
+    };
+
+    const source = await fetchGitHubPushObservationSource({
+      account: "f0rr0",
+      afterSha,
+      beforeSha: "0".repeat(40),
+      expectedCommitCount: null,
+      knownShas: [],
+      observedAt: new Date("2026-08-28T12:00:00.000Z"),
+      refName: "refs/heads/new",
+      repository: "example-org/example-repo",
+      repositoryId: "123",
+    });
+    expect(cursors).toEqual([null, "page-2"]);
+    expect(source.commitShas).toEqual([olderSha, middleSha, afterSha]);
+    expect(source.commits.map(({ sha }) => sha)).toEqual([middleSha, afterSha]);
   });
 });
 

--- a/tests/github-activity-schema.test.mjs
+++ b/tests/github-activity-schema.test.mjs
@@ -14,6 +14,7 @@ import {
   githubPushObservationCommits,
   githubPushObservations,
   githubRepositories,
+  githubRepositoryRefs,
   githubSummaryAttempts,
   githubWebhookDeliveries,
 } from "../src/db/schema.ts";
@@ -66,6 +67,11 @@ describe("GitHub activity persistence schema", () => {
       ])
     );
     expect(githubPushObservations.state.default).toBe("pending");
+    expect(getTableName(githubRepositoryRefs)).toBe("github_repository_refs");
+    expect(githubRepositoryRefs.active.default).toBe(true);
+    expect(indexNames(githubRepositoryRefs)).toContain(
+      "github_repository_refs_active_idx"
+    );
 
     const observationCommitForeignKeys = config(
       githubPushObservationCommits
@@ -165,6 +171,7 @@ describe("GitHub activity persistence schema", () => {
       githubCommits,
       githubAccountCheckpoints,
       githubRepositories,
+      githubRepositoryRefs,
       githubWebhookDeliveries,
       githubPushObservations,
       githubPushObservationCommits,

--- a/tests/github-commits.test.mjs
+++ b/tests/github-commits.test.mjs
@@ -730,7 +730,10 @@ describe("pull request observation normalization", () => {
       pullRequestSignal: {
         action: "merged",
         number: 42,
-        repositoryId: "123",
+        repository: {
+          fullName: "another-org/private-repo",
+          id: "123",
+        },
       },
       push: null,
     });
@@ -914,7 +917,10 @@ describe("bounded event collection", () => {
     expect(collected.events[0]?.pullRequestSignal).toEqual({
       action: "merged",
       number: 42,
-      repositoryId: "123",
+      repository: {
+        fullName: "another-org/private-repo",
+        id: "123",
+      },
     });
   });
 

--- a/tests/github-reconciliation.test.mjs
+++ b/tests/github-reconciliation.test.mjs
@@ -1,0 +1,174 @@
+import { afterEach, describe, expect, test } from "bun:test";
+
+import {
+  collectAccessibleGitHubRepositories,
+  collectGitHubRepositoryRefs,
+  hydrateSparseGitHubPullRequestEvents,
+} from "../src/lib/github-reconciliation.ts";
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+const repository = {
+  full_name: "example-org/example-repo",
+  html_url: "https://github.com/example-org/example-repo",
+  id: 123,
+  owner: {
+    avatar_url: "https://avatars.githubusercontent.com/u/456?v=4",
+    id: 456,
+    login: "example-org",
+    type: "Organization",
+  },
+  private: true,
+  visibility: "private",
+};
+
+const repositoryFacts = {
+  fullName: "example-org/example-repo",
+  htmlUrl: "https://github.com/example-org/example-repo",
+  id: "123",
+  ownerAvatarUrl: "https://avatars.githubusercontent.com/u/456?v=4",
+  ownerId: "456",
+  ownerLogin: "example-org",
+  ownerType: "Organization",
+  visibility: "private",
+};
+
+describe("GitHub repository reconciliation", () => {
+  test("enumerates every repository affiliation available to the token", async () => {
+    globalThis.fetch = async (input) => {
+      const url =
+        input instanceof Request ? new URL(input.url) : new URL(input);
+      expect(url.pathname).toBe("/user/repos");
+      expect(url.searchParams.get("affiliation")).toBe(
+        "owner,collaborator,organization_member"
+      );
+      expect(url.searchParams.get("visibility")).toBe("all");
+      expect(url.searchParams.get("per_page")).toBe("100");
+      return Response.json([repository]);
+    };
+
+    expect(await collectAccessibleGitHubRepositories("token")).toEqual([
+      repositoryFacts,
+    ]);
+  });
+
+  test("enumerates heads and peels annotated tags to commit SHAs", async () => {
+    const headSha = "a".repeat(40);
+    const tagSha = "b".repeat(40);
+    const taggedCommitSha = "c".repeat(40);
+    const paths = [];
+    globalThis.fetch = async (input) => {
+      const url =
+        input instanceof Request ? new URL(input.url) : new URL(input);
+      paths.push(url.pathname);
+      if (url.pathname.endsWith("/git/matching-refs/heads/")) {
+        return Response.json([
+          {
+            object: { sha: headSha, type: "commit" },
+            ref: "refs/heads/main",
+          },
+        ]);
+      }
+      if (url.pathname.endsWith("/git/matching-refs/tags/")) {
+        return Response.json([
+          {
+            object: { sha: tagSha, type: "tag" },
+            ref: "refs/tags/v1.0.0",
+          },
+        ]);
+      }
+      if (url.pathname.endsWith(`/git/tags/${tagSha}`)) {
+        return Response.json({
+          object: { sha: taggedCommitSha, type: "commit" },
+        });
+      }
+      throw new Error(`Unexpected GitHub path: ${url.pathname}`);
+    };
+
+    expect(await collectGitHubRepositoryRefs(repositoryFacts, "token")).toEqual(
+      [
+        { headSha, kind: "head", refName: "refs/heads/main" },
+        {
+          headSha: taggedCommitSha,
+          kind: "tag",
+          refName: "refs/tags/v1.0.0",
+        },
+      ]
+    );
+    expect(paths).toEqual([
+      "/repos/example-org/example-repo/git/matching-refs/heads/",
+      "/repos/example-org/example-repo/git/matching-refs/tags/",
+      `/repos/example-org/example-repo/git/tags/${tagSha}`,
+    ]);
+  });
+});
+
+describe("sparse PullRequestEvent hydration", () => {
+  const event = {
+    id: "123456789",
+    issue: null,
+    occurredAt: "2026-08-29T10:00:00.000Z",
+    pullRequest: null,
+    pullRequestSignal: {
+      action: "opened",
+      number: 7,
+      repository: {
+        fullName: repositoryFacts.fullName,
+        id: repositoryFacts.id,
+      },
+    },
+    push: null,
+  };
+
+  test("hydrates an unknown sparse event before its checkpoint advances", async () => {
+    const headSha = "d".repeat(40);
+    const baseSha = "e".repeat(40);
+    globalThis.fetch = async (input) => {
+      const url =
+        input instanceof Request ? new URL(input.url) : new URL(input);
+      expect(url.pathname).toBe("/repos/example-org/example-repo/pulls/7");
+      return Response.json({
+        base: { ref: "main", repo: repository, sha: baseSha },
+        body: "Adds credit billing.",
+        closed_at: null,
+        created_at: "2026-08-29T09:00:00Z",
+        draft: false,
+        head: { ref: "credit-billing", repo: repository, sha: headSha },
+        html_url: "https://github.com/example-org/example-repo/pull/7",
+        id: 789,
+        merge_commit_sha: null,
+        merged: false,
+        merged_at: null,
+        node_id: "PR_example",
+        number: 7,
+        state: "open",
+        title: "Add credit billing",
+        updated_at: "2026-08-29T10:00:00Z",
+        user: { id: 101, login: "f0rr0" },
+      });
+    };
+
+    const [hydrated] = await hydrateSparseGitHubPullRequestEvents(
+      [event],
+      "token"
+    );
+    expect(hydrated.pullRequest).toMatchObject({
+      authorAccount: "f0rr0",
+      nodeId: "PR_example",
+      number: 7,
+      title: "Add credit billing",
+    });
+    expect(hydrated.pullRequestSignal).toBeUndefined();
+  });
+
+  test("retains an inaccessible signal so known-PR reconciliation can still run", async () => {
+    globalThis.fetch = async () => new Response(null, { status: 404 });
+    expect(
+      await hydrateSparseGitHubPullRequestEvents([event], "token")
+    ).toEqual([event]);
+  });
+});


### PR DESCRIPTION
## Summary

- refresh the homepage activity timeline with grouped repositories, compact one-line commits, local timestamps, private-repository treatment, and stable expand/collapse rhythm
- hydrate sparse pull-request events before advancing the Events checkpoint
- reconcile every accessible repository branch and tag into durable push observations, including annotated tags and non-default branches
- handle missing event commit counts, ref rewinds, force-push bases that disappear, and complete pagination without synthetic timestamps
- add the repository-ref migration, ingestion documentation, API-contract tests, and PostgreSQL transaction coverage

## Correctness model

Events and webhooks remain low-latency hints. Repository head and tag checkpoints provide durable coverage for every commit that remains reachable between observations. Commits continue to deduplicate by repository ID and SHA, and later PR discovery re-groups standalone commits without changing their identity.

The remaining GitHub observability limit is a ref created and deleted or force-pushed away between observations without any Event, webhook, PR, or surviving ref exposing its commit.

## Verification

- bun test — 114 passing
- bun run lint
- bun run typecheck
- bun run build
- generated migration exercised against ephemeral PostgreSQL
