### PR TITLE
feat(github): add bounded activity backfills

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,6 +18,7 @@ GITHUB_PR_RECONCILIATION_MAX_AGE_DAYS=30
 # Shared by Supabase Cron and the Vercel polling function. Use 32+ random
 # characters. The webhook secret is configured on the GitHub App.
 CRON_SECRET=
+GITHUB_BACKFILL_SECRET=
 GITHUB_WEBHOOK_SECRET=
 
 # Per-commit public summary generation uses the existing direct OpenAI key.

--- a/.env.example
+++ b/.env.example
@@ -11,10 +11,6 @@ GITHUB_TOKEN=
 GITHUB_F0RR0_TOKEN=
 GITHUB_YUPPIESTECHDEV_TOKEN=
 
-# Optional pull-request reconciliation window. Defaults to 30 days; use a
-# positive integer or the literal "infinity".
-GITHUB_PR_RECONCILIATION_MAX_AGE_DAYS=30
-
 # Shared by Supabase Cron and the Vercel polling function. Use 32+ random
 # characters. The webhook secret is configured on the GitHub App.
 CRON_SECRET=

--- a/.github/workflows/github-activity-backfill.yml
+++ b/.github/workflows/github-activity-backfill.yml
@@ -1,0 +1,122 @@
+name: Backfill GitHub activity
+
+on:
+  workflow_dispatch:
+    inputs:
+      start_date:
+        description: First UTC date to include (YYYY-MM-DD)
+        required: true
+        type: string
+      end_date:
+        description: Last UTC date to include (YYYY-MM-DD, maximum 366 days)
+        required: true
+        type: string
+      account:
+        description: Credential used to discover accessible repositories
+        required: true
+        default: f0rr0
+        type: choice
+        options:
+          - f0rr0
+          - yuppiestechdev
+          - all
+      repository_id:
+        description: Optional numeric repository ID; blank scans all accessible repositories
+        required: false
+        type: string
+      worker_passes:
+        description: Immediate worker passes after queuing (0-50; cron finishes the rest)
+        required: true
+        default: 8
+        type: number
+
+concurrency:
+  group: github-activity-backfill
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  backfill:
+    name: Queue and process backfill
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    env:
+      ACCOUNT: ${{ inputs.account }}
+      BACKFILL_SECRET: ${{ secrets.ACTIVITY_BACKFILL_SECRET }}
+      END_DATE: ${{ inputs.end_date }}
+      REPOSITORY_ID: ${{ inputs.repository_id }}
+      SITE_URL: https://f0rr0.dev
+      START_DATE: ${{ inputs.start_date }}
+      WORKER_PASSES: ${{ inputs.worker_passes }}
+    steps:
+      - name: Queue bounded history observations
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ -z "$BACKFILL_SECRET" ]]; then
+            echo "The ACTIVITY_BACKFILL_SECRET repository secret is not configured." >&2
+            exit 1
+          fi
+          if ! [[ "$WORKER_PASSES" =~ ^[0-9]+$ ]] || (( WORKER_PASSES > 50 )); then
+            echo "worker_passes must be an integer from 0 through 50." >&2
+            exit 1
+          fi
+
+          response_file=$(mktemp)
+          trap 'rm -f "$response_file"' EXIT
+          payload=$(jq -n \
+            --arg account "$ACCOUNT" \
+            --arg endDate "$END_DATE" \
+            --arg repositoryId "$REPOSITORY_ID" \
+            --arg startDate "$START_DATE" \
+            '{account: $account, endDate: $endDate, repositoryId: $repositoryId, startDate: $startDate}')
+          status=$(curl --silent --show-error \
+            --request POST \
+            --header "Authorization: Bearer $BACKFILL_SECRET" \
+            --header "Content-Type: application/json" \
+            --data "$payload" \
+            --output "$response_file" \
+            --write-out '%{http_code}' \
+            "$SITE_URL/api/cron/github-backfill")
+
+          jq '{accounts, duplicates, endDate, failedAccounts, observations, ok, paused, refs, repositories, startDate, windows}' "$response_file"
+          if [[ "$status" -lt 200 || "$status" -ge 300 ]] || ! jq -e '.ok == true' "$response_file" >/dev/null; then
+            echo "Backfill queueing failed with HTTP $status." >&2
+            exit 1
+          fi
+          {
+            echo "### GitHub activity backfill"
+            echo
+            jq -r '"Queued **\(.observations)** observations across **\(.repositories)** repositories and **\(.windows)** date windows; **\(.duplicates)** were already durable."' "$response_file"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Process queued work immediately
+        if: ${{ inputs.worker_passes > 0 }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          response_file=$(mktemp)
+          trap 'rm -f "$response_file"' EXIT
+          for (( pass = 1; pass <= WORKER_PASSES; pass += 1 )); do
+            status=$(curl --silent --show-error \
+              --request POST \
+              --header "Authorization: Bearer $BACKFILL_SECRET" \
+              --header "Content-Type: application/json" \
+              --data '{"source":"github-actions-backfill"}' \
+              --output "$response_file" \
+              --write-out '%{http_code}' \
+              "$SITE_URL/api/cron/github-worker?batch=8")
+            if [[ "$status" -lt 200 || "$status" -ge 300 ]] || ! jq -e '.ok == true' "$response_file" >/dev/null; then
+              jq '{error, ok}' "$response_file"
+              echo "Worker pass $pass failed with HTTP $status." >&2
+              exit 1
+            fi
+
+            claimed=$(jq '[.activity.commits.claimed, .activity.observations.claimed, .activity.pullRequestDiscovery.claimed, .activity.pullRequests.claimed, .activity.summaries.claimed] | add' "$response_file")
+            echo "Worker pass $pass claimed $claimed items."
+            if (( claimed == 0 )); then
+              break
+            fi
+          done

--- a/docs/github-commits.md
+++ b/docs/github-commits.md
@@ -305,6 +305,7 @@ DATABASE_URL=postgresql://...:6543/postgres
 DATABASE_URL_UNPOOLED=postgresql://...:5432/postgres
 GITHUB_F0RR0_TOKEN=github_pat_...
 GITHUB_YUPPIESTECHDEV_TOKEN=github_pat_...
+GITHUB_BACKFILL_SECRET=<at-least-32-random-characters>
 GITHUB_PR_RECONCILIATION_MAX_AGE_DAYS=30
 GITHUB_WEBHOOK_SECRET=<at-least-32-random-characters>
 CRON_SECRET=<at-least-32-random-characters>
@@ -372,6 +373,46 @@ call OpenAI, or build the public timeline inline.
 The rollout order is schema, Vercel environment, Supabase jobs, GitHub App
 subscriptions, then end-to-end observation. Nothing in this document implies
 that a particular environment has already been migrated or deployed.
+
+### Date-bounded backfill Action
+
+The `Backfill GitHub activity` workflow is manually dispatched from GitHub
+Actions after its workflow file is present on the default branch. It accepts an
+inclusive UTC start and end date, one tracked credential or both, an optional
+numeric repository ID, and up to 50 immediate worker passes. A request may span
+at most 366 days; run adjacent ranges for older history.
+
+The Action sends only the request bounds to the production backfill route. It
+does not receive a database URL or either GitHub account token. The production
+`GITHUB_BACKFILL_SECRET` is mirrored into the repository Actions secret
+`ACTIVITY_BACKFILL_SECRET`. This dedicated bearer value is the only GitHub
+Actions secret the workflow needs.
+
+The server divides the requested range into non-overlapping 31-day windows,
+enumerates current refs with the selected server-side credential, collapses
+refs that share a head, and queues durable `backfill` observations. Repository
+ID, ref head, and window bounds form the idempotency identity: rerunning the
+same request is a no-op for completed observations and requeues deferred or
+unavailable observations. Normal five-minute worker runs finish anything not
+processed by the Action's immediate passes.
+
+Use an opaque numeric ID when targeting one repository so a private repository
+name does not appear in public workflow inputs. Resolve it locally with:
+
+```sh
+gh api repos/OWNER/REPOSITORY --jq .id
+```
+
+To queue the same request without GitHub Actions:
+
+```sh
+curl --fail-with-body \
+  --request POST \
+  --header "Authorization: Bearer $GITHUB_BACKFILL_SECRET" \
+  --header "Content-Type: application/json" \
+  --data '{"account":"f0rr0","startDate":"2026-08-01","endDate":"2026-08-29","repositoryId":""}' \
+  https://f0rr0.dev/api/cron/github-backfill
+```
 
 Run the normal synchronization locally:
 

--- a/docs/github-commits.md
+++ b/docs/github-commits.md
@@ -132,6 +132,11 @@ order:
 5. Create and claim one summary attempt for each still-canonical, non-merge
    commit, make one Nano call, and publish the activity only after it succeeds.
 
+Routine runs claim four items from each bounded stage. Manual backfill runs use
+eight. Both share a 90-second internal deadline and an absolute maximum batch
+of eight, so the regular worker can use available Hobby capacity without
+allowing one invocation to grow without bound.
+
 A commit with more than one parent is a regular merge commit. It remains fully
 stored for intake, ancestry, and alias evidence, but it is excluded from summary
 creation, summary claims, the public activity projection, pagination days, and
@@ -186,19 +191,12 @@ SHA changes or the current head's prior membership is incomplete. A base-only,
 title, or body edit does not fetch membership again and does not make another
 Nano call.
 
-Each worker run claims at most 25 due PRs per tracked account. The age window is
-configured with:
-
-```dotenv
-GITHUB_PR_RECONCILIATION_MAX_AGE_DAYS=30
-```
-
-The default is `30`. Set a positive integer for another number of days, or the
-literal `infinity` for no age cutoff. Eligibility is calculated from PR
-`created_at` at query time, not permanently written into a stopped state.
-Increasing the value or switching to `infinity` therefore makes older open PRs
-eligible again. The cap applies only to scheduled reconciliation; a webhook or
-an associated-PR observation can still update an older PR opportunistically.
+Each worker run claims at most 25 due PRs per tracked account. Open PR
+reconciliation has a reviewed 30-day age horizon in code. It is a product and
+resource policy, not an environment-specific deployment setting. Eligibility
+is calculated from PR `created_at` at query time, not permanently written into
+a stopped state. The cap applies only to scheduled reconciliation; a webhook
+or an associated-PR observation can still update an older PR opportunistically.
 
 The age cutoff applies to ongoing open-PR reconciliation. A known merged or
 closed PR still gets its terminal refresh. After that successful final refresh,
@@ -306,7 +304,6 @@ DATABASE_URL_UNPOOLED=postgresql://...:5432/postgres
 GITHUB_F0RR0_TOKEN=github_pat_...
 GITHUB_YUPPIESTECHDEV_TOKEN=github_pat_...
 GITHUB_BACKFILL_SECRET=<at-least-32-random-characters>
-GITHUB_PR_RECONCILIATION_MAX_AGE_DAYS=30
 GITHUB_WEBHOOK_SECRET=<at-least-32-random-characters>
 CRON_SECRET=<at-least-32-random-characters>
 OPENAI_API_KEY=...
@@ -317,6 +314,14 @@ SITE_URL=https://f0rr0.dev
 the other tracked account token, and then the optional default token so a PR or
 repository readable by either identity can still be processed. All tokens stay
 server-side.
+
+Application and maintenance-script configuration is parsed through the shared
+T3 Env schema in `src/env.ts`. Next.js loads root `.env.local` for local work;
+Bun loads the same file for the maintenance scripts. Vercel environment values
+are the production source. `.env.example` lists only values the application or
+a maintenance script actually reads. Provider ceilings, schedules, batches,
+windows, and retry timings remain reviewed code constants rather than
+environment variables.
 
 Every Vercel production build applies pending migrations before the Next.js
 build. Vercel remains the source of truth for which Git branch is production.
@@ -345,6 +350,11 @@ URLs and bearer secret, replaces jobs with the same names, and installs:
 7 */3 * * *   # authenticated Events intake
 */5 * * * *   # bounded activity worker
 ```
+
+Both cron requests have a 120-second HTTP timeout. The worker stops claiming
+new work after 90 seconds, leaving time for its final database writes and
+response. Full syncs currently complete inside the same bound; if they outgrow
+it, checkpoint the sync itself instead of merely extending the timeout.
 
 No Vercel Cron configuration is required. Inspect scheduling and HTTP delivery
 from Supabase with:

--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -1,10 +1,8 @@
-import { loadEnvConfig } from "@next/env";
 import { defineConfig } from "drizzle-kit";
 
-loadEnvConfig(process.cwd());
+import { env } from "./src/env";
 
-const databaseUrl =
-  process.env.DATABASE_URL_UNPOOLED ?? process.env.DATABASE_URL;
+const databaseUrl = env.DATABASE_URL_UNPOOLED ?? env.DATABASE_URL;
 
 export default defineConfig({
   ...(databaseUrl === undefined || databaseUrl.length === 0

--- a/drizzle/0010_clear_wonder_man.sql
+++ b/drizzle/0010_clear_wonder_man.sql
@@ -1,0 +1,7 @@
+ALTER TABLE "github_push_observations" DROP CONSTRAINT "github_push_observations_source";--> statement-breakpoint
+DROP INDEX "github_push_observations_push_unique";--> statement-breakpoint
+ALTER TABLE "github_push_observations" ADD COLUMN "history_since_at" timestamp with time zone;--> statement-breakpoint
+ALTER TABLE "github_push_observations" ADD COLUMN "history_until_at" timestamp with time zone;--> statement-breakpoint
+CREATE UNIQUE INDEX "github_push_observations_push_unique" ON "github_push_observations" USING btree ("repository_id","ref_name","before_sha","after_sha") WHERE "github_push_observations"."source" <> 'backfill';--> statement-breakpoint
+ALTER TABLE "github_push_observations" ADD CONSTRAINT "github_push_observations_history_bounds" CHECK (("github_push_observations"."source" <> 'backfill' AND "github_push_observations"."history_since_at" IS NULL AND "github_push_observations"."history_until_at" IS NULL) OR ("github_push_observations"."source" = 'backfill' AND "github_push_observations"."history_since_at" IS NOT NULL AND "github_push_observations"."history_until_at" IS NOT NULL AND "github_push_observations"."history_since_at" <= "github_push_observations"."history_until_at" AND "github_push_observations"."expected_commit_count" IS NULL AND "github_push_observations"."before_sha" = repeat('0', 40)));--> statement-breakpoint
+ALTER TABLE "github_push_observations" ADD CONSTRAINT "github_push_observations_source" CHECK ("github_push_observations"."source" IN ('webhook', 'events', 'refs', 'backfill'));

--- a/drizzle/meta/0010_snapshot.json
+++ b/drizzle/meta/0010_snapshot.json
@@ -1,0 +1,2360 @@
+{
+  "id": "a1f9673c-8edd-4220-a397-556ffe788aa7",
+  "prevId": "50a45567-4c5b-4d31-8186-f0ce255168ef",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.github_account_checkpoints": {
+      "name": "github_account_checkpoints",
+      "schema": "",
+      "columns": {
+        "account": {
+          "name": "account",
+          "type": "varchar(39)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "gap_detected_at": {
+          "name": "gap_detected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gap_expected_event_id": {
+          "name": "gap_expected_event_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gap_oldest_available_event_id": {
+          "name": "gap_oldest_available_event_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gap_state": {
+          "name": "gap_state",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'clear'"
+        },
+        "latest_event_id": {
+          "name": "latest_event_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "paused": {
+          "name": "paused",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "ref_backfill_since_at": {
+          "name": "ref_backfill_since_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "github_account_checkpoints_tracked_account": {
+          "name": "github_account_checkpoints_tracked_account",
+          "value": "\"github_account_checkpoints\".\"account\" IN ('f0rr0', 'yuppiestechdev')"
+        },
+        "github_account_checkpoints_event_id_shape": {
+          "name": "github_account_checkpoints_event_id_shape",
+          "value": "(\"github_account_checkpoints\".\"latest_event_id\" IS NULL OR \"github_account_checkpoints\".\"latest_event_id\" ~ '^[0-9]{1,64}$') AND (\"github_account_checkpoints\".\"gap_expected_event_id\" IS NULL OR \"github_account_checkpoints\".\"gap_expected_event_id\" ~ '^[0-9]{1,64}$') AND (\"github_account_checkpoints\".\"gap_oldest_available_event_id\" IS NULL OR \"github_account_checkpoints\".\"gap_oldest_available_event_id\" ~ '^[0-9]{1,64}$')"
+        },
+        "github_account_checkpoints_gap_state": {
+          "name": "github_account_checkpoints_gap_state",
+          "value": "\"github_account_checkpoints\".\"gap_state\" IN ('clear', 'detected')"
+        },
+        "github_account_checkpoints_gap_details": {
+          "name": "github_account_checkpoints_gap_details",
+          "value": "(\"github_account_checkpoints\".\"gap_state\" = 'detected' AND \"github_account_checkpoints\".\"gap_detected_at\" IS NOT NULL) OR (\"github_account_checkpoints\".\"gap_state\" = 'clear' AND \"github_account_checkpoints\".\"gap_detected_at\" IS NULL AND \"github_account_checkpoints\".\"gap_expected_event_id\" IS NULL AND \"github_account_checkpoints\".\"gap_oldest_available_event_id\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.github_commits": {
+      "name": "github_commits",
+      "schema": "",
+      "columns": {
+        "activity_public_id": {
+          "name": "activity_public_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "additions": {
+          "name": "additions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_login": {
+          "name": "author_login",
+          "type": "varchar(39)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "authored_at": {
+          "name": "authored_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_user_id": {
+          "name": "author_user_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canonicalized_at": {
+          "name": "canonicalized_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "changed_files": {
+          "name": "changed_files",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "change_fingerprint": {
+          "name": "change_fingerprint",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "committed_at": {
+          "name": "committed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "committer_at": {
+          "name": "committer_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "committer_user_id": {
+          "name": "committer_user_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deletions": {
+          "name": "deletions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enrichment_error": {
+          "name": "enrichment_error",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enrichment_lease_token": {
+          "name": "enrichment_lease_token",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enrichment_lease_until": {
+          "name": "enrichment_lease_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enrichment_state": {
+          "name": "enrichment_state",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "fingerprint_complete": {
+          "name": "fingerprint_complete",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "first_observed_at": {
+          "name": "first_observed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "full_message": {
+          "name": "full_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "languages": {
+          "name": "languages",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_shas": {
+          "name": "parent_shas",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_file_cap_reached": {
+          "name": "provider_file_cap_reached",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "pr_discovery_error": {
+          "name": "pr_discovery_error",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_discovery_lease_token": {
+          "name": "pr_discovery_lease_token",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_discovery_lease_until": {
+          "name": "pr_discovery_lease_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_discovery_state": {
+          "name": "pr_discovery_state",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "repository": {
+          "name": "repository",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository_owner_avatar_url": {
+          "name": "repository_owner_avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repository_owner_login": {
+          "name": "repository_owner_login",
+          "type": "varchar(39)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repository_owner_type": {
+          "name": "repository_owner_type",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repository_private": {
+          "name": "repository_private",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sha": {
+          "name": "sha",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "substantive_loc": {
+          "name": "substantive_loc",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary_attempted_at": {
+          "name": "summary_attempted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary_error": {
+          "name": "summary_error",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary_headline": {
+          "name": "summary_headline",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary_input_hash": {
+          "name": "summary_input_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary_model": {
+          "name": "summary_model",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary_recipe": {
+          "name": "summary_recipe",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary_short": {
+          "name": "summary_short",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tree_sha": {
+          "name": "tree_sha",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "github_commits_activity_public_id_unique": {
+          "name": "github_commits_activity_public_id_unique",
+          "columns": [
+            {
+              "expression": "activity_public_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_commits_activity_cursor_idx": {
+          "name": "github_commits_activity_cursor_idx",
+          "columns": [
+            {
+              "expression": "committed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "activity_public_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_commits_committed_at_idx": {
+          "name": "github_commits_committed_at_idx",
+          "columns": [
+            {
+              "expression": "committed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_commits_summary_pending_idx": {
+          "name": "github_commits_summary_pending_idx",
+          "columns": [
+            {
+              "expression": "summary_attempted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "committed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_commits_enrichment_pending_idx": {
+          "name": "github_commits_enrichment_pending_idx",
+          "columns": [
+            {
+              "expression": "enrichment_state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "enrichment_lease_until",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "committed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_commits_canonicalization_pending_idx": {
+          "name": "github_commits_canonicalization_pending_idx",
+          "columns": [
+            {
+              "expression": "canonicalized_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "first_observed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_commits_pr_discovery_pending_idx": {
+          "name": "github_commits_pr_discovery_pending_idx",
+          "columns": [
+            {
+              "expression": "pr_discovery_state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pr_discovery_lease_until",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "first_observed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "github_commits_repository_id_sha_pk": {
+          "name": "github_commits_repository_id_sha_pk",
+          "columns": ["repository_id", "sha"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "github_commits_sha_shape": {
+          "name": "github_commits_sha_shape",
+          "value": "\"github_commits\".\"sha\" ~ '^[a-f0-9]{40}$'"
+        },
+        "github_commits_tree_sha_shape": {
+          "name": "github_commits_tree_sha_shape",
+          "value": "\"github_commits\".\"tree_sha\" IS NULL OR \"github_commits\".\"tree_sha\" ~ '^[a-f0-9]{40}$'"
+        },
+        "github_commits_fingerprint_shape": {
+          "name": "github_commits_fingerprint_shape",
+          "value": "\"github_commits\".\"change_fingerprint\" IS NULL OR \"github_commits\".\"change_fingerprint\" ~ '^[a-f0-9]{64}$'"
+        },
+        "github_commits_fingerprint_completeness": {
+          "name": "github_commits_fingerprint_completeness",
+          "value": "NOT \"github_commits\".\"fingerprint_complete\" OR \"github_commits\".\"change_fingerprint\" IS NOT NULL"
+        },
+        "github_commits_parent_shas_array": {
+          "name": "github_commits_parent_shas_array",
+          "value": "\"github_commits\".\"parent_shas\" IS NULL OR jsonb_typeof(\"github_commits\".\"parent_shas\") = 'array'"
+        },
+        "github_commits_enrichment_state": {
+          "name": "github_commits_enrichment_state",
+          "value": "\"github_commits\".\"enrichment_state\" IN ('pending', 'processing', 'complete', 'unavailable')"
+        },
+        "github_commits_enrichment_lease": {
+          "name": "github_commits_enrichment_lease",
+          "value": "(\"github_commits\".\"enrichment_state\" = 'processing') = (\"github_commits\".\"enrichment_lease_token\" IS NOT NULL) AND (\"github_commits\".\"enrichment_state\" <> 'processing' OR \"github_commits\".\"enrichment_lease_until\" IS NOT NULL) AND (\"github_commits\".\"enrichment_state\" NOT IN ('complete', 'unavailable') OR \"github_commits\".\"enrichment_lease_until\" IS NULL)"
+        },
+        "github_commits_pr_discovery_state": {
+          "name": "github_commits_pr_discovery_state",
+          "value": "\"github_commits\".\"pr_discovery_state\" IN ('pending', 'processing', 'complete', 'unavailable')"
+        },
+        "github_commits_pr_discovery_lease": {
+          "name": "github_commits_pr_discovery_lease",
+          "value": "(\"github_commits\".\"pr_discovery_state\" = 'processing') = (\"github_commits\".\"pr_discovery_lease_token\" IS NOT NULL) AND (\"github_commits\".\"pr_discovery_state\" <> 'processing' OR \"github_commits\".\"pr_discovery_lease_until\" IS NOT NULL) AND (\"github_commits\".\"pr_discovery_state\" NOT IN ('complete', 'unavailable') OR \"github_commits\".\"pr_discovery_lease_until\" IS NULL)"
+        },
+        "github_commits_tracked_author": {
+          "name": "github_commits_tracked_author",
+          "value": "\"github_commits\".\"author_login\" IN ('f0rr0', 'yuppiestechdev')"
+        },
+        "github_commits_nonnegative_activity_counts": {
+          "name": "github_commits_nonnegative_activity_counts",
+          "value": "(\"github_commits\".\"changed_files\" IS NULL OR \"github_commits\".\"changed_files\" >= 0) AND (\"github_commits\".\"additions\" IS NULL OR \"github_commits\".\"additions\" >= 0) AND (\"github_commits\".\"deletions\" IS NULL OR \"github_commits\".\"deletions\" >= 0) AND (\"github_commits\".\"substantive_loc\" IS NULL OR \"github_commits\".\"substantive_loc\" >= 0)"
+        },
+        "github_commits_owner_type": {
+          "name": "github_commits_owner_type",
+          "value": "\"github_commits\".\"repository_owner_type\" IS NULL OR \"github_commits\".\"repository_owner_type\" IN ('Organization', 'User')"
+        },
+        "github_commits_summary_hash_shape": {
+          "name": "github_commits_summary_hash_shape",
+          "value": "\"github_commits\".\"summary_input_hash\" IS NULL OR \"github_commits\".\"summary_input_hash\" ~ '^[a-f0-9]{64}$'"
+        },
+        "github_commits_summary_pair": {
+          "name": "github_commits_summary_pair",
+          "value": "(\"github_commits\".\"summary_headline\" IS NULL) = (\"github_commits\".\"summary_short\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.github_issues": {
+      "name": "github_issues",
+      "schema": "",
+      "columns": {
+        "account": {
+          "name": "account",
+          "type": "varchar(39)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_login": {
+          "name": "author_login",
+          "type": "varchar(39)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_user_id": {
+          "name": "author_user_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_observed_at": {
+          "name": "first_observed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "varchar(128)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "number": {
+          "name": "number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title_snapshot": {
+          "name": "title_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url_snapshot": {
+          "name": "url_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "github_issues_repository_number_unique": {
+          "name": "github_issues_repository_number_unique",
+          "columns": [
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_issues_author_idx": {
+          "name": "github_issues_author_idx",
+          "columns": [
+            {
+              "expression": "author_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_issues_repository_id_github_repositories_id_fk": {
+          "name": "github_issues_repository_id_github_repositories_id_fk",
+          "tableFrom": "github_issues",
+          "tableTo": "github_repositories",
+          "columnsFrom": ["repository_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "github_issues_tracked_account": {
+          "name": "github_issues_tracked_account",
+          "value": "\"github_issues\".\"account\" IN ('f0rr0', 'yuppiestechdev')"
+        },
+        "github_issues_positive_number": {
+          "name": "github_issues_positive_number",
+          "value": "\"github_issues\".\"number\" > 0"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.github_public_activities": {
+      "name": "github_public_activities",
+      "schema": "",
+      "columns": {
+        "alias_evidence": {
+          "name": "alias_evidence",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alias_reason": {
+          "name": "alias_reason",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canonical_public_id": {
+          "name": "canonical_public_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "hidden_at": {
+          "name": "hidden_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_id": {
+          "name": "public_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revision": {
+          "name": "revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "source_node_id": {
+          "name": "source_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "github_public_activities_source_unique": {
+          "name": "github_public_activities_source_unique",
+          "columns": [
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_public_activities_cursor_idx": {
+          "name": "github_public_activities_cursor_idx",
+          "columns": [
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "public_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_public_activities_canonical_idx": {
+          "name": "github_public_activities_canonical_idx",
+          "columns": [
+            {
+              "expression": "canonical_public_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_public_activities_canonical_fk": {
+          "name": "github_public_activities_canonical_fk",
+          "tableFrom": "github_public_activities",
+          "tableTo": "github_public_activities",
+          "columnsFrom": ["canonical_public_id"],
+          "columnsTo": ["public_id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "github_public_activities_kind": {
+          "name": "github_public_activities_kind",
+          "value": "\"github_public_activities\".\"kind\" IN ('commit', 'pull_request', 'issue')"
+        },
+        "github_public_activities_not_self_canonical": {
+          "name": "github_public_activities_not_self_canonical",
+          "value": "\"github_public_activities\".\"canonical_public_id\" IS NULL OR \"github_public_activities\".\"canonical_public_id\" <> \"github_public_activities\".\"public_id\""
+        },
+        "github_public_activities_positive_revision": {
+          "name": "github_public_activities_positive_revision",
+          "value": "\"github_public_activities\".\"revision\" > 0"
+        },
+        "github_public_activities_alias_audit": {
+          "name": "github_public_activities_alias_audit",
+          "value": "(\"github_public_activities\".\"canonical_public_id\" IS NULL AND \"github_public_activities\".\"alias_reason\" IS NULL AND \"github_public_activities\".\"alias_evidence\" IS NULL) OR (\"github_public_activities\".\"canonical_public_id\" IS NOT NULL AND \"github_public_activities\".\"alias_reason\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.github_pull_request_memberships": {
+      "name": "github_pull_request_memberships",
+      "schema": "",
+      "columns": {
+        "commit_repository_id": {
+          "name": "commit_repository_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "commit_sha": {
+          "name": "commit_sha",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_head": {
+          "name": "is_head",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version_id": {
+          "name": "version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "github_pull_request_memberships_position_unique": {
+          "name": "github_pull_request_memberships_position_unique",
+          "columns": [
+            {
+              "expression": "version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_pull_request_memberships_commit_lookup_idx": {
+          "name": "github_pull_request_memberships_commit_lookup_idx",
+          "columns": [
+            {
+              "expression": "commit_repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "commit_sha",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gh_pr_memberships_version_fk": {
+          "name": "gh_pr_memberships_version_fk",
+          "tableFrom": "github_pull_request_memberships",
+          "tableTo": "github_pull_request_versions",
+          "columnsFrom": ["version_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "gh_pr_memberships_pk": {
+          "name": "gh_pr_memberships_pk",
+          "columns": ["version_id", "commit_repository_id", "commit_sha"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "github_pull_request_memberships_sha_shape": {
+          "name": "github_pull_request_memberships_sha_shape",
+          "value": "\"github_pull_request_memberships\".\"commit_sha\" ~ '^[a-f0-9]{40}$'"
+        },
+        "github_pull_request_memberships_nonnegative_position": {
+          "name": "github_pull_request_memberships_nonnegative_position",
+          "value": "\"github_pull_request_memberships\".\"position\" >= 0"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.github_pull_request_versions": {
+      "name": "github_pull_request_versions",
+      "schema": "",
+      "columns": {
+        "base_ref_name": {
+          "name": "base_ref_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_repository_id": {
+          "name": "base_repository_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_sha": {
+          "name": "base_sha",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "commit_count": {
+          "name": "commit_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "head_ref_name": {
+          "name": "head_ref_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "head_repository_id": {
+          "name": "head_repository_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "head_sha": {
+          "name": "head_sha",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "is_current": {
+          "name": "is_current",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "membership_complete": {
+          "name": "membership_complete",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "merge_snapshot": {
+          "name": "merge_snapshot",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "observed_at": {
+          "name": "observed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "provider_updated_at": {
+          "name": "provider_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pull_request_node_id": {
+          "name": "pull_request_node_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "github_pull_request_versions_head_unique": {
+          "name": "github_pull_request_versions_head_unique",
+          "columns": [
+            {
+              "expression": "pull_request_node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "head_sha",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_pull_request_versions_current_unique": {
+          "name": "github_pull_request_versions_current_unique",
+          "columns": [
+            {
+              "expression": "pull_request_node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"github_pull_request_versions\".\"is_current\"",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gh_pr_versions_pull_request_fk": {
+          "name": "gh_pr_versions_pull_request_fk",
+          "tableFrom": "github_pull_request_versions",
+          "tableTo": "github_pull_requests",
+          "columnsFrom": ["pull_request_node_id"],
+          "columnsTo": ["node_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "github_pull_request_versions_sha_shapes": {
+          "name": "github_pull_request_versions_sha_shapes",
+          "value": "\"github_pull_request_versions\".\"base_sha\" ~ '^[a-f0-9]{40}$' AND \"github_pull_request_versions\".\"head_sha\" ~ '^[a-f0-9]{40}$'"
+        },
+        "github_pull_request_versions_nonnegative_count": {
+          "name": "github_pull_request_versions_nonnegative_count",
+          "value": "\"github_pull_request_versions\".\"commit_count\" IS NULL OR \"github_pull_request_versions\".\"commit_count\" >= 0"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.github_pull_requests": {
+      "name": "github_pull_requests",
+      "schema": "",
+      "columns": {
+        "account": {
+          "name": "account",
+          "type": "varchar(39)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "additions": {
+          "name": "additions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_login": {
+          "name": "author_login",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_user_id": {
+          "name": "author_user_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "base_ref_name": {
+          "name": "base_ref_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_repository_id": {
+          "name": "base_repository_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_sha": {
+          "name": "base_sha",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body_snapshot": {
+          "name": "body_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "changed_files": {
+          "name": "changed_files",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commit_count": {
+          "name": "commit_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deletions": {
+          "name": "deletions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "draft": {
+          "name": "draft",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "first_observed_at": {
+          "name": "first_observed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "head_ref_name": {
+          "name": "head_ref_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "head_repository_id": {
+          "name": "head_repository_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "head_sha": {
+          "name": "head_sha",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_reconciled_at": {
+          "name": "last_reconciled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "merged_at": {
+          "name": "merged_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "merge_sha": {
+          "name": "merge_sha",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_reconcile_at": {
+          "name": "next_reconcile_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "varchar(128)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "number": {
+          "name": "number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_file_cap_reached": {
+          "name": "provider_file_cap_reached",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "provider_updated_at": {
+          "name": "provider_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "terminal_at": {
+          "name": "terminal_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title_snapshot": {
+          "name": "title_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "github_pull_requests_repository_number_unique": {
+          "name": "github_pull_requests_repository_number_unique",
+          "columns": [
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_pull_requests_reconciliation_idx": {
+          "name": "github_pull_requests_reconciliation_idx",
+          "columns": [
+            {
+              "expression": "account",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_reconcile_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_pull_requests_author_idx": {
+          "name": "github_pull_requests_author_idx",
+          "columns": [
+            {
+              "expression": "author_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_pull_requests_repository_id_github_repositories_id_fk": {
+          "name": "github_pull_requests_repository_id_github_repositories_id_fk",
+          "tableFrom": "github_pull_requests",
+          "tableTo": "github_repositories",
+          "columnsFrom": ["repository_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "github_pull_requests_tracked_account": {
+          "name": "github_pull_requests_tracked_account",
+          "value": "\"github_pull_requests\".\"account\" IN ('f0rr0', 'yuppiestechdev')"
+        },
+        "github_pull_requests_state": {
+          "name": "github_pull_requests_state",
+          "value": "\"github_pull_requests\".\"state\" IN ('open', 'closed', 'merged')"
+        },
+        "github_pull_requests_terminal_state": {
+          "name": "github_pull_requests_terminal_state",
+          "value": "(\"github_pull_requests\".\"state\" = 'open' AND \"github_pull_requests\".\"terminal_at\" IS NULL) OR (\"github_pull_requests\".\"state\" IN ('closed', 'merged') AND \"github_pull_requests\".\"terminal_at\" IS NOT NULL)"
+        },
+        "github_pull_requests_merged_state": {
+          "name": "github_pull_requests_merged_state",
+          "value": "(\"github_pull_requests\".\"state\" = 'merged') = (\"github_pull_requests\".\"merged_at\" IS NOT NULL)"
+        },
+        "github_pull_requests_sha_shapes": {
+          "name": "github_pull_requests_sha_shapes",
+          "value": "(\"github_pull_requests\".\"base_sha\" IS NULL OR \"github_pull_requests\".\"base_sha\" ~ '^[a-f0-9]{40}$') AND (\"github_pull_requests\".\"head_sha\" IS NULL OR \"github_pull_requests\".\"head_sha\" ~ '^[a-f0-9]{40}$') AND (\"github_pull_requests\".\"merge_sha\" IS NULL OR \"github_pull_requests\".\"merge_sha\" ~ '^[a-f0-9]{40}$')"
+        },
+        "github_pull_requests_positive_number": {
+          "name": "github_pull_requests_positive_number",
+          "value": "\"github_pull_requests\".\"number\" > 0"
+        },
+        "github_pull_requests_nonnegative_counts": {
+          "name": "github_pull_requests_nonnegative_counts",
+          "value": "(\"github_pull_requests\".\"changed_files\" IS NULL OR \"github_pull_requests\".\"changed_files\" >= 0) AND (\"github_pull_requests\".\"additions\" IS NULL OR \"github_pull_requests\".\"additions\" >= 0) AND (\"github_pull_requests\".\"deletions\" IS NULL OR \"github_pull_requests\".\"deletions\" >= 0) AND (\"github_pull_requests\".\"commit_count\" IS NULL OR \"github_pull_requests\".\"commit_count\" >= 0)"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.github_push_observation_commits": {
+      "name": "github_push_observation_commits",
+      "schema": "",
+      "columns": {
+        "observation_id": {
+          "name": "observation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sha": {
+          "name": "sha",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "github_push_observation_commits_position_unique": {
+          "name": "github_push_observation_commits_position_unique",
+          "columns": [
+            {
+              "expression": "observation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gh_push_observation_commits_observation_fk": {
+          "name": "gh_push_observation_commits_observation_fk",
+          "tableFrom": "github_push_observation_commits",
+          "tableTo": "github_push_observations",
+          "columnsFrom": ["observation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "gh_push_observation_commits_pk": {
+          "name": "gh_push_observation_commits_pk",
+          "columns": ["observation_id", "repository_id", "sha"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "github_push_observation_commits_sha_shape": {
+          "name": "github_push_observation_commits_sha_shape",
+          "value": "\"github_push_observation_commits\".\"sha\" ~ '^[a-f0-9]{40}$'"
+        },
+        "github_push_observation_commits_nonnegative_position": {
+          "name": "github_push_observation_commits_nonnegative_position",
+          "value": "\"github_push_observation_commits\".\"position\" >= 0"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.github_push_observations": {
+      "name": "github_push_observations",
+      "schema": "",
+      "columns": {
+        "account": {
+          "name": "account",
+          "type": "varchar(39)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "after_sha": {
+          "name": "after_sha",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "before_sha": {
+          "name": "before_sha",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expected_commit_count": {
+          "name": "expected_commit_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "history_since_at": {
+          "name": "history_since_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "history_until_at": {
+          "name": "history_until_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "lease_token": {
+          "name": "lease_token",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lease_until": {
+          "name": "lease_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "observed_at": {
+          "name": "observed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "provider_created_at": {
+          "name": "provider_created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ref_name": {
+          "name": "ref_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository_name_snapshot": {
+          "name": "repository_name_snapshot",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        }
+      },
+      "indexes": {
+        "github_push_observations_source_unique": {
+          "name": "github_push_observations_source_unique",
+          "columns": [
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_push_observations_push_unique": {
+          "name": "github_push_observations_push_unique",
+          "columns": [
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ref_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "before_sha",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "after_sha",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"github_push_observations\".\"source\" <> 'backfill'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_push_observations_pending_idx": {
+          "name": "github_push_observations_pending_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lease_until",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "observed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_push_observations_account_idx": {
+          "name": "github_push_observations_account_idx",
+          "columns": [
+            {
+              "expression": "account",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "observed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gh_push_observations_repository_fk": {
+          "name": "gh_push_observations_repository_fk",
+          "tableFrom": "github_push_observations",
+          "tableTo": "github_repositories",
+          "columnsFrom": ["repository_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "github_push_observations_tracked_account": {
+          "name": "github_push_observations_tracked_account",
+          "value": "\"github_push_observations\".\"account\" IN ('f0rr0', 'yuppiestechdev')"
+        },
+        "github_push_observations_source": {
+          "name": "github_push_observations_source",
+          "value": "\"github_push_observations\".\"source\" IN ('webhook', 'events', 'refs', 'backfill')"
+        },
+        "github_push_observations_sha_shape": {
+          "name": "github_push_observations_sha_shape",
+          "value": "\"github_push_observations\".\"before_sha\" ~ '^[a-f0-9]{40}$' AND \"github_push_observations\".\"after_sha\" ~ '^[a-f0-9]{40}$'"
+        },
+        "github_push_observations_nonnegative_count": {
+          "name": "github_push_observations_nonnegative_count",
+          "value": "\"github_push_observations\".\"expected_commit_count\" IS NULL OR \"github_push_observations\".\"expected_commit_count\" >= 0"
+        },
+        "github_push_observations_history_bounds": {
+          "name": "github_push_observations_history_bounds",
+          "value": "(\"github_push_observations\".\"source\" <> 'backfill' AND \"github_push_observations\".\"history_since_at\" IS NULL AND \"github_push_observations\".\"history_until_at\" IS NULL) OR (\"github_push_observations\".\"source\" = 'backfill' AND \"github_push_observations\".\"history_since_at\" IS NOT NULL AND \"github_push_observations\".\"history_until_at\" IS NOT NULL AND \"github_push_observations\".\"history_since_at\" <= \"github_push_observations\".\"history_until_at\" AND \"github_push_observations\".\"expected_commit_count\" IS NULL AND \"github_push_observations\".\"before_sha\" = repeat('0', 40))"
+        },
+        "github_push_observations_state": {
+          "name": "github_push_observations_state",
+          "value": "\"github_push_observations\".\"state\" IN ('pending', 'processing', 'complete', 'deferred', 'unavailable')"
+        },
+        "github_push_observations_lease": {
+          "name": "github_push_observations_lease",
+          "value": "(\"github_push_observations\".\"state\" = 'processing') = (\"github_push_observations\".\"lease_token\" IS NOT NULL) AND (\"github_push_observations\".\"state\" <> 'processing' OR \"github_push_observations\".\"lease_until\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.github_repositories": {
+      "name": "github_repositories",
+      "schema": "",
+      "columns": {
+        "default_branch": {
+          "name": "default_branch",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_observed_at": {
+          "name": "first_observed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "homepage_url": {
+          "name": "homepage_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "html_url": {
+          "name": "html_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar(32)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "last_observed_at": {
+          "name": "last_observed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "owner_avatar_url": {
+          "name": "owner_avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_login": {
+          "name": "owner_login",
+          "type": "varchar(39)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_type": {
+          "name": "owner_type",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "topics": {
+          "name": "topics",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "github_repositories_full_name_idx": {
+          "name": "github_repositories_full_name_idx",
+          "columns": [
+            {
+              "expression": "full_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "github_repositories_owner_type": {
+          "name": "github_repositories_owner_type",
+          "value": "\"github_repositories\".\"owner_type\" IS NULL OR \"github_repositories\".\"owner_type\" IN ('Organization', 'User')"
+        },
+        "github_repositories_visibility": {
+          "name": "github_repositories_visibility",
+          "value": "\"github_repositories\".\"visibility\" IS NULL OR \"github_repositories\".\"visibility\" IN ('public', 'private', 'internal')"
+        },
+        "github_repositories_topics_array": {
+          "name": "github_repositories_topics_array",
+          "value": "\"github_repositories\".\"topics\" IS NULL OR jsonb_typeof(\"github_repositories\".\"topics\") = 'array'"
+        },
+        "github_repositories_observation_order": {
+          "name": "github_repositories_observation_order",
+          "value": "\"github_repositories\".\"last_observed_at\" >= \"github_repositories\".\"first_observed_at\""
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.github_repository_refs": {
+      "name": "github_repository_refs",
+      "schema": "",
+      "columns": {
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "first_observed_at": {
+          "name": "first_observed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "head_sha": {
+          "name": "head_sha",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_observed_at": {
+          "name": "last_observed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ref_name": {
+          "name": "ref_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "github_repository_refs_active_idx": {
+          "name": "github_repository_refs_active_idx",
+          "columns": [
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_repository_refs_repository_fk": {
+          "name": "github_repository_refs_repository_fk",
+          "tableFrom": "github_repository_refs",
+          "tableTo": "github_repositories",
+          "columnsFrom": ["repository_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "github_repository_refs_repository_id_ref_name_pk": {
+          "name": "github_repository_refs_repository_id_ref_name_pk",
+          "columns": ["repository_id", "ref_name"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "github_repository_refs_kind": {
+          "name": "github_repository_refs_kind",
+          "value": "\"github_repository_refs\".\"kind\" IN ('head', 'tag')"
+        },
+        "github_repository_refs_name": {
+          "name": "github_repository_refs_name",
+          "value": "(\"github_repository_refs\".\"kind\" = 'head' AND \"github_repository_refs\".\"ref_name\" LIKE 'refs/heads/%') OR (\"github_repository_refs\".\"kind\" = 'tag' AND \"github_repository_refs\".\"ref_name\" LIKE 'refs/tags/%')"
+        },
+        "github_repository_refs_sha_shape": {
+          "name": "github_repository_refs_sha_shape",
+          "value": "\"github_repository_refs\".\"head_sha\" ~ '^[a-f0-9]{40}$'"
+        },
+        "github_repository_refs_observation_order": {
+          "name": "github_repository_refs_observation_order",
+          "value": "\"github_repository_refs\".\"last_observed_at\" >= \"github_repository_refs\".\"first_observed_at\""
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.github_summary_attempts": {
+      "name": "github_summary_attempts",
+      "schema": "",
+      "columns": {
+        "activity_public_id": {
+          "name": "activity_public_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempted_at": {
+          "name": "attempted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_hash": {
+          "name": "input_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lease_token": {
+          "name": "lease_token",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lease_until": {
+          "name": "lease_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recipe": {
+          "name": "recipe",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revision": {
+          "name": "revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "summary_headline": {
+          "name": "summary_headline",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary_short": {
+          "name": "summary_short",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "github_summary_attempts_pending_idx": {
+          "name": "github_summary_attempts_pending_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gh_summary_attempts_activity_fk": {
+          "name": "gh_summary_attempts_activity_fk",
+          "tableFrom": "github_summary_attempts",
+          "tableTo": "github_public_activities",
+          "columnsFrom": ["activity_public_id"],
+          "columnsTo": ["public_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "gh_summary_attempts_pk": {
+          "name": "gh_summary_attempts_pk",
+          "columns": ["activity_public_id", "revision"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "github_summary_attempts_state": {
+          "name": "github_summary_attempts_state",
+          "value": "\"github_summary_attempts\".\"state\" IN ('pending', 'processing', 'complete', 'failed', 'indeterminate')"
+        },
+        "github_summary_attempts_positive_revision": {
+          "name": "github_summary_attempts_positive_revision",
+          "value": "\"github_summary_attempts\".\"revision\" > 0"
+        },
+        "github_summary_attempts_input_hash_shape": {
+          "name": "github_summary_attempts_input_hash_shape",
+          "value": "\"github_summary_attempts\".\"input_hash\" IS NULL OR \"github_summary_attempts\".\"input_hash\" ~ '^[a-f0-9]{64}$'"
+        },
+        "github_summary_attempts_summary_pair": {
+          "name": "github_summary_attempts_summary_pair",
+          "value": "(\"github_summary_attempts\".\"summary_headline\" IS NULL) = (\"github_summary_attempts\".\"summary_short\" IS NULL)"
+        },
+        "github_summary_attempts_complete_output": {
+          "name": "github_summary_attempts_complete_output",
+          "value": "\"github_summary_attempts\".\"state\" <> 'complete' OR (\"github_summary_attempts\".\"summary_headline\" IS NOT NULL AND \"github_summary_attempts\".\"completed_at\" IS NOT NULL)"
+        },
+        "github_summary_attempts_lease": {
+          "name": "github_summary_attempts_lease",
+          "value": "(\"github_summary_attempts\".\"state\" = 'processing') = (\"github_summary_attempts\".\"lease_token\" IS NOT NULL) AND (\"github_summary_attempts\".\"state\" <> 'processing' OR \"github_summary_attempts\".\"lease_until\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.github_webhook_deliveries": {
+      "name": "github_webhook_deliveries",
+      "schema": "",
+      "columns": {
+        "accepted": {
+          "name": "accepted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account": {
+          "name": "account",
+          "type": "varchar(39)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_id": {
+          "name": "delivery_id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event": {
+          "name": "event",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "observed_at": {
+          "name": "observed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "github_webhook_deliveries_audit_idx": {
+          "name": "github_webhook_deliveries_audit_idx",
+          "columns": [
+            {
+              "expression": "event",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "observed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "github_webhook_deliveries_id_shape": {
+          "name": "github_webhook_deliveries_id_shape",
+          "value": "\"github_webhook_deliveries\".\"delivery_id\" ~ '^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$'"
+        },
+        "github_webhook_deliveries_event_shape": {
+          "name": "github_webhook_deliveries_event_shape",
+          "value": "\"github_webhook_deliveries\".\"event\" ~ '^[a-z][a-z0-9_]{0,39}$'"
+        },
+        "github_webhook_deliveries_action_shape": {
+          "name": "github_webhook_deliveries_action_shape",
+          "value": "\"github_webhook_deliveries\".\"action\" IS NULL OR \"github_webhook_deliveries\".\"action\" ~ '^[a-z][a-z0-9_]{0,39}$'"
+        },
+        "github_webhook_deliveries_repository_id_shape": {
+          "name": "github_webhook_deliveries_repository_id_shape",
+          "value": "\"github_webhook_deliveries\".\"repository_id\" IS NULL OR \"github_webhook_deliveries\".\"repository_id\" ~ '^[0-9]{1,32}$'"
+        },
+        "github_webhook_deliveries_tracked_account": {
+          "name": "github_webhook_deliveries_tracked_account",
+          "value": "\"github_webhook_deliveries\".\"account\" IS NULL OR \"github_webhook_deliveries\".\"account\" IN ('f0rr0', 'yuppiestechdev')"
+        }
+      },
+      "isRLSEnabled": true
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -71,6 +71,13 @@
       "when": 1788018865000,
       "tag": "0009_freezing_cobalt_man",
       "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "7",
+      "when": 1788020225272,
+      "tag": "0010_clear_wonder_man",
+      "breakpoints": true
     }
   ]
 }

--- a/scripts/configure-supabase-cron.ts
+++ b/scripts/configure-supabase-cron.ts
@@ -1,7 +1,10 @@
 import postgres from "postgres";
 
+import { env } from "../src/env";
+
 const JOB_NAME = "github-sync-every-three-hours";
 const JOB_SCHEDULE = "7 */3 * * *";
+const CRON_HTTP_TIMEOUT_MS = 120_000;
 const WORKER_JOB_NAME = "github-activity-worker-every-five-minutes";
 const WORKER_JOB_SCHEDULE = "*/5 * * * *";
 const SECRET_DESCRIPTION = "Vercel GitHub sync cron configuration";
@@ -9,25 +12,28 @@ const SECRET_NAME = "github_sync_bearer_secret";
 const URL_NAME = "github_sync_url";
 const WORKER_URL_NAME = "github_worker_url";
 
-const requiredEnvironmentValue = (name: string) => {
-  const value = process.env[name]?.trim();
+const requiredEnvironmentValue = (
+  name: string,
+  configured: string | undefined
+) => {
+  const value = configured?.trim();
   if (value === undefined || value.length === 0) {
     throw new Error(`${name} is not configured.`);
   }
   return value;
 };
 
-const unpooledDatabaseUrl = process.env.DATABASE_URL_UNPOOLED?.trim();
+const unpooledDatabaseUrl = env.DATABASE_URL_UNPOOLED?.trim();
 const databaseUrl =
   unpooledDatabaseUrl === undefined || unpooledDatabaseUrl.length === 0
-    ? requiredEnvironmentValue("DATABASE_URL")
+    ? requiredEnvironmentValue("DATABASE_URL", env.DATABASE_URL)
     : unpooledDatabaseUrl;
-const cronSecret = requiredEnvironmentValue("CRON_SECRET");
+const cronSecret = requiredEnvironmentValue("CRON_SECRET", env.CRON_SECRET);
 if (cronSecret.length < 32) {
   throw new Error("CRON_SECRET must contain at least 32 characters.");
 }
 
-const siteUrl = new URL(requiredEnvironmentValue("SITE_URL"));
+const siteUrl = new URL(requiredEnvironmentValue("SITE_URL", env.SITE_URL));
 if (siteUrl.protocol !== "https:") {
   throw new Error("SITE_URL must use HTTPS so Supabase can reach Vercel.");
 }
@@ -103,7 +109,7 @@ try {
         )
       ),
       body := jsonb_build_object('source', 'supabase-cron'),
-      timeout_milliseconds := 120000
+      timeout_milliseconds := ${CRON_HTTP_TIMEOUT_MS}
     ) as request_id
   `;
   const [job] = await sql<{ jobId: number }[]>`
@@ -129,7 +135,7 @@ try {
         )
       ),
       body := jsonb_build_object('source', 'supabase-cron'),
-      timeout_milliseconds := 120000
+      timeout_milliseconds := ${CRON_HTTP_TIMEOUT_MS}
     ) as request_id
   `;
   const [workerJob] = await sql<{ jobId: number }[]>`

--- a/scripts/migrate-production-database.ts
+++ b/scripts/migrate-production-database.ts
@@ -3,9 +3,17 @@ import { once } from "node:events";
 
 import postgres from "postgres";
 
+import { env } from "../src/env";
+
 const MIGRATION_LOCK_NAME = "f0rr0.dev:drizzle-migrations";
 
-type Environment = Readonly<Record<string, string | undefined>>;
+interface Environment {
+  DATABASE_URL?: string;
+  DATABASE_URL_UNPOOLED?: string;
+  POSTGRES_URL_NON_POOLING?: string;
+  VERCEL?: string;
+  VERCEL_ENV?: string;
+}
 
 export class ProductionMigrationConfigurationError extends Error {
   constructor(message: string) {
@@ -95,7 +103,7 @@ const runDrizzleMigrations = async (databaseUrl: string) => {
 };
 
 export const applyProductionMigrations = async (
-  environment: Environment = process.env
+  environment: Environment = env
 ) => {
   if (!shouldApplyProductionMigrations(environment)) {
     process.stdout.write("Skipping production database migrations.\n");

--- a/scripts/sample-nano-public-summaries.ts
+++ b/scripts/sample-nano-public-summaries.ts
@@ -5,6 +5,7 @@ import { generateText } from "ai";
 
 import { closeDatabase, getDatabase } from "../src/db/client";
 import { githubCommits } from "../src/db/schema";
+import { env } from "../src/env";
 import { fetchGitHubActivityCommitSource } from "../src/lib/github-activity-processor";
 import type { GitHubActivityCommitReference } from "../src/lib/github-activity-processor";
 import {
@@ -152,7 +153,7 @@ const callNano = async (modelInput: string) => {
 };
 
 const main = async () => {
-  if ((process.env.OPENAI_API_KEY?.trim().length ?? 0) === 0) {
+  if ((env.OPENAI_API_KEY?.trim().length ?? 0) === 0) {
     throw new Error("OPENAI_API_KEY is not configured.");
   }
   const selected = await selectedRows();

--- a/src/app/api/cron/github-backfill/route.ts
+++ b/src/app/api/cron/github-backfill/route.ts
@@ -1,3 +1,4 @@
+import { env } from "@/env";
 import { githubBackfillRequestFrom } from "@/lib/github-backfill-core";
 import { queueGitHubBackfill } from "@/lib/github-commits";
 import { reportOperationalError } from "@/lib/operational-error";
@@ -13,7 +14,7 @@ export async function POST(request: Request) {
   if (
     !hasBearerSecret(
       request.headers.get("authorization"),
-      process.env.GITHUB_BACKFILL_SECRET
+      env.GITHUB_BACKFILL_SECRET
     )
   ) {
     return Response.json({ ok: false }, { status: 401 });

--- a/src/app/api/cron/github-backfill/route.ts
+++ b/src/app/api/cron/github-backfill/route.ts
@@ -1,0 +1,62 @@
+import { githubBackfillRequestFrom } from "@/lib/github-backfill-core";
+import { queueGitHubBackfill } from "@/lib/github-commits";
+import { reportOperationalError } from "@/lib/operational-error";
+import { hasBearerSecret } from "@/lib/request-auth";
+
+const MAXIMUM_PAYLOAD_BYTES = 4096;
+
+export const dynamic = "force-dynamic";
+export const maxDuration = 300;
+export const runtime = "nodejs";
+
+export async function POST(request: Request) {
+  if (
+    !hasBearerSecret(
+      request.headers.get("authorization"),
+      process.env.GITHUB_BACKFILL_SECRET
+    )
+  ) {
+    return Response.json({ ok: false }, { status: 401 });
+  }
+  const declaredLength = Number(request.headers.get("content-length") ?? "0");
+  if (
+    Number.isFinite(declaredLength) &&
+    declaredLength > MAXIMUM_PAYLOAD_BYTES
+  ) {
+    return Response.json({ ok: false }, { status: 413 });
+  }
+
+  let body: unknown;
+  try {
+    const text = await request.text();
+    if (Buffer.byteLength(text, "utf-8") > MAXIMUM_PAYLOAD_BYTES) {
+      return Response.json({ ok: false }, { status: 413 });
+    }
+    body = JSON.parse(text) as unknown;
+  } catch {
+    return Response.json({ ok: false }, { status: 400 });
+  }
+  const backfill = githubBackfillRequestFrom(body);
+  if (backfill === null) {
+    return Response.json({ ok: false }, { status: 400 });
+  }
+
+  try {
+    const result = await queueGitHubBackfill(backfill);
+    const ok = result.failedAccounts.length === 0;
+    return Response.json(
+      {
+        ...result,
+        endDate: backfill.endDate,
+        ok,
+        repositoryId: backfill.repositoryId,
+        startDate: backfill.startDate,
+        windows: backfill.windows.length,
+      },
+      { status: ok ? 202 : 207 }
+    );
+  } catch (error) {
+    const errorName = reportOperationalError("github_backfill", error);
+    return Response.json({ error: errorName, ok: false }, { status: 503 });
+  }
+}

--- a/src/app/api/cron/github-sync/route.ts
+++ b/src/app/api/cron/github-sync/route.ts
@@ -1,5 +1,6 @@
 import { revalidateTag } from "next/cache";
 
+import { env } from "@/env";
 import { syncGitHubAccounts } from "@/lib/github-commits";
 import { reportOperationalError } from "@/lib/operational-error";
 import { hasBearerSecret } from "@/lib/request-auth";
@@ -9,12 +10,7 @@ export const maxDuration = 300;
 export const runtime = "nodejs";
 
 export async function POST(request: Request) {
-  if (
-    !hasBearerSecret(
-      request.headers.get("authorization"),
-      process.env.CRON_SECRET
-    )
-  ) {
+  if (!hasBearerSecret(request.headers.get("authorization"), env.CRON_SECRET)) {
     return Response.json({ ok: false }, { status: 401 });
   }
 

--- a/src/app/api/cron/github-worker/route.ts
+++ b/src/app/api/cron/github-worker/route.ts
@@ -1,5 +1,6 @@
 import { revalidateTag } from "next/cache";
 
+import { env } from "@/env";
 import { runGitHubActivityWorker } from "@/lib/github-activity-worker";
 import { workerBatchSizeFrom } from "@/lib/github-activity-worker-core";
 import { reportOperationalError } from "@/lib/operational-error";
@@ -12,8 +13,8 @@ export const runtime = "nodejs";
 export async function POST(request: Request) {
   const authorization = request.headers.get("authorization");
   if (
-    !hasBearerSecret(authorization, process.env.CRON_SECRET) &&
-    !hasBearerSecret(authorization, process.env.GITHUB_BACKFILL_SECRET)
+    !hasBearerSecret(authorization, env.CRON_SECRET) &&
+    !hasBearerSecret(authorization, env.GITHUB_BACKFILL_SECRET)
   ) {
     return Response.json({ ok: false }, { status: 401 });
   }

--- a/src/app/api/cron/github-worker/route.ts
+++ b/src/app/api/cron/github-worker/route.ts
@@ -1,6 +1,7 @@
 import { revalidateTag } from "next/cache";
 
 import { runGitHubActivityWorker } from "@/lib/github-activity-worker";
+import { workerBatchSizeFrom } from "@/lib/github-activity-worker-core";
 import { reportOperationalError } from "@/lib/operational-error";
 import { hasBearerSecret } from "@/lib/request-auth";
 
@@ -9,17 +10,31 @@ export const maxDuration = 300;
 export const runtime = "nodejs";
 
 export async function POST(request: Request) {
+  const authorization = request.headers.get("authorization");
   if (
-    !hasBearerSecret(
-      request.headers.get("authorization"),
-      process.env.CRON_SECRET
-    )
+    !hasBearerSecret(authorization, process.env.CRON_SECRET) &&
+    !hasBearerSecret(authorization, process.env.GITHUB_BACKFILL_SECRET)
   ) {
     return Response.json({ ok: false }, { status: 401 });
   }
+  const batchSize = workerBatchSizeFrom(
+    new URL(request.url).searchParams.get("batch")
+  );
+  if (batchSize === null) {
+    return Response.json({ ok: false }, { status: 400 });
+  }
 
   try {
-    const activity = await runGitHubActivityWorker();
+    const activity = await runGitHubActivityWorker(
+      batchSize === undefined
+        ? {}
+        : {
+            commitLimit: batchSize,
+            observationLimit: batchSize,
+            pullRequestDiscoveryLimit: batchSize,
+            summaryLimit: batchSize,
+          }
+    );
     if (
       activity.summaries.completed > 0 ||
       activity.pullRequests.completed > 0 ||

--- a/src/app/api/github/webhook/route.ts
+++ b/src/app/api/github/webhook/route.ts
@@ -3,6 +3,7 @@ import { createHmac } from "node:crypto";
 import { revalidateTag } from "next/cache";
 
 import { isDatabaseConfigured } from "@/db/client";
+import { env } from "@/env";
 import {
   githubDeliveryIdFrom,
   issueActionFromWebhook,
@@ -103,7 +104,7 @@ const persistSupportedWebhook = async (
 };
 
 export async function POST(request: Request) {
-  const webhookSecret = process.env.GITHUB_WEBHOOK_SECRET?.trim();
+  const webhookSecret = env.GITHUB_WEBHOOK_SECRET?.trim();
   if (
     webhookSecret === undefined ||
     webhookSecret.length < 32 ||

--- a/src/db/client.ts
+++ b/src/db/client.ts
@@ -2,6 +2,7 @@ import { drizzle } from "drizzle-orm/postgres-js";
 import postgres from "postgres";
 
 import * as schema from "@/db/schema";
+import { env } from "@/env";
 
 export class DatabaseConfigurationError extends Error {
   constructor() {
@@ -14,7 +15,7 @@ let client: ReturnType<typeof postgres> | null = null;
 let database: ReturnType<typeof drizzle<typeof schema>> | null = null;
 
 const readDatabaseUrl = () => {
-  const value = process.env.DATABASE_URL?.trim();
+  const value = env.DATABASE_URL?.trim();
   return value === undefined || value.length === 0 ? null : value;
 };
 

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -379,6 +379,14 @@ export const githubPushObservations = pgTable(
     }),
     errorCode: varchar("error_code", { length: 80 }),
     expectedCommitCount: integer("expected_commit_count"),
+    historySinceAt: timestamp("history_since_at", {
+      mode: "date",
+      withTimezone: true,
+    }),
+    historyUntilAt: timestamp("history_until_at", {
+      mode: "date",
+      withTimezone: true,
+    }),
     id: uuid("id").defaultRandom().primaryKey(),
     leaseToken: uuid("lease_token"),
     leaseUntil: timestamp("lease_until", {
@@ -409,12 +417,9 @@ export const githubPushObservations = pgTable(
       table.source,
       table.sourceId
     ),
-    uniqueIndex("github_push_observations_push_unique").on(
-      table.repositoryId,
-      table.refName,
-      table.beforeSha,
-      table.afterSha
-    ),
+    uniqueIndex("github_push_observations_push_unique")
+      .on(table.repositoryId, table.refName, table.beforeSha, table.afterSha)
+      .where(sql`${table.source} <> 'backfill'`),
     index("github_push_observations_pending_idx").on(
       table.state,
       table.leaseUntil,
@@ -435,7 +440,7 @@ export const githubPushObservations = pgTable(
     ),
     check(
       "github_push_observations_source",
-      sql`${table.source} IN ('webhook', 'events', 'refs')`
+      sql`${table.source} IN ('webhook', 'events', 'refs', 'backfill')`
     ),
     check(
       "github_push_observations_sha_shape",
@@ -444,6 +449,10 @@ export const githubPushObservations = pgTable(
     check(
       "github_push_observations_nonnegative_count",
       sql`${table.expectedCommitCount} IS NULL OR ${table.expectedCommitCount} >= 0`
+    ),
+    check(
+      "github_push_observations_history_bounds",
+      sql`(${table.source} <> 'backfill' AND ${table.historySinceAt} IS NULL AND ${table.historyUntilAt} IS NULL) OR (${table.source} = 'backfill' AND ${table.historySinceAt} IS NOT NULL AND ${table.historyUntilAt} IS NOT NULL AND ${table.historySinceAt} <= ${table.historyUntilAt} AND ${table.expectedCommitCount} IS NULL AND ${table.beforeSha} = repeat('0', 40))`
     ),
     check(
       "github_push_observations_state",

--- a/src/env.ts
+++ b/src/env.ts
@@ -1,9 +1,11 @@
 import { createEnv } from "@t3-oss/env-nextjs";
 import { z } from "zod";
 
+const optionalString = z.string().trim().min(1).optional();
+
 export const env = createEnv({
   client: {
-    NEXT_PUBLIC_PORT: z.string().min(1).optional(),
+    NEXT_PUBLIC_PORT: optionalString,
   },
   emptyStringAsUndefined: true,
   experimental__runtimeEnv: {
@@ -13,22 +15,20 @@ export const env = createEnv({
     CRON_SECRET: z.string().min(32).optional(),
     DATABASE_URL: z.url().optional(),
     DATABASE_URL_UNPOOLED: z.url().optional(),
-    GH_TOKEN: z.string().min(1).optional(),
+    GH_TOKEN: optionalString,
     GITHUB_BACKFILL_SECRET: z.string().min(32).optional(),
-    GITHUB_F0RR0_TOKEN: z.string().min(1).optional(),
-    GITHUB_PR_RECONCILIATION_MAX_AGE_DAYS: z
-      .string()
-      .regex(/^(?:[1-9]\d*|infinity)$/i)
-      .optional(),
-    GITHUB_TOKEN: z.string().min(1).optional(),
+    GITHUB_F0RR0_TOKEN: optionalString,
+    GITHUB_TOKEN: optionalString,
     GITHUB_WEBHOOK_SECRET: z.string().min(32).optional(),
-    GITHUB_YUPPIESTECHDEV_TOKEN: z.string().min(1).optional(),
+    GITHUB_YUPPIESTECHDEV_TOKEN: optionalString,
     NODE_ENV: z.enum(["development", "production", "test"]).optional(),
-    OPENAI_API_KEY: z.string().min(1).optional(),
-    PORT: z.string().min(1).optional(),
-    SITE_URL: z.string().min(1).optional(),
+    OPENAI_API_KEY: optionalString,
+    PORT: optionalString,
+    POSTGRES_URL_NON_POOLING: z.url().optional(),
+    SITE_URL: optionalString,
+    VERCEL: z.literal("1").optional(),
     VERCEL_ENV: z.enum(["development", "preview", "production"]).optional(),
-    VERCEL_PROJECT_PRODUCTION_URL: z.string().min(1).optional(),
-    VERCEL_URL: z.string().min(1).optional(),
+    VERCEL_PROJECT_PRODUCTION_URL: optionalString,
+    VERCEL_URL: optionalString,
   },
 });

--- a/src/env.ts
+++ b/src/env.ts
@@ -14,6 +14,7 @@ export const env = createEnv({
     DATABASE_URL: z.url().optional(),
     DATABASE_URL_UNPOOLED: z.url().optional(),
     GH_TOKEN: z.string().min(1).optional(),
+    GITHUB_BACKFILL_SECRET: z.string().min(32).optional(),
     GITHUB_F0RR0_TOKEN: z.string().min(1).optional(),
     GITHUB_PR_RECONCILIATION_MAX_AGE_DAYS: z
       .string()

--- a/src/lib/github-activity-cursor.ts
+++ b/src/lib/github-activity-cursor.ts
@@ -1,5 +1,7 @@
 import { createHmac, timingSafeEqual } from "node:crypto";
 
+import { env } from "@/env";
+
 const CURSOR_MAX_LENGTH = 512;
 const CURSOR_VERSION = 1;
 const UTC_DAY = /^\d{4}-\d{2}-\d{2}$/u;
@@ -51,7 +53,7 @@ const signatureFor = (payload: string, secret: string) =>
 
 export const encodeGitHubActivityCursor = (
   cursor: GitHubActivityCursor,
-  secret = process.env.CRON_SECRET
+  secret = env.CRON_SECRET
 ) => {
   if (!validCursor(cursor)) {
     throw new TypeError("The GitHub activity cursor is invalid.");
@@ -64,7 +66,7 @@ export const encodeGitHubActivityCursor = (
 
 export const decodeGitHubActivityCursor = (
   value: string | null,
-  secret = process.env.CRON_SECRET
+  secret = env.CRON_SECRET
 ): GitHubActivityCursor | null => {
   if (value === null || value.length === 0) {
     return null;

--- a/src/lib/github-activity-processor.ts
+++ b/src/lib/github-activity-processor.ts
@@ -77,6 +77,7 @@ export interface GitHubActivityPushObservationReference {
   beforeSha: string;
   expectedCommitCount: number | null;
   historySinceAt: Date;
+  historyUntilAt: Date | null;
   knownShas: readonly string[];
   observedAt: Date;
   refName: string;
@@ -600,6 +601,10 @@ const newBranchCommitValuesWithToken = async (
   const { expectedCommitCount } = row;
   const historySinceAt =
     expectedCommitCount === null ? row.historySinceAt.toISOString() : null;
+  const historyUntilAt =
+    expectedCommitCount === null
+      ? (row.historyUntilAt?.toISOString() ?? null)
+      : null;
   if (expectedCommitCount !== null && expectedCommitCount < 1) {
     throw new ActivityProcessingError(
       "source_incomplete",
@@ -613,11 +618,11 @@ const newBranchCommitValuesWithToken = async (
       "The stored GitHub repository reference is invalid."
     );
   }
-  const query = `query NewBranchCommits($owner: String!, $name: String!, $oid: GitObjectID!, $pageSize: Int!, $cursor: String, $since: GitTimestamp) {
+  const query = `query NewBranchCommits($owner: String!, $name: String!, $oid: GitObjectID!, $pageSize: Int!, $cursor: String, $since: GitTimestamp, $until: GitTimestamp) {
     repository(owner: $owner, name: $name) {
       object(oid: $oid) {
         ... on Commit {
-          history(first: $pageSize, after: $cursor, since: $since) {
+          history(first: $pageSize, after: $cursor, since: $since, until: $until) {
             nodes {
               oid
               message
@@ -649,6 +654,7 @@ const newBranchCommitValuesWithToken = async (
           owner,
           pageSize,
           since: historySinceAt,
+          until: historyUntilAt,
         },
       }),
       method: "POST",
@@ -775,7 +781,9 @@ export const validateGitHubPushObservationCommitShas = (
     (!emptyRewind && !emptyBoundedHistory && commitShas.length === 0) ||
     (row.expectedCommitCount !== null &&
       commitShas.length !== row.expectedCommitCount) ||
-    (commitShas.length > 0 && commitShas.at(-1) !== row.afterSha) ||
+    (commitShas.length > 0 &&
+      (row.historyUntilAt ?? null) === null &&
+      commitShas.at(-1) !== row.afterSha) ||
     new Set(commitShas).size !== commitShas.length ||
     commitShas.some((sha) => commitShaFrom(sha) === null)
   ) {

--- a/src/lib/github-activity-processor.ts
+++ b/src/lib/github-activity-processor.ts
@@ -3,6 +3,7 @@ import { createHash } from "node:crypto";
 import { openai } from "@ai-sdk/openai";
 import { APICallError, generateText } from "ai";
 
+import { env } from "@/env";
 import {
   formatPublicCommitSummaryMarkdown,
   parseCommitPublicSummary,
@@ -208,15 +209,15 @@ const repositoryReferenceFrom = (row: {
 const tokenCandidatesFor = (account: TrackedGitHubAccount) => {
   const accountToken =
     account === "f0rr0"
-      ? process.env.GITHUB_F0RR0_TOKEN
-      : process.env.GITHUB_YUPPIESTECHDEV_TOKEN;
+      ? env.GITHUB_F0RR0_TOKEN
+      : env.GITHUB_YUPPIESTECHDEV_TOKEN;
   const otherToken =
     account === "f0rr0"
-      ? process.env.GITHUB_YUPPIESTECHDEV_TOKEN
-      : process.env.GITHUB_F0RR0_TOKEN;
+      ? env.GITHUB_YUPPIESTECHDEV_TOKEN
+      : env.GITHUB_F0RR0_TOKEN;
   return [
     ...new Set(
-      [accountToken, otherToken, process.env.GITHUB_TOKEN].flatMap((value) => {
+      [accountToken, otherToken, env.GITHUB_TOKEN].flatMap((value) => {
         const token = value?.trim();
         return token === undefined || token.length === 0 ? [] : [token];
       })

--- a/src/lib/github-activity-worker-core.ts
+++ b/src/lib/github-activity-worker-core.ts
@@ -3,14 +3,8 @@ import { createHash } from "node:crypto";
 import type { PublicCommitEvidence } from "@/lib/github-activity-public-summary";
 
 export const GITHUB_EXACT_DIFF_DIGEST_RECIPE = "github-exact-diff-v2";
-export const DEFAULT_GITHUB_PR_RECONCILIATION_MAX_AGE_DAYS = 30;
-
-export class GitHubActivityConfigurationError extends Error {
-  constructor(message: string) {
-    super(message);
-    this.name = "GitHubActivityConfigurationError";
-  }
-}
+export const DEFAULT_GITHUB_ACTIVITY_WORKER_BATCH_SIZE = 4;
+export const GITHUB_PR_RECONCILIATION_MAX_AGE_DAYS = 30;
 
 export interface GitHubExactDiffDigest {
   complete: boolean;
@@ -138,7 +132,10 @@ export const exactGitHubDiffDigest = (
   };
 };
 
-export const boundedWorkerLimit = (value: number | undefined, fallback = 2) => {
+export const boundedWorkerLimit = (
+  value: number | undefined,
+  fallback = DEFAULT_GITHUB_ACTIVITY_WORKER_BATCH_SIZE
+) => {
   const selected = value ?? fallback;
   if (!Number.isSafeInteger(selected) || selected < 1 || selected > 8) {
     throw new RangeError("The GitHub activity worker batch size is invalid.");
@@ -153,30 +150,6 @@ export const workerBatchSizeFrom = (
     return undefined;
   }
   return /^[1-8]$/.test(value) ? Number(value) : null;
-};
-
-export const githubPrReconciliationMaximumAgeDays = (
-  value = process.env.GITHUB_PR_RECONCILIATION_MAX_AGE_DAYS
-) => {
-  const normalized = value?.trim().toLowerCase();
-  if (normalized === undefined || normalized.length === 0) {
-    return DEFAULT_GITHUB_PR_RECONCILIATION_MAX_AGE_DAYS;
-  }
-  if (normalized === "infinity") {
-    return Number.POSITIVE_INFINITY;
-  }
-  if (!/^[1-9]\d*$/.test(normalized)) {
-    throw new GitHubActivityConfigurationError(
-      "GITHUB_PR_RECONCILIATION_MAX_AGE_DAYS must be a positive integer or infinity."
-    );
-  }
-  const days = Number(normalized);
-  if (!Number.isSafeInteger(days)) {
-    throw new GitHubActivityConfigurationError(
-      "GITHUB_PR_RECONCILIATION_MAX_AGE_DAYS is outside the supported range."
-    );
-  }
-  return days;
 };
 
 export const githubPrReconciliationCutoff = (

--- a/src/lib/github-activity-worker-core.ts
+++ b/src/lib/github-activity-worker-core.ts
@@ -146,6 +146,15 @@ export const boundedWorkerLimit = (value: number | undefined, fallback = 2) => {
   return selected;
 };
 
+export const workerBatchSizeFrom = (
+  value: string | null
+): number | null | undefined => {
+  if (value === null) {
+    return undefined;
+  }
+  return /^[1-8]$/.test(value) ? Number(value) : null;
+};
+
 export const githubPrReconciliationMaximumAgeDays = (
   value = process.env.GITHUB_PR_RECONCILIATION_MAX_AGE_DAYS
 ) => {

--- a/src/lib/github-activity-worker-store.ts
+++ b/src/lib/github-activity-worker-store.ts
@@ -91,6 +91,7 @@ export interface ClaimedGitHubPushObservation {
   beforeSha: string;
   expectedCommitCount: number | null;
   historySinceAt: Date;
+  historyUntilAt: Date | null;
   id: string;
   knownShas: readonly string[];
   leaseToken: string;
@@ -162,7 +163,8 @@ export const claimGitHubPushObservations = async (
         afterSha: githubPushObservations.afterSha,
         beforeSha: githubPushObservations.beforeSha,
         expectedCommitCount: githubPushObservations.expectedCommitCount,
-        historySinceAt: githubAccountCheckpoints.refBackfillSinceAt,
+        historySinceAt: sql<Date>`coalesce(${githubPushObservations.historySinceAt}, ${githubAccountCheckpoints.refBackfillSinceAt})`,
+        historyUntilAt: githubPushObservations.historyUntilAt,
         id: githubPushObservations.id,
         observedAt: githubPushObservations.observedAt,
         refName: githubPushObservations.refName,

--- a/src/lib/github-activity-worker.ts
+++ b/src/lib/github-activity-worker.ts
@@ -1,3 +1,4 @@
+import { env } from "@/env";
 import {
   ActivityProcessingError,
   fetchGitHubActivityCommitSource,
@@ -12,7 +13,7 @@ import { PUBLIC_COMMIT_SUMMARY_RECIPE } from "@/lib/github-activity-public-summa
 import {
   boundedWorkerLimit,
   exactGitHubDiffDigest,
-  githubPrReconciliationMaximumAgeDays,
+  GITHUB_PR_RECONCILIATION_MAX_AGE_DAYS,
   workerDeadlineReached,
 } from "@/lib/github-activity-worker-core";
 import {
@@ -308,14 +309,13 @@ const processPullRequests = async (
   context: WorkerContext,
   result: StageResult
 ) => {
-  const maximumAgeDays = githubPrReconciliationMaximumAgeDays();
   for (const account of context.activeAccounts) {
     if (context.deadlineReached()) {
       break;
     }
     const duePullRequests = await claimDueGitHubPullRequests(
       account,
-      maximumAgeDays,
+      GITHUB_PR_RECONCILIATION_MAX_AGE_DAYS,
       25
     );
     result.claimed += duePullRequests.length;
@@ -349,7 +349,7 @@ const processSummaries = async (
 ) => {
   if (
     context.deadlineReached() ||
-    (process.env.OPENAI_API_KEY?.trim().length ?? 0) === 0
+    (env.OPENAI_API_KEY?.trim().length ?? 0) === 0
   ) {
     return;
   }

--- a/src/lib/github-api.ts
+++ b/src/lib/github-api.ts
@@ -1,5 +1,7 @@
 import { setTimeout as delay } from "node:timers/promises";
 
+import { env } from "@/env";
+
 const GITHUB_API_ORIGIN = "https://api.github.com";
 const GITHUB_API_VERSION = "2026-03-10";
 const REQUEST_ATTEMPTS = 3;
@@ -55,8 +57,7 @@ const isRateLimited = (response: Response) =>
       response.headers.get("x-ratelimit-remaining") === "0"));
 
 const readDefaultGitHubToken = () => {
-  const token =
-    process.env.GITHUB_TOKEN?.trim() ?? process.env.GITHUB_F0RR0_TOKEN?.trim();
+  const token = env.GITHUB_TOKEN?.trim() ?? env.GITHUB_F0RR0_TOKEN?.trim();
   return token === undefined || token.length === 0 ? null : token;
 };
 

--- a/src/lib/github-backfill-core.ts
+++ b/src/lib/github-backfill-core.ts
@@ -1,0 +1,105 @@
+import {
+  repositoryIdFrom,
+  TRACKED_GITHUB_ACCOUNTS,
+  trackedGitHubAccountFrom,
+} from "@/lib/github-commits-core";
+import type { TrackedGitHubAccount } from "@/lib/github-commits-core";
+import type { GitHubBackfillWindow } from "@/lib/github-commits-store";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+const MAXIMUM_BACKFILL_DAYS = 366;
+const WINDOW_DAYS = 31;
+const MINIMUM_GITHUB_DATE = Date.UTC(1970, 0, 1);
+const MAXIMUM_GITHUB_DATE = Date.UTC(2099, 11, 13);
+
+type JsonObject = Record<string, unknown>;
+
+const isObject = (value: unknown): value is JsonObject =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const utcDayFrom = (value: unknown) => {
+  if (typeof value !== "string" || !DATE_PATTERN.test(value)) {
+    return null;
+  }
+  const date = new Date(`${value}T00:00:00.000Z`);
+  return !Number.isNaN(date.getTime()) &&
+    date.toISOString().slice(0, 10) === value
+    ? date
+    : null;
+};
+
+export interface GitHubBackfillRequest {
+  accounts: readonly TrackedGitHubAccount[];
+  endDate: string;
+  repositoryId: string | null;
+  startDate: string;
+  windows: readonly GitHubBackfillWindow[];
+}
+
+export const githubBackfillRequestFrom = (
+  value: unknown,
+  now = new Date()
+): GitHubBackfillRequest | null => {
+  if (!isObject(value)) {
+    return null;
+  }
+  const startAt = utcDayFrom(value.startDate);
+  const endDay = utcDayFrom(value.endDate);
+  const today = new Date(
+    Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate())
+  );
+  if (
+    startAt === null ||
+    endDay === null ||
+    startAt > endDay ||
+    startAt.getTime() < MINIMUM_GITHUB_DATE ||
+    endDay.getTime() > Math.min(MAXIMUM_GITHUB_DATE, today.getTime())
+  ) {
+    return null;
+  }
+  const dayCount = (endDay.getTime() - startAt.getTime()) / DAY_MS + 1;
+  if (dayCount > MAXIMUM_BACKFILL_DAYS) {
+    return null;
+  }
+
+  const account =
+    value.account === "all" ? "all" : trackedGitHubAccountFrom(value.account);
+  if (account === null) {
+    return null;
+  }
+  const accounts =
+    account === "all" ? TRACKED_GITHUB_ACCOUNTS : ([account] as const);
+  const rawRepositoryId =
+    typeof value.repositoryId === "string" ? value.repositoryId.trim() : "";
+  const repositoryId =
+    rawRepositoryId.length === 0 ? null : repositoryIdFrom(rawRepositoryId);
+  if (rawRepositoryId.length > 0 && repositoryId === null) {
+    return null;
+  }
+
+  const windows: GitHubBackfillWindow[] = [];
+  const rangeEndExclusive = endDay.getTime() + DAY_MS;
+  for (
+    let cursor = startAt.getTime();
+    cursor < rangeEndExclusive;
+    cursor += WINDOW_DAYS * DAY_MS
+  ) {
+    const windowEndExclusive = Math.min(
+      cursor + WINDOW_DAYS * DAY_MS,
+      rangeEndExclusive
+    );
+    windows.push({
+      sinceAt: new Date(cursor),
+      untilAt: new Date(windowEndExclusive - 1),
+    });
+  }
+
+  return {
+    accounts,
+    endDate: endDay.toISOString().slice(0, 10),
+    repositoryId,
+    startDate: startAt.toISOString().slice(0, 10),
+    windows,
+  };
+};

--- a/src/lib/github-commits-core.ts
+++ b/src/lib/github-commits-core.ts
@@ -141,7 +141,7 @@ const optionalDate = (value: unknown) => {
   return { valid: date !== null, value: date } as const;
 };
 
-const repositoryIdFrom = (value: unknown) => {
+export const repositoryIdFrom = (value: unknown) => {
   if (typeof value === "number" && Number.isSafeInteger(value) && value > 0) {
     return String(value);
   }
@@ -212,18 +212,21 @@ export const githubDeliveryIdFrom = (value: unknown) => {
   return GITHUB_DELIVERY_ID.test(deliveryId) ? deliveryId : null;
 };
 
+export const repositoryFullNameFrom = (value: unknown) => {
+  const fullName = normalizedText(value, 200);
+  return fullName !== null && REPOSITORY_FULL_NAME.test(fullName)
+    ? fullName
+    : null;
+};
+
 export const repositoryFrom = (value: unknown): GitHubRepository | null => {
   if (!isObject(value)) {
     return null;
   }
 
   const id = repositoryIdFrom(value.id);
-  const fullName = normalizedText(value.full_name ?? value.name, 200);
-  if (
-    id === null ||
-    fullName === null ||
-    !REPOSITORY_FULL_NAME.test(fullName)
-  ) {
+  const fullName = repositoryFullNameFrom(value.full_name ?? value.name);
+  if (id === null || fullName === null) {
     return null;
   }
 

--- a/src/lib/github-commits-store.ts
+++ b/src/lib/github-commits-store.ts
@@ -4,6 +4,7 @@ import {
   and,
   eq,
   gt,
+  inArray,
   isNull,
   lt,
   lte,
@@ -73,6 +74,17 @@ export interface GitHubRepositoryRefSnapshot {
 export interface GitHubRepositoryRefIntakeResult {
   knownCommits: number;
   pushes: number;
+  refs: number;
+}
+
+export interface GitHubBackfillWindow {
+  sinceAt: Date;
+  untilAt: Date;
+}
+
+export interface GitHubRepositoryBackfillIntakeResult {
+  duplicates: number;
+  observations: number;
   refs: number;
 }
 
@@ -281,6 +293,7 @@ const insertPushObservations = async (
 };
 
 const ZERO_SHA = "0".repeat(40);
+const BACKFILL_OBSERVATION_INSERT_BATCH = 250;
 
 const refObservationSourceId = (input: {
   afterSha: string;
@@ -295,6 +308,128 @@ const refObservationSourceId = (input: {
       )
     )
     .digest("hex")}`;
+
+const backfillObservationSourceId = (input: {
+  afterSha: string;
+  repositoryId: string;
+  sinceAt: Date;
+  untilAt: Date;
+}) =>
+  `backfill:${createHash("sha256")
+    .update(
+      [
+        input.repositoryId,
+        input.afterSha,
+        input.sinceAt.toISOString(),
+        input.untilAt.toISOString(),
+      ].join("\0")
+    )
+    .digest("hex")}`;
+
+export const persistGitHubRepositoryBackfill = async (input: {
+  account: TrackedGitHubAccount;
+  observedAt: Date;
+  refs: readonly GitHubRepositoryRefSnapshot[];
+  repository: GitHubRepositoryFacts;
+  windows: readonly GitHubBackfillWindow[];
+}): Promise<GitHubRepositoryBackfillIntakeResult> => {
+  if (
+    input.windows.length === 0 ||
+    input.windows.some(
+      ({ sinceAt, untilAt }) =>
+        Number.isNaN(sinceAt.getTime()) ||
+        Number.isNaN(untilAt.getTime()) ||
+        sinceAt > untilAt
+    )
+  ) {
+    throw new RangeError("The GitHub backfill windows are invalid.");
+  }
+  const windowIdentities = input.windows.map(({ sinceAt, untilAt }) =>
+    [sinceAt.toISOString(), untilAt.toISOString()].join("\0")
+  );
+  if (new Set(windowIdentities).size !== windowIdentities.length) {
+    throw new RangeError("The GitHub backfill windows are duplicated.");
+  }
+
+  const refsByHead = new Map<string, GitHubRepositoryRefSnapshot>();
+  for (const ref of input.refs) {
+    const existing = refsByHead.get(ref.headSha);
+    if (existing === undefined || ref.refName < existing.refName) {
+      refsByHead.set(ref.headSha, ref);
+    }
+  }
+  const refs = [...refsByHead.values()].toSorted((left, right) =>
+    left.refName < right.refName ? -1 : left.refName > right.refName ? 1 : 0
+  );
+  const rows = refs.flatMap((ref) =>
+    input.windows.map(({ sinceAt, untilAt }) => ({
+      account: input.account,
+      afterSha: ref.headSha,
+      beforeSha: ZERO_SHA,
+      expectedCommitCount: null,
+      historySinceAt: sinceAt,
+      historyUntilAt: untilAt,
+      observedAt: input.observedAt,
+      providerCreatedAt: null,
+      refName: ref.refName,
+      repositoryId: input.repository.id,
+      repositoryNameSnapshot: input.repository.fullName,
+      source: "backfill" as const,
+      sourceId: backfillObservationSourceId({
+        afterSha: ref.headSha,
+        repositoryId: input.repository.id,
+        sinceAt,
+        untilAt,
+      }),
+      state: "pending" as const,
+    }))
+  );
+
+  return await getDatabase().transaction(async (transaction) => {
+    await transaction
+      .insert(githubAccountCheckpoints)
+      .values({ account: input.account })
+      .onConflictDoNothing({ target: githubAccountCheckpoints.account });
+    await upsertRepository(transaction, input.repository, input.observedAt);
+
+    let queued = 0;
+    for (
+      let offset = 0;
+      offset < rows.length;
+      offset += BACKFILL_OBSERVATION_INSERT_BATCH
+    ) {
+      const persisted = await transaction
+        .insert(githubPushObservations)
+        .values(rows.slice(offset, offset + BACKFILL_OBSERVATION_INSERT_BATCH))
+        .onConflictDoUpdate({
+          set: {
+            completedAt: null,
+            errorCode: null,
+            leaseToken: null,
+            leaseUntil: null,
+            observedAt: input.observedAt,
+            state: "pending",
+          },
+          setWhere: and(
+            eq(githubPushObservations.source, "backfill"),
+            inArray(githubPushObservations.state, ["deferred", "unavailable"])
+          ),
+          target: [
+            githubPushObservations.source,
+            githubPushObservations.sourceId,
+          ],
+        })
+        .returning({ id: githubPushObservations.id });
+      queued += persisted.length;
+    }
+
+    return {
+      duplicates: rows.length - queued,
+      observations: queued,
+      refs: refs.length,
+    };
+  });
+};
 
 export const persistGitHubRepositoryRefs = async (input: {
   account: TrackedGitHubAccount;

--- a/src/lib/github-commits.ts
+++ b/src/lib/github-commits.ts
@@ -1,5 +1,6 @@
 import { DatabaseConfigurationError, isDatabaseConfigured } from "@/db/client";
 import { fetchGitHub, githubApiUrl, nextGitHubPage } from "@/lib/github-api";
+import type { GitHubBackfillRequest } from "@/lib/github-backfill-core";
 import {
   authenticatedGitHubAccountFrom,
   githubEventFrom,
@@ -17,6 +18,7 @@ import {
 } from "@/lib/github-commits-store";
 import {
   hydrateSparseGitHubPullRequestEvents,
+  queueAccessibleGitHubHistoryBackfill,
   reconcileAccessibleGitHubRepositoryRefs,
 } from "@/lib/github-reconciliation";
 
@@ -56,6 +58,19 @@ export interface GitHubSyncResult {
   paused: number;
   pullRequests: number;
   pushes: number;
+  refs: number;
+  repositories: number;
+}
+
+export interface GitHubBackfillResult {
+  accounts: number;
+  duplicates: number;
+  failedAccounts: readonly {
+    account: TrackedGitHubAccount;
+    error: string;
+  }[];
+  observations: number;
+  paused: number;
   refs: number;
   repositories: number;
 }
@@ -281,6 +296,68 @@ export const syncGitHubAccounts = async (): Promise<GitHubSyncResult> => {
       0
     ),
     pushes: results.reduce((total, result) => total + result.pushes, 0),
+    refs: results.reduce((total, result) => total + result.refs, 0),
+    repositories: results.reduce(
+      (total, result) => total + result.repositories,
+      0
+    ),
+  };
+};
+
+export const queueGitHubBackfill = async (
+  request: GitHubBackfillRequest
+): Promise<GitHubBackfillResult> => {
+  if (!isDatabaseConfigured()) {
+    throw new DatabaseConfigurationError();
+  }
+  const settled = await Promise.allSettled(
+    request.accounts.map(async (account) => {
+      const checkpoint = await readGitHubAccountCheckpoint(account);
+      if (isGitHubAccountPaused(checkpoint)) {
+        return { account, paused: true as const, result: null };
+      }
+      const token = tokenFor(account);
+      await assertTokenIdentity(account, token);
+      return {
+        account,
+        paused: false as const,
+        result: await queueAccessibleGitHubHistoryBackfill({
+          account,
+          repositoryId: request.repositoryId,
+          token,
+          windows: request.windows,
+        }),
+      };
+    })
+  );
+  const succeeded = settled.flatMap((outcome) =>
+    outcome.status === "fulfilled" ? [outcome.value] : []
+  );
+  const failedAccounts = settled.flatMap((outcome, index) =>
+    outcome.status === "fulfilled"
+      ? []
+      : [
+          {
+            account: request.accounts[index],
+            error:
+              outcome.reason instanceof Error
+                ? outcome.reason.name.slice(0, 80)
+                : "UnknownError",
+          },
+        ]
+  );
+  const results = succeeded.flatMap(({ result }) =>
+    result === null ? [] : [result]
+  );
+  return {
+    accounts: results.length,
+    duplicates: results.reduce((total, result) => total + result.duplicates, 0),
+    failedAccounts,
+    observations: results.reduce(
+      (total, result) => total + result.observations,
+      0
+    ),
+    paused: succeeded.filter(({ paused }) => paused).length,
     refs: results.reduce((total, result) => total + result.refs, 0),
     repositories: results.reduce(
       (total, result) => total + result.repositories,

--- a/src/lib/github-commits.ts
+++ b/src/lib/github-commits.ts
@@ -1,4 +1,5 @@
 import { DatabaseConfigurationError, isDatabaseConfigured } from "@/db/client";
+import { env } from "@/env";
 import { fetchGitHub, githubApiUrl, nextGitHubPage } from "@/lib/github-api";
 import type { GitHubBackfillRequest } from "@/lib/github-backfill-core";
 import {
@@ -84,7 +85,7 @@ export class GitHubSyncConfigurationError extends Error {
 
 const tokenFor = (account: TrackedGitHubAccount) => {
   const variable = ACCOUNT_TOKEN_VARIABLES[account];
-  const token = process.env[variable]?.trim();
+  const token = env[variable]?.trim();
   if (token === undefined || token.length === 0) {
     throw new GitHubSyncConfigurationError(variable);
   }

--- a/src/lib/github-reconciliation.ts
+++ b/src/lib/github-reconciliation.ts
@@ -15,11 +15,18 @@ import type {
   GitHubRepositoryFacts,
   TrackedGitHubAccount,
 } from "@/lib/github-commits-core";
-import { persistGitHubRepositoryRefs } from "@/lib/github-commits-store";
-import type { GitHubRepositoryRefSnapshot } from "@/lib/github-commits-store";
+import {
+  persistGitHubRepositoryBackfill,
+  persistGitHubRepositoryRefs,
+} from "@/lib/github-commits-store";
+import type {
+  GitHubBackfillWindow,
+  GitHubRepositoryRefSnapshot,
+} from "@/lib/github-commits-store";
 
 const GITHUB_PAGE_SIZE = 100;
 const GITHUB_REQUEST_CONCURRENCY = 4;
+const MAXIMUM_BACKFILL_OBSERVATIONS = 5000;
 
 type JsonObject = Record<string, unknown>;
 
@@ -80,7 +87,21 @@ const fetchPaginatedArray = async (initialUrl: URL, token: string) => {
   return values;
 };
 
-export const collectAccessibleGitHubRepositories = async (token: string) => {
+export const collectAccessibleGitHubRepositories = async (
+  token: string,
+  repositoryId: string | null = null
+) => {
+  if (repositoryId !== null) {
+    const { payload } = await fetchJson(
+      githubApiUrl(`/repositories/${encodeURIComponent(repositoryId)}`),
+      token
+    );
+    const facts = repositoryFactsFrom(payload);
+    if (facts === null) {
+      throw new TypeError("GitHub returned an invalid repository response.");
+    }
+    return [facts];
+  }
   const url = githubApiUrl("/user/repos");
   url.searchParams.set("affiliation", "owner,collaborator,organization_member");
   url.searchParams.set("direction", "asc");
@@ -300,6 +321,70 @@ export interface GitHubRefReconciliationResult {
   refs: number;
   repositories: number;
 }
+
+export interface GitHubHistoryBackfillResult {
+  duplicates: number;
+  observations: number;
+  refs: number;
+  repositories: number;
+}
+
+export const queueAccessibleGitHubHistoryBackfill = async (input: {
+  account: TrackedGitHubAccount;
+  repositoryId: string | null;
+  token: string;
+  windows: readonly GitHubBackfillWindow[];
+}): Promise<GitHubHistoryBackfillResult> => {
+  const repositories = await collectAccessibleGitHubRepositories(
+    input.token,
+    input.repositoryId
+  );
+  const collected = await mapWithConcurrency(
+    repositories,
+    async (repository) => ({
+      refs: await collectGitHubRepositoryRefs(repository, input.token),
+      repository,
+    })
+  );
+  const accessible = collected.flatMap(({ refs, repository }) =>
+    refs === null ? [] : [{ refs, repository }]
+  );
+  let observationCount = 0;
+  for (const { refs } of accessible) {
+    observationCount +=
+      new Set(refs.map(({ headSha }) => headSha)).size * input.windows.length;
+  }
+  if (observationCount > MAXIMUM_BACKFILL_OBSERVATIONS) {
+    throw new RangeError(
+      "The GitHub backfill would create too many durable observations."
+    );
+  }
+
+  const persisted = await mapWithConcurrency(
+    accessible,
+    async ({ refs, repository }) =>
+      await persistGitHubRepositoryBackfill({
+        account: input.account,
+        observedAt: new Date(),
+        refs,
+        repository,
+        windows: input.windows,
+      })
+  );
+  const result: GitHubHistoryBackfillResult = {
+    duplicates: 0,
+    observations: 0,
+    refs: 0,
+    repositories: 0,
+  };
+  for (const repository of persisted) {
+    result.duplicates += repository.duplicates;
+    result.observations += repository.observations;
+    result.refs += repository.refs;
+    result.repositories += 1;
+  }
+  return result;
+};
 
 export const reconcileAccessibleGitHubRepositoryRefs = async (
   account: TrackedGitHubAccount,

--- a/src/lib/remark-embed-github.mjs
+++ b/src/lib/remark-embed-github.mjs
@@ -3,6 +3,8 @@ import { Buffer } from "node:buffer";
 import remarkEmbedderModule from "@remark-embedder/core";
 import { codeToHtml } from "shiki";
 
+import { env } from "../env.ts";
+
 function resolveDefaultExport(value) {
   if (typeof value === "function") {
     return value;
@@ -454,7 +456,7 @@ async function fetchGitHubResource(parsed) {
             .map((segment) => encodeURIComponent(segment))
             .join("/")}?ref=${encodeURIComponent(parsed.commit)}`
         : `repos/${encodeURIComponent(parsed.owner)}/${encodeURIComponent(parsed.repo)}`;
-  const token = process.env.GITHUB_TOKEN ?? process.env.GH_TOKEN;
+  const token = env.GITHUB_TOKEN ?? env.GH_TOKEN;
   const headers = {
     Accept: "application/vnd.github+json",
     "X-GitHub-Api-Version": GITHUB_API_VERSION,

--- a/tests/github-activity-feed-postgres.test.mjs
+++ b/tests/github-activity-feed-postgres.test.mjs
@@ -80,6 +80,7 @@ describe.skipIf(!dockerAvailable)(
     let originalCronSecret;
     let originalDatabaseUrl;
     let persistAccountIntake;
+    let persistGitHubRepositoryBackfill;
     let persistGitHubRepositoryRefs;
     let readPublicGitHubActivityPage;
 
@@ -159,8 +160,11 @@ describe.skipIf(!dockerAvailable)(
         ensureGitHubSummaryAttempt,
         ensureMissingGitHubSummaryAttempts,
       } = await import("../src/lib/github-activity-worker-store.ts"));
-      ({ persistAccountIntake, persistGitHubRepositoryRefs } =
-        await import("../src/lib/github-commits-store.ts"));
+      ({
+        persistAccountIntake,
+        persistGitHubRepositoryBackfill,
+        persistGitHubRepositoryRefs,
+      } = await import("../src/lib/github-commits-store.ts"));
     });
 
     afterAll(async () => {
@@ -259,6 +263,91 @@ describe.skipIf(!dockerAvailable)(
           source: "refs",
         },
       ]);
+    });
+
+    test("queues idempotent bounded backfill observations per distinct ref head", async () => {
+      const headSha = "8".repeat(40);
+      const repository = {
+        fullName: "example-org/backfill-checkpoints",
+        htmlUrl: "https://github.com/example-org/backfill-checkpoints",
+        id: "405",
+        ownerAvatarUrl: null,
+        ownerId: "202",
+        ownerLogin: "example-org",
+        ownerType: "Organization",
+        visibility: "private",
+      };
+      const input = {
+        account: "f0rr0",
+        observedAt: new Date("2026-08-29T11:00:00.000Z"),
+        refs: [
+          { headSha, kind: "head", refName: "refs/heads/main" },
+          { headSha, kind: "tag", refName: "refs/tags/v1" },
+        ],
+        repository,
+        windows: [
+          {
+            sinceAt: new Date("2026-07-01T00:00:00.000Z"),
+            untilAt: new Date("2026-07-31T23:59:59.999Z"),
+          },
+          {
+            sinceAt: new Date("2026-08-01T00:00:00.000Z"),
+            untilAt: new Date("2026-08-29T23:59:59.999Z"),
+          },
+        ],
+      };
+
+      try {
+        expect(await persistGitHubRepositoryBackfill(input)).toEqual({
+          duplicates: 0,
+          observations: 2,
+          refs: 1,
+        });
+        expect(await persistGitHubRepositoryBackfill(input)).toEqual({
+          duplicates: 2,
+          observations: 0,
+          refs: 1,
+        });
+        const observations = await admin`
+        select before_sha, history_since_at, history_until_at, ref_name, source
+        from github_push_observations
+        where repository_id = '405'
+        order by history_since_at
+      `;
+        expect(observations).toEqual([
+          {
+            before_sha: "0".repeat(40),
+            history_since_at: "2026-07-01 00:00:00+00",
+            history_until_at: "2026-07-31 23:59:59.999+00",
+            ref_name: "refs/heads/main",
+            source: "backfill",
+          },
+          {
+            before_sha: "0".repeat(40),
+            history_since_at: "2026-08-01 00:00:00+00",
+            history_until_at: "2026-08-29 23:59:59.999+00",
+            ref_name: "refs/heads/main",
+            source: "backfill",
+          },
+        ]);
+
+        await admin`
+        update github_push_observations
+        set state = 'unavailable'
+        where repository_id = '405'
+          and history_since_at = '2026-07-01T00:00:00.000Z'
+      `;
+        expect(
+          await persistGitHubRepositoryBackfill({
+            ...input,
+            observedAt: new Date("2026-08-29T12:00:00.000Z"),
+          })
+        ).toEqual({ duplicates: 1, observations: 1, refs: 1 });
+      } finally {
+        await admin`delete from github_push_observations where repository_id = '405'`;
+        await admin`delete from github_repositories where id = '405'`;
+        await admin`delete from github_account_checkpoints where account = 'f0rr0'`;
+      }
     });
 
     test("pages complete UTC days and projects only current complete PR membership", async () => {

--- a/tests/github-activity-feed-postgres.test.mjs
+++ b/tests/github-activity-feed-postgres.test.mjs
@@ -12,6 +12,8 @@ import { drizzle } from "drizzle-orm/postgres-js";
 import { migrate } from "drizzle-orm/postgres-js/migrator";
 import postgres from "postgres";
 
+import { env } from "../src/env.ts";
+
 setDefaultTimeout(30_000);
 
 const dockerAvailable =
@@ -85,8 +87,8 @@ describe.skipIf(!dockerAvailable)(
     let readPublicGitHubActivityPage;
 
     beforeAll(async () => {
-      originalCronSecret = process.env.CRON_SECRET;
-      originalDatabaseUrl = process.env.DATABASE_URL;
+      originalCronSecret = env.CRON_SECRET;
+      originalDatabaseUrl = env.DATABASE_URL;
       const started = Bun.spawnSync([
         "docker",
         "run",
@@ -146,8 +148,8 @@ describe.skipIf(!dockerAvailable)(
       });
       await migrate(drizzle({ client: admin }), { migrationsFolder });
 
-      process.env.CRON_SECRET = "github-activity-cursor-test-secret";
-      process.env.DATABASE_URL = databaseUrl;
+      env.CRON_SECRET = "github-activity-cursor-test-secret";
+      env.DATABASE_URL = databaseUrl;
       ({ closeDatabase } = await import("../src/db/client.ts"));
       ({ readPublicGitHubActivityPage } =
         await import("../src/lib/github-activity-store.ts"));
@@ -171,14 +173,14 @@ describe.skipIf(!dockerAvailable)(
       await closeDatabase?.();
       await admin?.end({ timeout: 1 });
       if (originalDatabaseUrl === undefined) {
-        delete process.env.DATABASE_URL;
+        delete env.DATABASE_URL;
       } else {
-        process.env.DATABASE_URL = originalDatabaseUrl;
+        env.DATABASE_URL = originalDatabaseUrl;
       }
       if (originalCronSecret === undefined) {
-        delete process.env.CRON_SECRET;
+        delete env.CRON_SECRET;
       } else {
-        process.env.CRON_SECRET = originalCronSecret;
+        env.CRON_SECRET = originalCronSecret;
       }
       if (containerId !== undefined) {
         Bun.spawnSync(["docker", "stop", "--time", "1", containerId], {

--- a/tests/github-activity-processor.test.mjs
+++ b/tests/github-activity-processor.test.mjs
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
+import { env } from "../src/env.ts";
 import {
   fetchGitHubActivityCommitSource,
   fetchGitHubAssociatedPullRequests,
@@ -8,9 +9,9 @@ import {
 } from "../src/lib/github-activity-processor.ts";
 
 const originalFetch = globalThis.fetch;
-const originalF0rr0Token = process.env.GITHUB_F0RR0_TOKEN;
-const originalYuppiesTechDevToken = process.env.GITHUB_YUPPIESTECHDEV_TOKEN;
-const originalDefaultToken = process.env.GITHUB_TOKEN;
+const originalF0rr0Token = env.GITHUB_F0RR0_TOKEN;
+const originalYuppiesTechDevToken = env.GITHUB_YUPPIESTECHDEV_TOKEN;
+const originalDefaultToken = env.GITHUB_TOKEN;
 
 const pushCommitValue = (sha, login, id) => ({
   author: { id, login },
@@ -24,16 +25,16 @@ const pushCommitValue = (sha, login, id) => ({
 
 const restoreEnvironmentValue = (name, value) => {
   if (value === undefined) {
-    Reflect.deleteProperty(process.env, name);
+    Reflect.deleteProperty(env, name);
   } else {
-    process.env[name] = value;
+    env[name] = value;
   }
 };
 
 beforeEach(() => {
-  delete process.env.GITHUB_F0RR0_TOKEN;
-  delete process.env.GITHUB_YUPPIESTECHDEV_TOKEN;
-  delete process.env.GITHUB_TOKEN;
+  delete env.GITHUB_F0RR0_TOKEN;
+  delete env.GITHUB_YUPPIESTECHDEV_TOKEN;
+  delete env.GITHUB_TOKEN;
 });
 
 afterEach(() => {
@@ -59,7 +60,7 @@ describe("GitHub activity commit acquisition", () => {
     filenames[2] = "A.ts";
     const requestedPages = [];
 
-    process.env.GITHUB_F0RR0_TOKEN = "test-token";
+    env.GITHUB_F0RR0_TOKEN = "test-token";
     globalThis.fetch = async (input) => {
       const url =
         input instanceof Request ? new URL(input.url) : new URL(input);
@@ -133,7 +134,7 @@ describe("GitHub activity commit acquisition", () => {
     const sha = "d".repeat(40);
     const ancestryResponses = [undefined, [{ sha: "not-a-sha" }], []];
     let commitReads = 0;
-    process.env.GITHUB_F0RR0_TOKEN = "test-token";
+    env.GITHUB_F0RR0_TOKEN = "test-token";
     globalThis.fetch = async (input) => {
       const url =
         input instanceof Request ? new URL(input.url) : new URL(input);
@@ -195,7 +196,7 @@ describe("GitHub activity commit acquisition", () => {
     const trackedSha = "3".repeat(40);
     const foreignSha = "4".repeat(40);
     const afterSha = foreignSha;
-    process.env.GITHUB_F0RR0_TOKEN = "test-token";
+    env.GITHUB_F0RR0_TOKEN = "test-token";
     globalThis.fetch = async (input) => {
       const url =
         input instanceof Request ? new URL(input.url) : new URL(input);
@@ -232,7 +233,7 @@ describe("GitHub activity commit acquisition", () => {
     const firstSha = "2".repeat(40);
     const surplusSha = "3".repeat(40);
     const afterSha = "4".repeat(40);
-    process.env.GITHUB_F0RR0_TOKEN = "test-token";
+    env.GITHUB_F0RR0_TOKEN = "test-token";
     globalThis.fetch = async () =>
       Response.json({
         ahead_by: 3,
@@ -262,7 +263,7 @@ describe("GitHub activity commit acquisition", () => {
     const beforeSha = "1".repeat(40);
     const firstSha = "2".repeat(40);
     const afterSha = "3".repeat(40);
-    process.env.GITHUB_F0RR0_TOKEN = "test-token";
+    env.GITHUB_F0RR0_TOKEN = "test-token";
     globalThis.fetch = async () =>
       Response.json({
         ahead_by: 2,
@@ -291,7 +292,7 @@ describe("GitHub activity commit acquisition", () => {
     const beforeSha = "1".repeat(40);
     const foreignSha = "2".repeat(40);
     const afterSha = "3".repeat(40);
-    process.env.GITHUB_F0RR0_TOKEN = "test-token";
+    env.GITHUB_F0RR0_TOKEN = "test-token";
     globalThis.fetch = async () =>
       Response.json({
         ahead_by: 2,
@@ -333,7 +334,7 @@ describe("GitHub activity commit acquisition", () => {
   test("rejects a tracked commit without a provider timestamp", async () => {
     const beforeSha = "1".repeat(40);
     const afterSha = "2".repeat(40);
-    process.env.GITHUB_F0RR0_TOKEN = "test-token";
+    env.GITHUB_F0RR0_TOKEN = "test-token";
     globalThis.fetch = async () =>
       Response.json({
         ahead_by: 1,
@@ -364,7 +365,7 @@ describe("GitHub activity commit acquisition", () => {
   test("accepts a ref rewind with no newly reachable commits", async () => {
     const beforeSha = "1".repeat(40);
     const afterSha = "2".repeat(40);
-    process.env.GITHUB_F0RR0_TOKEN = "test-token";
+    env.GITHUB_F0RR0_TOKEN = "test-token";
     globalThis.fetch = async () => Response.json({ ahead_by: 0, commits: [] });
 
     const source = await fetchGitHubPushObservationSource({
@@ -387,7 +388,7 @@ describe("GitHub activity commit acquisition", () => {
     const olderSha = "2".repeat(40);
     const afterSha = "3".repeat(40);
     const paths = [];
-    process.env.GITHUB_F0RR0_TOKEN = "test-token";
+    env.GITHUB_F0RR0_TOKEN = "test-token";
     globalThis.fetch = async (input, init) => {
       const url =
         input instanceof Request ? new URL(input.url) : new URL(input);
@@ -449,7 +450,7 @@ describe("GitHub activity commit acquisition", () => {
   test("bounds a new branch by the observed count without slicing history", async () => {
     const olderSha = "1".repeat(40);
     const afterSha = "2".repeat(40);
-    process.env.GITHUB_F0RR0_TOKEN = "test-token";
+    env.GITHUB_F0RR0_TOKEN = "test-token";
     globalThis.fetch = async (input, init) => {
       const url =
         input instanceof Request ? new URL(input.url) : new URL(input);
@@ -509,7 +510,7 @@ describe("GitHub activity commit acquisition", () => {
     const middleSha = "2".repeat(40);
     const afterSha = "3".repeat(40);
     const cursors = [];
-    process.env.GITHUB_F0RR0_TOKEN = "test-token";
+    env.GITHUB_F0RR0_TOKEN = "test-token";
     globalThis.fetch = async (_input, init) => {
       const request = JSON.parse(init?.body);
       cursors.push(request.variables.cursor);
@@ -582,7 +583,7 @@ describe("GitHub activity commit acquisition", () => {
   test("backfills a closed date window without requiring the current ref head", async () => {
     const rangedSha = "4".repeat(40);
     const afterSha = "5".repeat(40);
-    process.env.GITHUB_F0RR0_TOKEN = "test-token";
+    env.GITHUB_F0RR0_TOKEN = "test-token";
     globalThis.fetch = async (_input, init) => {
       const request = JSON.parse(init?.body);
       expect(request.variables.since).toBe("2026-07-01T00:00:00.000Z");
@@ -628,7 +629,7 @@ describe("GitHub activity commit acquisition", () => {
 
   test("accepts a ref whose reachable history predates the boundary", async () => {
     const afterSha = "4".repeat(40);
-    process.env.GITHUB_F0RR0_TOKEN = "test-token";
+    env.GITHUB_F0RR0_TOKEN = "test-token";
     globalThis.fetch = async (_input, init) => {
       const request = JSON.parse(init?.body);
       expect(request.variables.since).toBe("2026-08-18T00:00:00.000Z");
@@ -723,7 +724,7 @@ describe("GitHub pull request acquisition", () => {
         sha: headSha,
       },
     };
-    process.env.GITHUB_F0RR0_TOKEN = "test-token";
+    env.GITHUB_F0RR0_TOKEN = "test-token";
     globalThis.fetch = async (input) => {
       const url =
         input instanceof Request ? new URL(input.url) : new URL(input);
@@ -750,8 +751,8 @@ describe("GitHub pull request acquisition", () => {
 
   test("unions associated PR visibility across both tracked identities", async () => {
     const commitSha = "8".repeat(40);
-    process.env.GITHUB_F0RR0_TOKEN = "f0-token";
-    process.env.GITHUB_YUPPIESTECHDEV_TOKEN = "yuppies-token";
+    env.GITHUB_F0RR0_TOKEN = "f0-token";
+    env.GITHUB_YUPPIESTECHDEV_TOKEN = "yuppies-token";
     let calls = 0;
     globalThis.fetch = async () => {
       calls += 1;
@@ -775,7 +776,7 @@ describe("GitHub pull request acquisition", () => {
   test("discovers associated tracked pull requests and reconciles membership", async () => {
     const commitSha = "a".repeat(40);
     const requestedPaths = [];
-    process.env.GITHUB_F0RR0_TOKEN = "test-token";
+    env.GITHUB_F0RR0_TOKEN = "test-token";
     globalThis.fetch = async (input) => {
       const url =
         input instanceof Request ? new URL(input.url) : new URL(input);
@@ -821,7 +822,7 @@ describe("GitHub pull request acquisition", () => {
   });
 
   test("falls back to GraphQL for pull requests beyond the REST cap", async () => {
-    process.env.GITHUB_F0RR0_TOKEN = "test-token";
+    env.GITHUB_F0RR0_TOKEN = "test-token";
     const graphQlCursors = [];
     globalThis.fetch = async (input, init) => {
       const url =

--- a/tests/github-activity-processor.test.mjs
+++ b/tests/github-activity-processor.test.mjs
@@ -458,6 +458,7 @@ describe("GitHub activity commit acquisition", () => {
       const request = JSON.parse(init?.body);
       expect(request.variables.pageSize).toBe(2);
       expect(request.variables.since).toBeNull();
+      expect(request.variables.until).toBeNull();
       return Response.json({
         data: {
           repository: {
@@ -514,6 +515,7 @@ describe("GitHub activity commit acquisition", () => {
       cursors.push(request.variables.cursor);
       expect(request.variables.pageSize).toBe(100);
       expect(request.variables.since).toBe("2026-08-18T00:00:00.000Z");
+      expect(request.variables.until).toBeNull();
       const secondPage = request.variables.cursor === "page-2";
       return Response.json({
         data: {
@@ -575,6 +577,53 @@ describe("GitHub activity commit acquisition", () => {
     expect(cursors).toEqual([null, "page-2"]);
     expect(source.commitShas).toEqual([olderSha, middleSha, afterSha]);
     expect(source.commits.map(({ sha }) => sha)).toEqual([middleSha, afterSha]);
+  });
+
+  test("backfills a closed date window without requiring the current ref head", async () => {
+    const rangedSha = "4".repeat(40);
+    const afterSha = "5".repeat(40);
+    process.env.GITHUB_F0RR0_TOKEN = "test-token";
+    globalThis.fetch = async (_input, init) => {
+      const request = JSON.parse(init?.body);
+      expect(request.variables.since).toBe("2026-07-01T00:00:00.000Z");
+      expect(request.variables.until).toBe("2026-07-31T23:59:59.999Z");
+      return Response.json({
+        data: {
+          repository: {
+            object: {
+              history: {
+                nodes: [
+                  {
+                    author: { user: { login: "f0rr0" } },
+                    authoredDate: "2026-07-15T12:00:00Z",
+                    message: "historical change",
+                    oid: rangedSha,
+                    url: `https://github.com/example-org/example-repo/commit/${rangedSha}`,
+                  },
+                ],
+                pageInfo: { endCursor: null, hasNextPage: false },
+              },
+            },
+          },
+        },
+      });
+    };
+
+    const source = await fetchGitHubPushObservationSource({
+      account: "f0rr0",
+      afterSha,
+      beforeSha: "0".repeat(40),
+      expectedCommitCount: null,
+      historySinceAt: new Date("2026-07-01T00:00:00.000Z"),
+      historyUntilAt: new Date("2026-07-31T23:59:59.999Z"),
+      knownShas: [],
+      observedAt: new Date("2026-08-29T12:00:00.000Z"),
+      refName: "refs/heads/main",
+      repository: "example-org/example-repo",
+      repositoryId: "123",
+    });
+    expect(source.commitShas).toEqual([rangedSha]);
+    expect(source.commits.map(({ sha }) => sha)).toEqual([rangedSha]);
   });
 
   test("accepts a ref whose reachable history predates the boundary", async () => {

--- a/tests/github-activity-schema.test.mjs
+++ b/tests/github-activity-schema.test.mjs
@@ -69,6 +69,15 @@ describe("GitHub activity persistence schema", () => {
       ])
     );
     expect(githubPushObservations.state.default).toBe("pending");
+    expect(githubPushObservations.historySinceAt.notNull).toBe(false);
+    expect(githubPushObservations.historyUntilAt.notNull).toBe(false);
+    expect(checkNames(githubPushObservations)).toContain(
+      "github_push_observations_history_bounds"
+    );
+    const pushIdentity = config(githubPushObservations).indexes.find(
+      (item) => item.config.name === "github_push_observations_push_unique"
+    );
+    expect(pushIdentity?.config.where).toBeDefined();
     expect(getTableName(githubRepositoryRefs)).toBe("github_repository_refs");
     expect(githubRepositoryRefs.active.default).toBe(true);
     expect(indexNames(githubRepositoryRefs)).toContain(

--- a/tests/github-activity-worker.test.mjs
+++ b/tests/github-activity-worker.test.mjs
@@ -2,11 +2,12 @@ import { describe, expect, test } from "bun:test";
 
 import {
   boundedWorkerLimit,
+  DEFAULT_GITHUB_ACTIVITY_WORKER_BATCH_SIZE,
   exactGitHubDiffDigest,
   githubCommitActivityOccurredAt,
   githubPullRequestSnapshotDisposition,
   githubPrReconciliationCutoff,
-  githubPrReconciliationMaximumAgeDays,
+  GITHUB_PR_RECONCILIATION_MAX_AGE_DAYS,
   githubSummaryCanPublish,
   GITHUB_EXACT_DIFF_DIGEST_RECIPE,
   nextGitHubPullRequestReconciliationAt,
@@ -131,7 +132,8 @@ describe("GitHub exact diff digest", () => {
 
 describe("GitHub activity worker bounds", () => {
   test("accepts only deliberately small batches", () => {
-    expect(boundedWorkerLimit()).toBe(2);
+    expect(DEFAULT_GITHUB_ACTIVITY_WORKER_BATCH_SIZE).toBe(4);
+    expect(boundedWorkerLimit()).toBe(4);
     expect(boundedWorkerLimit(8)).toBe(8);
     expect(() => boundedWorkerLimit(0)).toThrow("batch size");
     expect(() => boundedWorkerLimit(9)).toThrow("batch size");
@@ -161,21 +163,8 @@ describe("GitHub activity worker bounds", () => {
     ).toBe("2026-08-28T15:00:00.000Z");
   });
 
-  test("parses the bounded PR reconciliation horizon", () => {
-    expect(githubPrReconciliationMaximumAgeDays()).toBe(30);
-    expect(githubPrReconciliationMaximumAgeDays(" 45 ")).toBe(45);
-    expect(githubPrReconciliationMaximumAgeDays("infinity")).toBe(
-      Number.POSITIVE_INFINITY
-    );
-    expect(githubPrReconciliationMaximumAgeDays(" Infinity ")).toBe(
-      Number.POSITIVE_INFINITY
-    );
-    expect(() => githubPrReconciliationMaximumAgeDays("0")).toThrow(
-      "positive integer"
-    );
-    expect(() => githubPrReconciliationMaximumAgeDays("all")).toThrow(
-      "positive integer"
-    );
+  test("applies the bounded PR reconciliation horizon", () => {
+    expect(GITHUB_PR_RECONCILIATION_MAX_AGE_DAYS).toBe(30);
     const now = new Date("2026-08-28T12:00:00.000Z");
     expect(githubPrReconciliationCutoff(30, now)?.toISOString()).toBe(
       "2026-07-29T12:00:00.000Z"

--- a/tests/github-activity-worker.test.mjs
+++ b/tests/github-activity-worker.test.mjs
@@ -10,6 +10,7 @@ import {
   githubSummaryCanPublish,
   GITHUB_EXACT_DIFF_DIGEST_RECIPE,
   nextGitHubPullRequestReconciliationAt,
+  workerBatchSizeFrom,
   workerDeadlineReached,
 } from "../src/lib/github-activity-worker-core.ts";
 
@@ -134,6 +135,10 @@ describe("GitHub activity worker bounds", () => {
     expect(boundedWorkerLimit(8)).toBe(8);
     expect(() => boundedWorkerLimit(0)).toThrow("batch size");
     expect(() => boundedWorkerLimit(9)).toThrow("batch size");
+    expect(workerBatchSizeFrom(null)).toBeUndefined();
+    expect(workerBatchSizeFrom("8")).toBe(8);
+    expect(workerBatchSizeFrom("0")).toBeNull();
+    expect(workerBatchSizeFrom("08")).toBeNull();
   });
 
   test("uses a deterministic wall-clock deadline", () => {

--- a/tests/github-backfill.test.mjs
+++ b/tests/github-backfill.test.mjs
@@ -1,0 +1,96 @@
+import { describe, expect, test } from "bun:test";
+
+import { githubBackfillRequestFrom } from "../src/lib/github-backfill-core.ts";
+
+const now = new Date("2026-08-29T15:00:00.000Z");
+
+describe("GitHub history backfill requests", () => {
+  test("normalizes inclusive UTC dates into bounded 31-day windows", () => {
+    const request = githubBackfillRequestFrom(
+      {
+        account: "all",
+        endDate: "2026-08-29",
+        repositoryId: "123456789",
+        startDate: "2026-07-01",
+      },
+      now
+    );
+
+    expect(request).toMatchObject({
+      accounts: ["f0rr0", "yuppiestechdev"],
+      endDate: "2026-08-29",
+      repositoryId: "123456789",
+      startDate: "2026-07-01",
+    });
+    expect(request?.windows).toEqual([
+      {
+        sinceAt: new Date("2026-07-01T00:00:00.000Z"),
+        untilAt: new Date("2026-07-31T23:59:59.999Z"),
+      },
+      {
+        sinceAt: new Date("2026-08-01T00:00:00.000Z"),
+        untilAt: new Date("2026-08-29T23:59:59.999Z"),
+      },
+    ]);
+  });
+
+  test("accepts one account and an unfiltered repository set", () => {
+    expect(
+      githubBackfillRequestFrom(
+        {
+          account: "f0rr0",
+          endDate: "2026-08-29",
+          repositoryId: "",
+          startDate: "2026-08-29",
+        },
+        now
+      )
+    ).toMatchObject({ accounts: ["f0rr0"], repositoryId: null });
+  });
+
+  test("rejects malformed, future, reversed, and oversized ranges", () => {
+    const requests = [
+      { endDate: "2026-08-29", startDate: "2026-08-30" },
+      { endDate: "2026-08-30", startDate: "2026-08-29" },
+      { endDate: "2026-08-29", startDate: "2025-08-28" },
+      { endDate: "2026-02-30", startDate: "2026-02-01" },
+    ];
+    for (const request of requests) {
+      expect(
+        githubBackfillRequestFrom(
+          {
+            account: "f0rr0",
+            repositoryId: "",
+            ...request,
+          },
+          now
+        )
+      ).toBeNull();
+    }
+  });
+
+  test("rejects unknown accounts and unsafe repository selectors", () => {
+    expect(
+      githubBackfillRequestFrom(
+        {
+          account: "octocat",
+          endDate: "2026-08-29",
+          repositoryId: "123",
+          startDate: "2026-08-01",
+        },
+        now
+      )
+    ).toBeNull();
+    expect(
+      githubBackfillRequestFrom(
+        {
+          account: "f0rr0",
+          endDate: "2026-08-29",
+          repositoryId: "private/repository",
+          startDate: "2026-08-01",
+        },
+        now
+      )
+    ).toBeNull();
+  });
+});

--- a/tests/github-reconciliation.test.mjs
+++ b/tests/github-reconciliation.test.mjs
@@ -56,6 +56,19 @@ describe("GitHub repository reconciliation", () => {
     ]);
   });
 
+  test("fetches one opaque repository ID without enumerating affiliations", async () => {
+    globalThis.fetch = async (input) => {
+      const url =
+        input instanceof Request ? new URL(input.url) : new URL(input);
+      expect(url.pathname).toBe("/repositories/123");
+      return Response.json(repository);
+    };
+
+    expect(await collectAccessibleGitHubRepositories("token", "123")).toEqual([
+      repositoryFacts,
+    ]);
+  });
+
   test("enumerates heads and peels annotated tags to commit SHAs", async () => {
     const headSha = "a".repeat(40);
     const tagSha = "b".repeat(40);


### PR DESCRIPTION
## Summary

- add a manually dispatched `Backfill GitHub activity` Action with inclusive UTC start/end dates, credential selection, optional opaque repository ID, and configurable immediate worker passes
- queue durable, idempotent closed Git history windows through a dedicated authenticated production endpoint
- teach commit history acquisition to use GraphQL `history(since:, until:)` without requiring a historical page to end at the repository current head
- split large requests into 31-day windows, collapse refs sharing a head, batch database writes and worker processing, and cap one dispatch at 366 days / 5,000 observations
- add migration 0010 for observation-specific history bounds and keep automatic production migration delivery through Vercel
- centralize application, Drizzle, and maintenance-script configuration in the existing T3 Env schema
- tune the routine worker batch from 2 to 4 while retaining the backfill batch of 8, the 90-second worker deadline, and the shared 120-second Supabase Cron request bound
- make the 30-day open-PR reconciliation horizon a reviewed code policy instead of an environment variable

## Security and operations

- the Action receives no database URL and no GitHub account tokens
- it uses only the dedicated `ACTIVITY_BACKFILL_SECRET`, already mirrored to production as `GITHUB_BACKFILL_SECRET`
- targeted private repositories use a numeric repository ID so their names do not appear in public workflow inputs or summaries
- rerunning a completed range is a no-op; deferred or unavailable observations are requeued
- the normal five-minute worker completes any work left after the selected immediate passes
- environment variables are limited to secrets, connection URLs, and platform-provided deployment values; schedules, batches, windows, retry counts, and provider ceilings stay in code

## Validation

- 126 tests passing, including PostgreSQL migration/persistence coverage
- `bun run typecheck`
- `bun run lint`
- `bunx drizzle-kit check`
- `actionlint`
- production `bun run build`
- authenticated GitHub GraphQL proof that a closed `since`/`until` window returns historical commits without requiring the current ref head