### PR TITLE
docs(config): clarify environment and backfill inputs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,9 +1,12 @@
-# Supabase Transaction Pooler URL at runtime and its direct URL for migrations
-# and cron configuration.
+# Copy this file to .env.local for local work. Platform-provided variables and
+# compatibility aliases are intentionally omitted.
+
+# Supabase transaction-pooler URL at runtime and a non-transaction-pooled URL
+# for migrations and cron configuration.
 DATABASE_URL=
 DATABASE_URL_UNPOOLED=
 
-# Optional default token for the public portfolio repository list.
+# Optional fallback for public repository discovery and pinned GitHub embeds.
 GITHUB_TOKEN=
 
 # Account-specific tokens used to read each authenticated user event feed and
@@ -11,14 +14,20 @@ GITHUB_TOKEN=
 GITHUB_F0RR0_TOKEN=
 GITHUB_YUPPIESTECHDEV_TOKEN=
 
-# Shared by Supabase Cron and the Vercel polling function. Use 32+ random
-# characters. The webhook secret is configured on the GitHub App.
+# Authenticates Supabase Cron requests and signs activity pagination cursors.
+# Use at least 32 random characters.
 CRON_SECRET=
+
+# Authenticates manual backfills dispatched by GitHub Actions. Use at least 32
+# random characters and mirror it to the repository Action secret.
 GITHUB_BACKFILL_SECRET=
+
+# Verifies GitHub webhook signatures. Use at least 32 random characters and
+# configure the same value on the webhook sender.
 GITHUB_WEBHOOK_SECRET=
 
-# Per-commit public summary generation uses the existing direct OpenAI key.
+# Generates per-commit public summaries in the activity worker.
 OPENAI_API_KEY=
 
-# Production Vercel origin used by the Supabase cron setup script.
+# Canonical production origin, also used by the Supabase cron setup script.
 SITE_URL=https://f0rr0.dev


### PR DESCRIPTION
## Summary

- reconcile `.env.example` with the typed environment schema and current runtime/script consumers
- distinguish cron, manual-backfill, and webhook secrets by their actual responsibilities
- document intentional omission of platform-provided variables and compatibility aliases
- keep the canonical key set identical to the local `.env.local` template
- clarify that the backfill start and end dates are both included and that the entire range may contain at most 366 calendar days

## Validation

- `.env.example` and `.env.local` canonical key sets match
- `actionlint .github/workflows/github-activity-backfill.yml`
- `bun run format:check`
- `git diff --check`