### PR TITLE
ci(db): migrate production before deploy

### DIFF
--- a/.vercelignore
+++ b/.vercelignore
@@ -2,7 +2,5 @@
 .output/
 career/
 docs/
-drizzle/
 inspiration/
-scripts/
 tests/

--- a/README.md
+++ b/README.md
@@ -26,7 +26,9 @@ bun test
 bun run build
 ```
 
-Database migrations are explicit and are never run during install or build:
+Vercel production builds apply pending migrations before building the site,
+using the database connection already synchronized by Supabase. Preview and
+local builds skip migrations. Apply them manually in other environments with:
 
 ```sh
 bun run db:migrate

--- a/docs/github-commits.md
+++ b/docs/github-commits.md
@@ -315,7 +315,12 @@ the other tracked account token, and then the optional default token so a PR or
 repository readable by either identity can still be processed. All tokens stay
 server-side.
 
-Apply migrations explicitly; deployment does not run them:
+Every Vercel production build from `next` applies pending migrations before the
+Next.js build. `scripts/migrate-production-database.ts` uses the database URL
+already synchronized from Supabase to Vercel; when only the transaction-pooler
+URL is present, it derives the corresponding session-pooler URL. A PostgreSQL
+advisory lock serializes overlapping builds. Preview and local builds skip the
+database entirely. Apply migrations manually in other environments with:
 
 ```sh
 bun run db:migrate

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "next dev",
-    "build": "next build",
+    "build": "bun scripts/migrate-production-database.ts && next build",
     "start": "next start",
     "test": "bun test",
     "typecheck": "tsgo --noEmit",

--- a/scripts/migrate-production-database.ts
+++ b/scripts/migrate-production-database.ts
@@ -1,0 +1,137 @@
+import { spawn } from "node:child_process";
+import { once } from "node:events";
+
+import postgres from "postgres";
+
+const PRODUCTION_BRANCH = "next";
+const MIGRATION_LOCK_NAME = "f0rr0.dev:drizzle-migrations";
+
+type Environment = Readonly<Record<string, string | undefined>>;
+
+export class ProductionMigrationConfigurationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ProductionMigrationConfigurationError";
+  }
+}
+
+const configuredValue = (value: string | undefined) => {
+  const trimmed = value?.trim();
+  return trimmed === undefined || trimmed.length === 0 ? null : trimmed;
+};
+
+export const shouldApplyProductionMigrations = (environment: Environment) => {
+  if (environment.VERCEL !== "1") {
+    return false;
+  }
+  if (
+    environment.VERCEL_ENV === "preview" ||
+    environment.VERCEL_ENV === "development"
+  ) {
+    return false;
+  }
+  if (environment.VERCEL_ENV !== "production") {
+    throw new ProductionMigrationConfigurationError(
+      "VERCEL_ENV is unavailable during a Vercel build."
+    );
+  }
+  if (environment.VERCEL_GIT_COMMIT_REF !== PRODUCTION_BRANCH) {
+    throw new ProductionMigrationConfigurationError(
+      `Production migrations may only run from ${PRODUCTION_BRANCH}.`
+    );
+  }
+  return true;
+};
+
+export const productionMigrationDatabaseUrl = (environment: Environment) => {
+  const configured =
+    configuredValue(environment.DATABASE_URL_UNPOOLED) ??
+    configuredValue(environment.POSTGRES_URL_NON_POOLING) ??
+    configuredValue(environment.DATABASE_URL);
+  if (configured === null) {
+    throw new ProductionMigrationConfigurationError(
+      "A production database URL is not configured in Vercel."
+    );
+  }
+
+  let url: URL;
+  try {
+    url = new URL(configured);
+  } catch {
+    throw new ProductionMigrationConfigurationError(
+      "The production database URL is invalid."
+    );
+  }
+  if (url.protocol !== "postgres:" && url.protocol !== "postgresql:") {
+    throw new ProductionMigrationConfigurationError(
+      "The production database URL must use PostgreSQL."
+    );
+  }
+
+  if (url.port === "6543") {
+    if (!url.hostname.endsWith(".pooler.supabase.com")) {
+      throw new ProductionMigrationConfigurationError(
+        "A transaction-pooler database URL cannot run migrations."
+      );
+    }
+    url.port = "5432";
+  }
+  return url.toString();
+};
+
+const runDrizzleMigrations = async (databaseUrl: string) => {
+  const migrationProcess = spawn(process.execPath, ["run", "db:migrate"], {
+    env: {
+      ...process.env,
+      DATABASE_URL_UNPOOLED: databaseUrl,
+    },
+    stdio: "inherit",
+  });
+  const [code, signal] = (await once(migrationProcess, "exit")) as [
+    number | null,
+    NodeJS.Signals | null,
+  ];
+  if (signal !== null) {
+    throw new Error(`Database migration received signal ${signal}.`);
+  }
+  const exitCode = code ?? 1;
+  if (exitCode !== 0) {
+    throw new Error(`Database migration exited with code ${String(exitCode)}.`);
+  }
+};
+
+export const applyProductionMigrations = async (
+  environment: Environment = process.env
+) => {
+  if (!shouldApplyProductionMigrations(environment)) {
+    process.stdout.write("Skipping production database migrations.\n");
+    return;
+  }
+
+  const databaseUrl = productionMigrationDatabaseUrl(environment);
+  const lockConnection = postgres(databaseUrl, {
+    connect_timeout: 10,
+    max: 1,
+    prepare: false,
+  });
+  let locked = false;
+  try {
+    process.stdout.write("Applying production database migrations.\n");
+    await lockConnection`
+      select pg_advisory_lock(hashtextextended(${MIGRATION_LOCK_NAME}, 0))
+    `;
+    locked = true;
+    await runDrizzleMigrations(databaseUrl);
+  } finally {
+    if (locked) {
+      await lockConnection`
+        select pg_advisory_unlock(hashtextextended(${MIGRATION_LOCK_NAME}, 0))
+      `;
+    }
+    await lockConnection.end({ timeout: 5 });
+  }
+};
+
+if (import.meta.main) {
+  await applyProductionMigrations();
+}

--- a/tests/production-database-migration.test.mjs
+++ b/tests/production-database-migration.test.mjs
@@ -1,0 +1,68 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  ProductionMigrationConfigurationError,
+  productionMigrationDatabaseUrl,
+  shouldApplyProductionMigrations,
+} from "../scripts/migrate-production-database.ts";
+
+describe("production migration environment", () => {
+  test("runs only for production deployments from next", () => {
+    expect(
+      shouldApplyProductionMigrations({
+        VERCEL: "1",
+        VERCEL_ENV: "production",
+        VERCEL_GIT_COMMIT_REF: "next",
+      })
+    ).toBe(true);
+    expect(shouldApplyProductionMigrations({})).toBe(false);
+    expect(
+      shouldApplyProductionMigrations({
+        VERCEL: "1",
+        VERCEL_ENV: "preview",
+        VERCEL_GIT_COMMIT_REF: "feature",
+      })
+    ).toBe(false);
+  });
+
+  test("rejects an unexpected production branch", () => {
+    expect(() =>
+      shouldApplyProductionMigrations({
+        VERCEL: "1",
+        VERCEL_ENV: "production",
+        VERCEL_GIT_COMMIT_REF: "feature",
+      })
+    ).toThrow(ProductionMigrationConfigurationError);
+  });
+});
+
+describe("production migration database URL", () => {
+  test("prefers an explicitly non-pooling URL", () => {
+    expect(
+      productionMigrationDatabaseUrl({
+        DATABASE_URL: "postgresql://fallback:secret@runtime.example:6543/db",
+        DATABASE_URL_UNPOOLED:
+          "postgresql://primary:secret@db.example:5432/postgres",
+      })
+    ).toBe("postgresql://primary:secret@db.example:5432/postgres");
+  });
+
+  test("turns a synced Supabase transaction URL into its session URL", () => {
+    expect(
+      productionMigrationDatabaseUrl({
+        DATABASE_URL:
+          "postgresql://postgres.project:p%40ss@aws-0-region.pooler.supabase.com:6543/postgres?sslmode=require",
+      })
+    ).toBe(
+      "postgresql://postgres.project:p%40ss@aws-0-region.pooler.supabase.com:5432/postgres?sslmode=require"
+    );
+  });
+
+  test("rejects an unknown transaction pooler", () => {
+    expect(() =>
+      productionMigrationDatabaseUrl({
+        DATABASE_URL: "postgresql://user:secret@database.example:6543/db",
+      })
+    ).toThrow(ProductionMigrationConfigurationError);
+  });
+});


### PR DESCRIPTION
## Summary

- run pending Drizzle migrations before Vercel production builds from `next`
- reuse the Supabase database URL already synchronized to Vercel, with no GitHub database secret
- use the Supabase session pooler and a PostgreSQL advisory lock while previews and local builds skip migration work

## Validation

- `bun run format:check`
- `bun run lint`
- `bun run typecheck`
- `bun test` (119 passing)
- `bun run build`