### PR TITLE
feat(github): harden activity ingestion

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,8 +22,6 @@ CRON_SECRET=
 # configure the same value on the webhook sender.
 GITHUB_WEBHOOK_SECRET=
 
-# Generates per-commit public summaries in the activity worker.
+# Optional. Generates richer public-repository summaries. Private commits,
+# missing credentials, and provider failures use a deterministic local summary.
 OPENAI_API_KEY=
-
-# Canonical production origin, also used by the Supabase cron setup script.
-SITE_URL=https://f0rr0.dev

--- a/.github/workflows/github-activity-backfill.yml
+++ b/.github/workflows/github-activity-backfill.yml
@@ -4,15 +4,15 @@ on:
   workflow_dispatch:
     inputs:
       start_date:
-        description: Oldest commit date to include (YYYY-MM-DD)
+        description: Start date — earliest UTC day included (YYYY-MM-DD)
         required: true
         type: string
       end_date:
-        description: Newest commit date to include (YYYY-MM-DD)
+        description: End date — latest UTC day included, not in future (YYYY-MM-DD)
         required: true
         type: string
       account:
-        description: Credential used to discover accessible repositories
+        description: Account whose token and accessible repositories are scanned
         required: true
         default: f0rr0
         type: choice
@@ -21,11 +21,11 @@ on:
           - yuppiestechdev
           - all
       repository_id:
-        description: Optional numeric repository ID; blank scans all accessible repositories
+        description: Numeric repository ID to scan; blank scans every accessible repository
         required: false
         type: string
       maximum_minutes:
-        description: Maximum run time, including queueing and processing (1-330 minutes)
+        description: Discovery/processing budget; durable work can continue (1-330 min)
         required: true
         default: 300
         type: number
@@ -39,20 +39,20 @@ permissions:
 
 jobs:
   backfill:
-    name: Queue and process backfill
+    name: Discover and process backfill
     runs-on: ubuntu-latest
     timeout-minutes: 350
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Setup mise
-        uses: jdx/mise-action@v4
+        uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
-      - name: Queue and process GitHub history
+      - name: Discover history and process shared work
         env:
           ACCOUNT: ${{ inputs.account }}
           DATABASE_URL: ${{ secrets.ACTIVITY_DATABASE_URL }}

--- a/.github/workflows/github-evidence-recovery.yml
+++ b/.github/workflows/github-evidence-recovery.yml
@@ -1,0 +1,49 @@
+name: Repair GitHub evidence
+
+on:
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: Preview is read-only; apply performs the versioned repair
+        required: true
+        default: preview
+        type: choice
+        options:
+          - preview
+          - apply
+      confirmation:
+        description: For apply, enter REPAIR_GITHUB_EVIDENCE_V1 exactly
+        required: false
+        type: string
+
+concurrency:
+  group: github-evidence-recovery
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  recover:
+    name: Preview or repair durable evidence
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+
+      - name: Setup mise
+        uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Run evidence recovery
+        env:
+          CONFIRMATION: ${{ inputs.confirmation }}
+          DATABASE_URL: ${{ secrets.ACTIVITY_DATABASE_URL }}
+          MODE: ${{ inputs.mode }}
+        run: >-
+          bun scripts/repair-github-evidence.ts
+          --mode "$MODE"
+          --confirm "$CONFIRMATION"

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -9,10 +9,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Setup mise
-        uses: jdx/mise-action@v4
+        uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4
 
       - name: Install dependencies
         run: bun install --frozen-lockfile

--- a/docs/github-activity-public-commit-summaries.md
+++ b/docs/github-activity-public-commit-summaries.md
@@ -5,7 +5,7 @@
 Generate and persist public prose per canonical commit. Organize commits under
 pull requests only when GitHub supplies deterministic membership; do not infer
 work-item groups with an LLM. PR grouping changes the timeline projection, not
-the unit sent to Nano or the identity of the stored source activity.
+the unit summarized or the identity of the stored source activity.
 
 ## Per-commit processing
 
@@ -15,14 +15,18 @@ verified tracked-author non-merge commit
   -> read commit-wide and per-file additions/deletions from GitHub
   -> derive languages and substantive churn from the per-file counters
   -> discover GitHub PR membership and suppress exact-evidence integration copies
-  -> one gpt-5-nano call producing both public summary lengths
+  -> for public repositories, one gpt-5-nano call when configured
+  -> otherwise, or on model failure, a deterministic commit-message summary
   -> persist one revision-scoped attempt, both summaries, recipe/model/input
      hash, languages, and churn
   -> always show the headline; add short for higher-churn commits
 ```
 
-The model runs once per commit with no retry and `store: false`. The generic
-prompt asks for two plain-text values in one response:
+Private commit evidence never leaves the application. Those commits always use
+the deterministic first-line summary. For a public repository with
+`OPENAI_API_KEY` configured, the model runs once per commit with no retry and
+`store: false`. The generic prompt asks for two plain-text values in one
+response:
 
 - `HEADLINE`: a compact, action-led headline containing the main outcome and
   enough natural project context to stand alone.
@@ -46,13 +50,13 @@ not asked to infer languages.
 
 ## Model context and output
 
-The pipeline starts with the repository and commit evidence that the
-authenticated GitHub fetch path returns. Repository evidence includes its
-owner, full name, visibility, ownership relationship, description, homepage,
-topics, and avatar URL. Commit evidence includes the complete commit message,
-time, SHA, parents, aggregate statistics, every returned file's metadata, and
-every patch string GitHub returns. A missing GitHub patch is represented as
-unavailable.
+For eligible public repositories, the model pipeline starts with the repository
+and commit evidence that the authenticated GitHub fetch path returns.
+Repository evidence includes its owner, full name, visibility, ownership
+relationship, description, homepage, topics, and avatar URL. Commit evidence
+includes the complete commit message, time, SHA, parents, aggregate statistics,
+every returned file's metadata, and every patch string GitHub returns. A
+missing GitHub patch is represented as unavailable.
 
 The completed request is measured locally with Nano's model-specific tokenizer.
 Ordinary requests through 240,000 input tokens keep all evidence unabridged in
@@ -139,16 +143,16 @@ which manages multi-turn state rather than a single commit diff.
 There is no content disclosure validator, privacy-term filter, word-count
 rejection, response-length rejection, or display truncation. The response must
 contain non-empty `HEADLINE` and `SHORT` labels in the requested order; malformed
-protocol text fails instead of being copied into both public fields. Once parsed,
-both values—including a multiline `SHORT`—are stored and displayed in full. The
-deterministic final pass only adds missing Markdown
-backticks to unmistakable code references and capitalizes the first headline
-character; it does not remove text.
+protocol text selects the deterministic fallback instead of copying arbitrary
+text into both public fields. Once parsed, both values—including a multiline
+`SHORT`—are stored and displayed in full. The deterministic final pass only
+adds missing Markdown backticks to unmistakable code references and capitalizes
+the first headline character; it does not remove text.
 
-A source-fetch failure, model request or transport failure, empty Nano response,
-or malformed labelled output fails processing. Such a failure is terminal for
-explicit operational inspection and omitted from the public feed. The call is
-not retried inside or after the request. Repository descriptions and other
+A source-fetch failure remains retryable ingestion work. A missing model key,
+model request or transport failure, empty Nano response, or malformed labelled
+output selects the deterministic commit-message summary instead of blocking
+publication. The model call is not retried. Repository descriptions and other
 display facts are persisted as repository snapshots; raw per-file and patch
 evidence is not.
 
@@ -156,15 +160,15 @@ The displayed additions and deletions are GitHub's commit-wide `stats` values.
 The headline threshold and language weights use GitHub's per-file additions and
 deletions so generated output, lockfiles, vendored files, and binary assets can
 still be excluded procedurally. Missing or truncated patch text does not make
-these counts partial. Patch text is used only as Nano evidence.
+these counts partial. Within model summary generation, patch text is used only
+as Nano evidence.
 
-Both Nano outputs are persisted on the activity's revision-scoped summary
-attempt, along with the exact model snapshot, prompt recipe, and input hash. The
-page always uses the headline and conditionally adds the short value without
-another model call. A failed attempt is terminal; an expired in-flight lease is
-`indeterminate`, because its remote outcome may be unknown. Neither state is
-automatically retried. PR title/body reconciliation does not create a new
-summary revision.
+The selected outputs are persisted on the activity's revision-scoped summary
+attempt, along with the model or deterministic recipe and input hash. The page
+always uses the headline and conditionally adds the short value without another
+model call. Database and lease failures defer the attempt with bounded
+exponential backoff. PR title/body reconciliation does not create a new summary
+revision.
 
 ## Timeline presentation
 
@@ -176,7 +180,7 @@ published after the first page. Pagination never splits one day across pages.
 Canonical commits with the same primary GitHub PR and UTC day render as one PR
 slice containing their individual headlines/disclosures. A PR spanning several
 days produces one slice per day. Stored multi-parent merge commits are omitted
-from both Nano and the timeline. The PR merge is a separate milestone. Daily
+from summary generation and the timeline. The PR merge is a separate milestone. Daily
 totals include repositories, additions, deletions, merged PRs, and opened
 issues; proven aliases and omitted merge commits do not add duplicate churn.
 

--- a/docs/github-commits.md
+++ b/docs/github-commits.md
@@ -1,11 +1,12 @@
 # GitHub activity ingestion
 
-The site records commits authored by `f0rr0` or `yuppiestechdev` when either
-account pushes them. A repository can be public or private and can belong to
-either account or to somebody else. GitHub remains the source of truth for
-repository contents: the database keeps durable identities, observations,
-deterministic facts, pull-request structure, and generated summaries, but not
-patch bodies, tree/blob contents, or webhook payloads.
+The site records commits authored by `f0rr0` or `yuppiestechdev` when GitHub
+exposes them through a push, pull request, or current ref in a repository that
+one of those accounts can access. A repository can be public or private and can
+belong to either account or to somebody else. GitHub remains the source of
+truth for repository contents: the database keeps durable identities,
+observations, deterministic facts, pull-request structure, and generated
+summaries, but not patch bodies, tree/blob contents, or webhook payloads.
 
 ## Architecture
 
@@ -15,10 +16,16 @@ GitHub push / pull_request / issues webhooks
   -> verify + durably record delivery/observation/snapshot
   -> 202 (no GitHub or OpenAI work in the request)
 
-Supabase Cron every 3 hours
+Supabase Cron every 5 minutes
   -> Vercel /api/cron/github-sync
-  -> authenticated GitHub user Events feeds + accessible repository refs
-  -> hydrate sparse PRs, persist observations, reconcile ref checkpoints
+  -> authenticated GitHub user Events feeds
+  -> persist observations, sparse PR signals, and event checkpoints
+
+Supabase Cron every 15 minutes, staggered by ref kind
+  -> Vercel /api/cron/github-refs?kind=head&repositories=8
+  -> Vercel /api/cron/github-refs?kind=tag&repositories=8
+  -> resume a bounded accessible-repository/page scan
+  -> persist changed tips and the repository/page cursor
 
 Supabase Cron every 5 minutes
   -> Vercel /api/cron/github-worker
@@ -27,7 +34,9 @@ Supabase Cron every 5 minutes
 
 Manual GitHub Actions backfill
   -> authenticated GitHub APIs + Supabase transaction pooler
-  -> queue bounded historical observations and run the same durable worker
+  -> scan commits from every distinct current ref head
+  -> independently scan PR snapshots, memberships, and merge evidence
+  -> persist candidates directly and run the same durable worker
 
 Next.js server render / GET /api/github/activity
   -> snapshot-stable pages of complete UTC days
@@ -35,17 +44,18 @@ Next.js server render / GET /api/github/activity
 
 The webhook is the low-latency path for repositories where the GitHub App is
 installed. Authenticated Events polling accelerates discovery for pushes made
-by either account. A complete sweep of every accessible repository's branch and
-tag tips is the coverage path, including commits pushed to non-default branches
-without a PR. All three intake paths converge on the same durable observation
-and source-identity tables. Leases and unique constraints make overlapping
-webhook, polling, ref reconciliation, and worker invocations safe.
+by either account. A checkpointed sweep of every accessible repository's branch
+and tag tips is the coverage path, including commits pushed to non-default
+branches without a PR. Events intake never waits for that potentially expensive
+sweep. All three intake paths converge on the same durable observation and
+source-identity tables. Leases and unique constraints make overlapping webhook,
+polling, ref reconciliation, and worker invocations safe.
 
-The poller verifies each token with `/user` before requesting
-`/users/{account}/events`; a token mix-up cannot silently turn private activity
-into a public-only feed. The same token enumerates repositories through
-`/user/repos` and only the `refs/heads/*` and `refs/tags/*` namespaces. A
-candidate commit is retained only after GitHub identifies its top-level commit
+Each GitHub API polling/reconciliation job verifies its token with `/user`; a
+token mix-up cannot silently turn private activity into a public-only feed. Ref
+reconciliation enumerates repositories through `/user/repos` and normalizes the
+branch and repository-tag endpoints into `refs/heads/*` and `refs/tags/*`.
+A candidate commit is retained only after GitHub identifies its top-level commit
 author as one of the tracked accounts.
 
 ## Durable intake and checkpoints
@@ -58,19 +68,25 @@ The intake boundary is intentionally cheap:
   are recorded as ignored. The raw JSON body is never stored.
 - A push observation records its source, account, repository, ref, before/after
   SHAs, expected commit count, and any SHA list GitHub supplied. The worker can
-  later expand a truncated push with authenticated GitHub APIs.
-- The Events poll hydrates GitHub's sparse PR shape from the canonical pull
-  request endpoint before persistence. A newly authored PR can therefore be
-  created immediately; a 404 retains the strictly validated signal for
-  known-only reconciliation. The poll then persists push observations, PR
-  snapshots, and tracked-author issue milestones before advancing the event
-  checkpoint transactionally. Stale event timestamps cannot overwrite or
-  reschedule newer provider state.
+  later expand a truncated push with authenticated GitHub APIs. When an Event
+  or webhook later supplies an exact count and SHA sequence for a range first
+  seen by ref scanning, that richer evidence replaces the sparse evidence and
+  safely requeues the observation; contradictory evidence aborts intake.
+- The Events poll persists GitHub's sparse PR shape as a durable signal rather
+  than making a second provider request inline. The worker later hydrates that
+  signal from the canonical pull-request endpoint; a transient 404 remains
+  queued for reconciliation. The poll persists push observations, PR signals,
+  and tracked-author issue milestones before advancing the event checkpoint
+  transactionally. Stale event timestamps cannot overwrite or reschedule newer
+  provider state.
 - Repository reconciliation stores the last observed commit target for every
-  current branch and tag. A new or changed target creates the same durable push
-  observation used by Events and webhooks. Missing refs are marked inactive,
-  annotated tags are peeled to commits, and identical heads are not expanded
-  twice. Ref state and its observation are committed together.
+  current branch and tag. After the initial namespace baseline, a new or changed
+  target creates the same durable push observation used by Events and webhooks.
+  Missing refs are marked inactive, and identical heads are not expanded twice.
+  The documented branch and repository-tag endpoints already return commit
+  targets, including the commit behind an annotated tag, so no per-tag peel
+  request is needed. Ref state and any resulting observation are committed
+  together.
 - Checkpoint updates use compare-and-swap. A concurrent winner causes the
   loser to reread and retry instead of overwriting newer progress.
 
@@ -81,12 +97,29 @@ available observation, advances to the newest event, and records the expected
 and oldest available event IDs as a durable `detected` gap. It does not loop
 forever on an unrecoverable checkpoint.
 
-The first ref sweep has a fixed lower bound: the earliest commit already in the
-durable timeline when this policy is installed. This fills gaps in the existing
-timeline without importing a repository's entire history. New accounts start at
-the time their checkpoint is created. Later sweeps expand only ref movements.
-Commits remain keyed by repository ID and SHA after a branch is deleted or
-force-pushed.
+The first Events page uses its saved ETag. A `304` is a successful no-op and
+updates the checkpoint's last-attempted/last-succeeded health timestamps. Ref
+lists do not use that shortcut: a validator for page one cannot prove that a
+mutable ref on a later page did not move.
+
+The poller also persists GitHub's `X-Poll-Interval` as the next eligible Events
+poll time. A five-minute cron invocation that arrives before that boundary is a
+healthy deferred no-op rather than an unnecessary provider request.
+
+Head and tag scans have independent leases and immutable numeric repository-ID
+cursors. Each run handles at most eight API pages and eight distinct
+repositories. A repository with more than 100 refs stores its next page and
+scan-start watermark, resumes on the next run, and marks missing refs inactive
+only after the final page. Its namespace reconciliation timestamp also advances
+only then, so a partial scan can never masquerade as a complete snapshot.
+
+The first complete sweep of each repository and ref kind establishes a baseline
+without emitting historical observations for every pre-existing branch or tag.
+This avoids turning the initial tag inventory into a large accidental backfill.
+Events and webhooks remain the live bootstrap path while that baseline is being
+built; run the date-bounded Action for deterministic pre-baseline history. Later
+sweeps expand new and moved refs normally. Once observed, commits remain keyed
+by repository ID and SHA after a branch is deleted or force-pushed.
 
 A ref created and deleted (or force-pushed away) between observations is not
 recoverable unless an Event, webhook, PR, or another surviving ref exposes its
@@ -130,17 +163,24 @@ order:
    Verify repository ID, SHA, and tracked author again; persist commit metadata,
    GitHub aggregate counters, file-derived languages, repository facts, and a
    deterministic change fingerprint.
-3. Ask GitHub which PRs are associated with each newly enriched commit and
-   persist those PR snapshots. Reconcile known PRs that are due.
+3. Process the durable webhook/Event PR-signal inbox, ask GitHub which PRs are
+   associated with each newly enriched commit, persist snapshots and complete
+   memberships, then reconcile known PRs that are due.
 4. Canonicalize only copies supported by complete, deterministic evidence.
 5. Create and claim one summary attempt for each still-canonical, non-merge
-   commit, make one Nano call, and publish the activity only after it succeeds.
+   commit. Public commits use Nano when configured; private commits, missing
+   credentials, provider failures, and invalid output use the deterministic
+   commit-message summary. Publish only after one of those paths succeeds.
 
-Routine Vercel runs claim four items from each bounded stage with a 90-second
-internal deadline. Direct GitHub Actions backfills claim up to 16 with a
-four-minute per-pass deadline. Both keep claims bounded; the Action runner uses
-its longer job lifetime through repeated durable passes rather than one
-unbounded operation.
+Routine Vercel runs claim up to four items in every provider-backed stage:
+observations, commits, PR signals, commit-to-PR discoveries, due PR
+reconciliations, and summaries. Canonicalization remains capped at eight, and
+the pass has a 90-second internal deadline. Direct GitHub Actions backfill
+passes raise every provider-backed stage limit to eight and use a four-minute
+per-pass deadline. The Action runner uses its longer job lifetime through
+repeated durable passes rather than one unbounded operation. A pass that reaches
+its deadline releases unfinished claims at their previously eligible retry
+state; an invocation boundary does not spend a retry attempt or add backoff.
 
 A commit with more than one parent is a regular merge commit. It remains fully
 stored for intake, ancestry, and alias evidence, but it is excluded from summary
@@ -167,7 +207,12 @@ assumption that repository access and history remain available. It includes
 repository ID, SHA, tree SHA, parent SHAs, full commit message, author and
 committer identities/times, GitHub counters, languages, repository display
 facts, and the fingerprint result. Patch text and per-file evidence exist only
-in memory for deterministic derivation and the Nano request.
+in memory for deterministic derivation and the optional Nano request.
+
+Author identity determines whether a commit belongs to a tracked account.
+GitHub's committer timestamp determines date-range inclusion, timeline order,
+and the stored activity occurrence time; author time remains preserved as
+source evidence but is not substituted for the public timestamp.
 
 ## Pull requests and deterministic grouping
 
@@ -189,42 +234,35 @@ Commits without a proven PR association remain standalone.
 
 ### Reconciliation policy
 
-An eligible open PR receives a full snapshot refresh every three hours. That
-refresh updates title, body, draft/state, base/head, merge fields, counts, and
-provider timestamps. Its commit membership is fetched again only when the head
-SHA changes or the current head's prior membership is incomplete. A base-only,
-title, or body edit does not fetch membership again and does not make another
-Nano call.
+Open PR reconciliation has no age cutoff. Its cadence slows with age: every
+three hours through day 30, daily through day 180, then weekly. A refresh
+updates title, body, draft/state, base/head, authoritative merge evidence,
+counts, and provider timestamps. Commit membership is fetched again only when
+the head SHA changes or the current head's prior membership is incomplete. A
+base-only, title, or body edit does not fetch membership again or create a new
+commit-summary revision.
 
-Each worker run claims at most 25 due PRs per tracked account. Open PR
-reconciliation has a reviewed 30-day age horizon in code. It is a product and
-resource policy, not an environment-specific deployment setting. Eligibility
-is calculated from PR `created_at` at query time, not permanently written into
-a stopped state. The cap applies only to scheduled reconciliation; a webhook
-or an associated-PR observation can still update an older PR opportunistically.
-
-The age cutoff applies to ongoing open-PR reconciliation. A known merged or
-closed PR still gets its terminal refresh. After that successful final refresh,
-`next_reconcile_at` is cleared and it leaves the queue permanently. Temporary
-failures defer the same terminal refresh rather than silently dropping it.
-GitHub `404`, `410`, or `422` responses mark the PR permanently unavailable and
-clear its reconciliation schedule.
+Each routine worker pass claims at most four due PRs globally across active
+tracked accounts; the Action raises that global cap to eight. Claims rotate one
+account at a time so one account cannot consume the whole pass while another
+has eligible work. A known merged or closed PR receives one successful terminal
+refresh, then clears
+`next_reconcile_at` and leaves the queue. Temporary failures use exponential
+backoff from 15 minutes through 24 hours instead of silently dropping that
+refresh. A GitHub `404` remains retryable because repository permissions can
+change; `410` and `422` become unavailable only after eight attempts.
+A proven repository/SHA provenance change remains immediately terminal.
 
 ### Proven-copy canonicalization
 
 The public feed hides an integration copy only when the database can point to a
 specific canonical activity and persist the reason plus evidence:
 
-- Amendments, rebases, force-push rewrites, and same-repository cherry-picks
-  that preserve the exact non-null GitHub author ID, authored timestamp, and
-  full commit message form one non-merge rewrite lineage. The latest committer
-  timestamp wins, followed by observation time and SHA as deterministic ties.
-  Fingerprints and parent SHAs may differ because rewriting is allowed to change
-  the patch and its base. Existing aliases are retargeted directly to the winner
-  so the public graph never contains an alias chain.
 - A GitHub-reported merge SHA is aliased to an existing source member only when
-  that PR has complete membership. Parent count distinguishes regular merge
-  commits from squash integration commits.
+  GraphQL authoritatively verified that value and the PR has complete
+  membership. A verified null merge commit is valid for a rebase merge, but it
+  cannot prove an alias. Parent count distinguishes regular merge commits from
+  squash integration commits.
 - A multi-parent commit with a complete exact fingerprint is aliased when the
   matching commit SHA is literally one of its parents. If that parent is
   already an alias, the new copy resolves to the same canonical activity.
@@ -233,45 +271,46 @@ specific canonical activity and persist the reason plus evidence:
   of the same PR.
 - A cherry-pick is aliased only with the explicit `cherry picked from commit`
   trailer and the same complete fingerprint.
-- The provider can omit PR association for squash/rebase flows, especially on
-  non-default target branches. Two single-parent commits can therefore be
-  aliased without PR membership only when they have the same repository,
-  complete exact fingerprint, non-null GitHub author ID, and normalized first
-  message line. Normalization removes only GitHub's terminal ` (#123)` suffix;
-  the earlier committer timestamp wins, with observation time and SHA used only
-  as deterministic ties.
+
+Author ID, author timestamp, commit message, committer order, or even an exact
+fingerprint never establishes rewrite lineage by itself. Commits remain
+separate unless one of the explicit PR-version, parent, or cherry-pick
+relationships above proves causality.
+
+A newer webhook, Event, or authoritative snapshot that changes a PR head or
+state invalidates every alias derived from that PR in both its base repository
+and any fork head repository. Those aliases are unpublished, their
+canonical-alias summary attempts are requeued, and they become visible again
+only after refreshed membership is conservatively canonicalized.
 
 The fingerprint hashes stable hunk bodies—including unchanged context—and
 file-change metadata. It excludes commit identity and numeric hunk coordinates.
 A missing patch, counter mismatch, binary/provider omission, or GitHub file cap
 makes the fingerprint incomplete, so it cannot prove an alias. Exact counters,
-filenames, a headline, or timing by themselves never hide a commit. The
-same-author/headline fallback is admitted only after complete byte-identical
-patch evidence and single-parent shape. Unproven commits remain visible. The
-known ambiguity is an intentional revert-and-reapply of the same exact patch
-with the same headline by the same author; for this achievement timeline it is
-deliberately collapsed, and the stored alias evidence keeps the decision
-auditable and reversible.
+filenames, a headline, or timing by themselves never hide a commit. This can
+leave visible duplicates when a standalone branch is rewritten without durable
+PR-version evidence; that is the intentional fail-open behavior because hiding
+a legitimate pushed commit would be irreversible without another refresh.
 
-## One-shot Nano summaries
+## Commit summaries
 
-Every canonical non-merge commit gets one revision-scoped summary-attempt row
-and, when claimed, one `gpt-5-nano-2025-08-07` request with `maxRetries: 0` and
-`store: false`. The request produces both the compact headline and expandable
-short summary. Languages and line counts are procedural and are not inferred
-by the model.
+Every canonical non-merge commit gets one revision-scoped summary-attempt row.
+For a public repository with `OPENAI_API_KEY` configured, the claimed attempt
+makes one `gpt-5-nano-2025-08-07` request with `maxRetries: 0` and `store: false`.
+The request produces both the compact headline and expandable short summary;
+languages and line counts remain procedural rather than model-inferred.
 
-If the worker reaches its deadline before issuing the model request, it releases
-the claim back to `pending`; no attempt was consumed. Once the request starts,
-an API/transport error, empty response, output that lacks the requested
-`HEADLINE`/`SHORT` labels, or other processing error is terminal `failed`. A
-lost lease becomes `indeterminate` and is not automatically
-reclaimed, avoiding duplicate billing when the remote outcome is unknown.
-There are no automatic model retries. PR reconciliation, including title/body
+Private repository evidence is never sent to OpenAI. Private commits and runs
+without a model key use a deterministic summary derived from the first commit
+message line. A model/API error, empty or malformed response, or validation
+failure falls back to that same deterministic result, so model credentials and
+availability cannot block publication. A database or lease failure defers the
+attempt with exponential backoff. PR reconciliation, including title/body
 updates, does not create a new commit-summary revision.
 
-Ordinary commits send the full fetched evidence. Oversized evidence goes
-through deterministic procedural compaction before the same single call. See
+Public model input uses the full fetched evidence when it fits. Oversized
+evidence goes through deterministic procedural compaction before the same
+single call. See
 [`github-activity-public-commit-summaries.md`](./github-activity-public-commit-summaries.md)
 for the prompt, compaction, and output contract.
 
@@ -290,13 +329,15 @@ mix in activities published after the first page. A safety limit fails the read
 instead of returning a partial day.
 
 Each day shows totals for repositories, GitHub-reported additions/deletions,
-PRs merged, and issues opened. Commit items always show the headline, counters,
-file-derived language icons, and file count. Higher-substantive-LOC or
-provider-capped commits can expand to the full short summary. PR commits are
-shown under deterministic per-day PR slices, while a merge is a separate
-milestone with its GitHub link when the repository is public. Repository and
-owner display facts are served from persisted snapshots; the page does not
-refetch GitHub.
+PRs merged, and issues opened. Repositories are ordered by their newest commit.
+A contracted commit is one line containing its truncated headline, line-change
+count, and chevron; expansion leaves those elements in place and adds the muted
+description, languages, and file count below. PR commits are shown under
+deterministic per-day PR slices, while a merge is a separate milestone with its
+GitHub link when the repository is public. Repository and owner display facts
+are served from persisted snapshots; the page does not refetch GitHub.
+Timestamps hydrate to the viewer's local time without a timezone suffix; UTC is
+used only for stable day grouping and pagination.
 
 ## Database and environment
 
@@ -310,14 +351,16 @@ GITHUB_F0RR0_TOKEN=github_pat_...
 GITHUB_YUPPIESTECHDEV_TOKEN=github_pat_...
 GITHUB_WEBHOOK_SECRET=<at-least-32-random-characters>
 CRON_SECRET=<at-least-32-random-characters>
+# Optional for richer public-repository summaries.
 OPENAI_API_KEY=...
-SITE_URL=https://f0rr0.dev
 ```
 
-`GITHUB_TOKEN` remains optional. Source fetches try the owning account token,
-the other tracked account token, and then the optional default token so a PR or
-repository readable by either identity can still be processed. All tokens stay
-server-side.
+`OPENAI_API_KEY` is also optional: private commits always use the deterministic
+summary, and public commits fall back to it when the key or provider is
+unavailable. `GITHUB_TOKEN` remains optional. Source fetches try the owning
+account token, the other tracked account token, and then the optional default
+token so a PR or repository readable by either identity can still be processed.
+All tokens stay server-side.
 
 Application and maintenance-script configuration is parsed through the shared
 T3 Env schema in `src/env.ts`. Next.js loads root `.env.local` for local work;
@@ -325,15 +368,24 @@ Bun loads the same file for the maintenance scripts. Vercel environment values
 are the production source. `.env.example` lists only values the application or
 a maintenance script actually reads. Provider ceilings, schedules, batches,
 windows, and retry timings remain reviewed code constants rather than
-environment variables.
+environment variables. `vercel.json` runs server functions in Tokyo (`hnd1`),
+beside the Supabase `ap-northeast-1` database.
+
+Cron targets use Vercel's system-provided production hostname during a
+production build and the canonical site origin for a manual local setup. No
+separate site-URL environment variable is required.
 
 Every Vercel production build applies pending migrations before the Next.js
-build. Vercel remains the source of truth for which Git branch is production.
+build, then reconciles Supabase Cron after a successful Next.js build. Both
+maintenance steps use Vercel's `VERCEL=1` and `VERCEL_ENV=production` signals;
+they do not hard-code a Git branch. Preview and local builds skip them without
+opening the database, while a production failure fails the build.
+
 `scripts/migrate-production-database.ts` uses the database URL already
 synchronized from Supabase to Vercel; when only the transaction-pooler URL is
 present, it derives the corresponding session-pooler URL. A PostgreSQL advisory
-lock serializes overlapping builds. Preview and local builds skip the database
-entirely. Apply migrations manually in other environments with:
+lock serializes overlapping migration builds. Apply migrations manually in
+other environments with:
 
 ```sh
 bun run db:migrate
@@ -341,24 +393,48 @@ bun run db:migrate
 
 ## Supabase Cron
 
-After the production Vercel routes and environment exist, run:
+The production Vercel build installs and updates these jobs automatically. Use
+the ungated command below only as an explicit repair or manual fallback with the
+intended database and bearer secret loaded:
 
 ```sh
 bun run supabase:cron
 ```
 
-The script enables `pg_cron`, `pg_net`, and Vault, upserts the encrypted route
-URLs and bearer secret, replaces jobs with the same names, and installs:
+The script enables `pg_cron`, `pg_net`, and Vault and upserts the encrypted
+route URLs and bearer secret. It then takes a PostgreSQL advisory transaction
+lock and replaces the complete job set in one transaction, so overlapping
+production builds serialize and a scheduling failure cannot leave a partial
+set. It installs:
 
 ```cron
-7 */3 * * *   # authenticated Events intake
-*/5 * * * *   # bounded activity worker
+*/5 * * * *        # authenticated Events intake
+2-57/5 * * * *     # bounded activity worker
+4,19,34,49 * * * * # head-ref reconciliation, eight pages maximum
+9,24,39,54 * * * * # tag-ref reconciliation, eight pages maximum
 ```
 
-Both cron requests have a 120-second HTTP timeout. The worker stops claiming
-new work after 90 seconds, leaving time for its final database writes and
-response. Full syncs currently complete inside the same bound; if they outgrow
-it, checkpoint the sync itself instead of merely extending the timeout.
+All cron requests have a 120-second HTTP timeout. Events intake and ref
+reconciliation use one absolute 90-second provider deadline per invocation,
+including token-identity checks and every pagination request; the ref batch
+consumes whatever time remains instead of starting a new budget. The worker also
+stops claiming new work after 90 seconds. This leaves time for final database
+writes and the response. A bounded ref run continues its persisted repository
+and within-repository page cursor on the next invocation.
+
+At the audited inventory of roughly 193 accessible repositories, 3,025 head
+refs, and 17,383 tags, the eight-page batches complete a head cycle in about six
+hours and a tag cycle in about twelve hours. Scheduled intake uses roughly 112
+REST requests per hour per token before worker traffic, about 2.2% of GitHub's
+5,000-request authenticated hourly allowance. These are capacity estimates,
+not correctness boundaries: persisted cursors and leases preserve progress if
+inventory size or request latency grows.
+
+`cron.job_run_details` proves that PostgreSQL enqueued a `pg_net` request; it
+does not prove that Vercel accepted it. Inspect both tables. HTTP responses are
+retained by `pg_net` for only six hours, and either cron route returns `503` if
+even one account failed so standard failure monitoring cannot mistake a partial
+run for success.
 
 No Vercel Cron configuration is required. Inspect scheduling and HTTP delivery
 from Supabase with:
@@ -388,37 +464,137 @@ The rollout order is schema, Vercel environment, Supabase jobs, GitHub App
 subscriptions, then end-to-end observation. Nothing in this document implies
 that a particular environment has already been migrated or deployed.
 
+### Post-deploy evidence recovery
+
+The REST 2026 pull-request contract removed the legacy `merge_commit_sha`
+field. Earlier ingestion could therefore retain an unverified test-merge SHA,
+falsely complete PR discovery, or permanently stop reconciliation. The schema
+migration adds the nullable verification column but deliberately defers the
+strict merge-evidence check: Vercel applies migrations while the previous
+deployment can still receive traffic, and that deployment must remain
+write-compatible until the new code is live.
+
+The final invariant distinguishes three cases: unverified evidence stores both
+fields as null; an authoritative merged PR stores a verification timestamp and
+either its merge SHA or null for a rebase merge; non-merged PRs cannot carry
+verified merge evidence.
+
+The first authenticated GitHub worker request from the compatible deployment
+acquires a database advisory lock and completes the recovery transaction before
+claiming work. Later workers take only the constraint-marker fast path. This is
+safe when there are no legacy rows too: the deferred constraint is still
+installed. A newly provisioned database is not at final schema integrity after
+migrations alone; either one compatible worker request or the manual Action
+must finish this post-deploy step. A failed transaction rolls back completely;
+the worker reports `503` without claiming work, and the manual Action exits
+nonzero.
+
+The `Repair GitHub evidence` workflow remains the auditable preview and manual
+fallback. Run `preview` to read shared-production counts without changes. If the
+constraint marker is absent, choose `apply` and enter
+`REPAIR_GITHUB_EVIDENCE_V1` exactly. Apply performs one transaction that:
+
+- clears only merge SHAs lacking authoritative verification while preserving
+  already verified GraphQL evidence;
+- resets commit aliases and canonicalization, and unpublishes only activities
+  whose legacy alias is being cleared so they cannot surface as duplicates;
+- requeues PR discovery for enriched commits, reconciliation for every known
+  PR, and every current incomplete commit summary with retry counts reset; and
+- installs the deferred database check so unverified merge evidence cannot be
+  written again.
+
+No commit, PR snapshot, membership, public-activity identity, or summary row is
+deleted. Existing complete summaries remain reusable and are republished only
+after canonicalization is rebuilt. Scheduled GitHub workers consume the durable
+queues after recovery commits. The constraint is also the repair version
+marker, so repeating `apply` returns `already_applied` without requeueing work.
+Do not run manual apply before the compatible application deployment is serving
+production traffic.
+
 ### Date-bounded backfill Action
 
 The `Backfill GitHub activity` workflow is manually dispatched from GitHub
-Actions after its workflow file is present on the default branch. It accepts an
-inclusive oldest and newest commit date, one tracked credential or both, an
-optional numeric repository ID, and a wall-clock budget of up to 330 minutes.
-The standard GitHub-hosted job has a 350-minute ceiling, leaving a 20-minute
-setup and cleanup margin beneath GitHub's six-hour hard limit.
+Actions after its workflow file is present on the default branch. `start_date`
+is the earliest UTC calendar day included and `end_date` is the latest; both
+days are inclusive, the start must not follow the end, and the end cannot be in
+the future. Before inventory starts, the Action runs the same locked evidence
+integrity preflight as the scheduled worker, so a backfill cannot process rows
+under the transitional migration invariant. The workflow also accepts one
+tracked account or both, an optional
+numeric repository ID, and a wall-clock budget of up to 330 minutes. The
+standard GitHub-hosted job has a 350-minute ceiling, leaving a 20-minute setup
+and cleanup margin beneath GitHub's six-hour hard limit.
 
-The Action runs the ingestion code directly. Its repository secrets map to the
-same typed runtime names used by Vercel:
+The Action runs the ingestion code directly. Its required repository secrets
+map to the same typed runtime names used by Vercel:
 
 ```text
 ACTIVITY_DATABASE_URL
 ACTIVITY_F0RR0_TOKEN
 ACTIVITY_YUPPIESTECHDEV_TOKEN
-ACTIVITY_OPENAI_API_KEY
 ```
 
-The runner divides an arbitrary date range into requests of at most 366 days,
-then into non-overlapping 31-day history windows. It enumerates current refs,
-collapses refs that share a head, and queues durable `backfill` observations.
-If a request would exceed the 5,000-observation database bound, the runner
-divides that date request again rather than weakening the bound. Repository ID,
-ref head, and window bounds form the idempotency identity: rerunning the same
-range is a no-op for completed observations and requeues deferred or
-unavailable observations.
+Only the token for each selected account is required. The optional
+`ACTIVITY_OPENAI_API_KEY` enables richer public-repository summaries; omitting
+it selects the deterministic fallback and does not reduce discovery coverage.
 
-Direct worker passes claim at most 16 items from each bounded stage and stop
-when the queue drains or the selected wall-clock budget expires. Normal
-five-minute Vercel worker runs finish any durable work left behind.
+For each selected account, the runner first verifies that `/user` matches the
+selected tracked account, then performs two independent discovery passes over
+the requested inclusive UTC interval. There is no arbitrary day-count cap; the
+selected Action time budget is the operational bound. Pull requests run first
+because the all-repository authored-PR stream cannot be repository-sharded:
+
+1. Enumerate every all-state pull request in each affiliated repository in
+   descending `updated_at` order; no timestamp cutoff is safe because Git commit
+   timestamps are author-controlled. An all-repository run independently walks
+   the tracked user's unbounded GraphQL `pullRequests` connection as well, so an
+   authored PR remains discoverable when its base is an unaffiliated external
+   repository. The author stream validates the returned user and PR author,
+   repository database ID/name, PR identity/link, total count, unique progress,
+   and every cursor before merging by PR node ID with the affiliated inventory.
+   A repository-targeted run stays scoped to that numeric repository ID and does
+   not invoke the author stream. Fetch complete membership, retain a PR when it
+   contains a tracked commit in the interval or is a tracked-authored merge in
+   the interval, and resolve merged PR evidence through GraphQL. A verified null
+   merge commit is retained as the valid result of a rebase merge.
+2. Enumerate every accessible repository and its current branches and tags,
+   order branches before tags, and collapse refs that share a commit target.
+   For each distinct target, paginate GitHub's commit list with that SHA,
+   tracked author, `since`, and `until`, then persist candidates directly using
+   repository ID plus commit SHA as their identity.
+
+The commit and merge date filters remain inclusive at both ends. When `all` is
+selected, the two account inventories run concurrently with a maximum
+concurrency of two; each account still uses its own token and author filter.
+
+Together, the passes deterministically cover tracked-author commits in the date
+range that are reachable from a current ref or retained by an eligible PR when
+the Action runs. They cannot discover a commit that was force-pushed away or
+whose only branch, tag, and PR were deleted before any webhook, Event, prior
+backfill, or surviving ref exposed its SHA. They also cannot inspect a
+repository the selected token cannot access, and GitHub must associate the
+commit author with the tracked account.
+
+GitHub primary-rate-limit responses are waited out when the reset still fits
+inside the selected budget. A deadline or provider delay that cannot fit marks
+the inventory incomplete and fails the job explicitly. Repeating the same
+inputs is safe: commit, PR, and membership identities deduplicate in the
+database, and a complete current membership is not rewritten or invalidated on
+an unchanged PR version. Provider discovery still restarts from the
+deterministic beginning rather than storing an Action-only cursor. If an
+all-repository scan repeatedly exceeds 330 minutes, dispatch the same range once
+per numeric `repository_id` to shard the affiliated inventory; those scoped runs
+intentionally do not replace the all-repository authored-PR pass.
+
+After discovery, direct worker passes request at most eight items from every
+configurable stage. They process the shared global queue, which can include work
+unrelated to the selected backfill. The final JSON contains per-account
+`inventories` with `direct` and `pullRequests` results, the aggregate
+`inventoryComplete` flag, and global `processing` outcomes. A complete inventory
+proves that both discovery passes reached their ends; it does not prove the
+shared worker queue is empty. Likewise, a worker pass that claims zero items
+does not prove retry-delayed work is absent. Normal five-minute Vercel worker
+runs continue durable work after the Action stops.
 
 Use an opaque numeric ID when targeting one repository so a private repository
 name does not appear in public workflow inputs. Resolve it locally with:
@@ -427,7 +603,7 @@ name does not appear in public workflow inputs. Resolve it locally with:
 gh api repos/OWNER/REPOSITORY --jq .id
 ```
 
-Run the normal synchronization locally:
+Run Events intake plus one worker pass locally:
 
 ```sh
 bun run github:sync
@@ -440,6 +616,16 @@ curl --fail-with-body \
   --request POST \
   --header "Authorization: Bearer $CRON_SECRET" \
   https://f0rr0.dev/api/cron/github-sync
+
+curl --fail-with-body \
+  --request POST \
+  --header "Authorization: Bearer $CRON_SECRET" \
+  'https://f0rr0.dev/api/cron/github-refs?kind=head&repositories=8'
+
+curl --fail-with-body \
+  --request POST \
+  --header "Authorization: Bearer $CRON_SECRET" \
+  'https://f0rr0.dev/api/cron/github-refs?kind=tag&repositories=8'
 
 curl --fail-with-body \
   --request POST \
@@ -457,8 +643,8 @@ Verify, in order:
    its observations; concurrent runs converge through compare-and-swap.
 3. Worker passes move observations and commits through their states, populate
    PR versions/memberships, and create exactly one summary attempt.
-4. Terminal PRs have `next_reconcile_at = null`; eligible open PRs have a future
-   due time; old open PR behavior follows the configured query-time cap.
+4. Terminal PRs have `next_reconcile_at = null`; every open PR has a future due
+   time following the three-hour, daily, or weekly age-based cadence.
 5. The public page contains complete UTC days, no proven integration-copy
    duplicates, stable older-page cursors, and correct daily totals.
 
@@ -467,15 +653,11 @@ Verify, in order:
 - GitHub Events are delayed and expose a bounded window. Webhooks improve
   latency but only where the App is installed; a recorded checkpoint gap still
   requires explicit operational review if missing history matters.
-- The system covers commits pushed by a tracked account and authored by a
-  tracked account. It deliberately does not discover a tracked author's commit
-  when somebody else pushes it and no tracked-account observation includes it.
+- Current-ref reconciliation covers tracked-authored commits even when somebody
+  else pushed them, provided a selected token can read the repository and the
+  commit remains reachable long enough for a scan.
 - PR association and copy suppression favor false negatives: incomplete or
   ambiguous evidence leaves a commit standalone and visible.
-- A finite reconciliation age intentionally stops checking old open PRs. If a
-  third-party PR merges after that cutoff and no relevant webhook/Event reaches
-  us, its terminal state is not discovered unless the cap is widened (or set to
-  `infinity`).
 - Repository deletion, inaccessible history, and force-pushed-away objects can
   make later enrichment unavailable. Raw patches are intentionally not retained.
 - Supabase free-tier backup and retention characteristics are external to this

--- a/drizzle/0011_vengeful_reavers.sql
+++ b/drizzle/0011_vengeful_reavers.sql
@@ -1,0 +1,69 @@
+CREATE TABLE "github_pull_request_signals" (
+	"account" varchar(39) NOT NULL,
+	"action" varchar(40) NOT NULL,
+	"attempt_count" integer DEFAULT 0 NOT NULL,
+	"completed_at" timestamp with time zone,
+	"error_code" varchar(80),
+	"event_id" varchar(64) NOT NULL,
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"lease_token" uuid,
+	"lease_until" timestamp with time zone,
+	"number" integer NOT NULL,
+	"observed_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"occurred_at" timestamp with time zone NOT NULL,
+	"repository_id" varchar(32) NOT NULL,
+	"repository_name_snapshot" varchar(200) NOT NULL,
+	"state" varchar(16) DEFAULT 'pending' NOT NULL,
+	CONSTRAINT "github_pull_request_signals_account" CHECK ("github_pull_request_signals"."account" IN ('f0rr0', 'yuppiestechdev')),
+	CONSTRAINT "github_pull_request_signals_event_id" CHECK ("github_pull_request_signals"."event_id" ~ '^[0-9]{1,64}$'),
+	CONSTRAINT "github_pull_request_signals_repository_id" CHECK ("github_pull_request_signals"."repository_id" ~ '^[0-9]{1,32}$'),
+	CONSTRAINT "github_pull_request_signals_state" CHECK ("github_pull_request_signals"."state" IN ('pending', 'processing', 'complete', 'unavailable')),
+	CONSTRAINT "github_pull_request_signals_lease" CHECK (("github_pull_request_signals"."state" = 'processing') = ("github_pull_request_signals"."lease_token" IS NOT NULL) AND ("github_pull_request_signals"."state" <> 'processing' OR "github_pull_request_signals"."lease_until" IS NOT NULL)),
+	CONSTRAINT "github_pull_request_signals_values" CHECK ("github_pull_request_signals"."number" > 0 AND "github_pull_request_signals"."attempt_count" >= 0)
+);
+--> statement-breakpoint
+ALTER TABLE "github_pull_request_signals" ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
+ALTER TABLE "github_push_observations" DROP CONSTRAINT "github_push_observations_nonnegative_count";--> statement-breakpoint
+ALTER TABLE "github_summary_attempts" DROP CONSTRAINT "github_summary_attempts_positive_revision";--> statement-breakpoint
+ALTER TABLE "github_account_checkpoints" ADD COLUMN "events_etag" text;--> statement-breakpoint
+ALTER TABLE "github_account_checkpoints" ADD COLUMN "events_last_attempted_at" timestamp with time zone;--> statement-breakpoint
+ALTER TABLE "github_account_checkpoints" ADD COLUMN "events_last_succeeded_at" timestamp with time zone;--> statement-breakpoint
+ALTER TABLE "github_account_checkpoints" ADD COLUMN "events_next_poll_at" timestamp with time zone;--> statement-breakpoint
+ALTER TABLE "github_account_checkpoints" ADD COLUMN "head_ref_cursor_repository_id" varchar(32);--> statement-breakpoint
+ALTER TABLE "github_account_checkpoints" ADD COLUMN "head_ref_cycle_started_at" timestamp with time zone;--> statement-breakpoint
+ALTER TABLE "github_account_checkpoints" ADD COLUMN "head_ref_last_attempted_at" timestamp with time zone;--> statement-breakpoint
+ALTER TABLE "github_account_checkpoints" ADD COLUMN "head_ref_last_succeeded_at" timestamp with time zone;--> statement-breakpoint
+ALTER TABLE "github_account_checkpoints" ADD COLUMN "head_ref_lease_token" uuid;--> statement-breakpoint
+ALTER TABLE "github_account_checkpoints" ADD COLUMN "head_ref_lease_until" timestamp with time zone;--> statement-breakpoint
+ALTER TABLE "github_account_checkpoints" ADD COLUMN "head_ref_next_page" integer;--> statement-breakpoint
+ALTER TABLE "github_account_checkpoints" ADD COLUMN "head_ref_scan_started_at" timestamp with time zone;--> statement-breakpoint
+ALTER TABLE "github_account_checkpoints" ADD COLUMN "tag_ref_cursor_repository_id" varchar(32);--> statement-breakpoint
+ALTER TABLE "github_account_checkpoints" ADD COLUMN "tag_ref_cycle_started_at" timestamp with time zone;--> statement-breakpoint
+ALTER TABLE "github_account_checkpoints" ADD COLUMN "tag_ref_last_attempted_at" timestamp with time zone;--> statement-breakpoint
+ALTER TABLE "github_account_checkpoints" ADD COLUMN "tag_ref_last_succeeded_at" timestamp with time zone;--> statement-breakpoint
+ALTER TABLE "github_account_checkpoints" ADD COLUMN "tag_ref_lease_token" uuid;--> statement-breakpoint
+ALTER TABLE "github_account_checkpoints" ADD COLUMN "tag_ref_lease_until" timestamp with time zone;--> statement-breakpoint
+ALTER TABLE "github_account_checkpoints" ADD COLUMN "tag_ref_next_page" integer;--> statement-breakpoint
+ALTER TABLE "github_account_checkpoints" ADD COLUMN "tag_ref_scan_started_at" timestamp with time zone;--> statement-breakpoint
+ALTER TABLE "github_commits" ADD COLUMN "enrichment_attempts" integer DEFAULT 0 NOT NULL;--> statement-breakpoint
+ALTER TABLE "github_commits" ADD COLUMN "pr_discovery_attempts" integer DEFAULT 0 NOT NULL;--> statement-breakpoint
+ALTER TABLE "github_pull_requests" ADD COLUMN "merge_sha_verified_at" timestamp with time zone;--> statement-breakpoint
+ALTER TABLE "github_pull_requests" ADD COLUMN "reconcile_attempts" integer DEFAULT 0 NOT NULL;--> statement-breakpoint
+ALTER TABLE "github_pull_requests" ADD COLUMN "reconcile_error" varchar(80);--> statement-breakpoint
+ALTER TABLE "github_push_observations" ADD COLUMN "attempt_count" integer DEFAULT 0 NOT NULL;--> statement-breakpoint
+ALTER TABLE "github_repositories" ADD COLUMN "heads_last_reconciled_at" timestamp with time zone;--> statement-breakpoint
+ALTER TABLE "github_repositories" ADD COLUMN "tags_last_reconciled_at" timestamp with time zone;--> statement-breakpoint
+ALTER TABLE "github_summary_attempts" ADD COLUMN "attempt_count" integer DEFAULT 0 NOT NULL;--> statement-breakpoint
+CREATE UNIQUE INDEX "github_pull_request_signals_event_unique" ON "github_pull_request_signals" USING btree ("account","event_id");--> statement-breakpoint
+CREATE INDEX "github_pull_request_signals_pending_idx" ON "github_pull_request_signals" USING btree ("state","lease_until","observed_at");--> statement-breakpoint
+ALTER TABLE "github_account_checkpoints" ADD CONSTRAINT "github_account_checkpoints_ref_cursor_shape" CHECK (("github_account_checkpoints"."head_ref_cursor_repository_id" IS NULL OR "github_account_checkpoints"."head_ref_cursor_repository_id" ~ '^[0-9]{1,32}$') AND ("github_account_checkpoints"."tag_ref_cursor_repository_id" IS NULL OR "github_account_checkpoints"."tag_ref_cursor_repository_id" ~ '^[0-9]{1,32}$'));--> statement-breakpoint
+ALTER TABLE "github_account_checkpoints" ADD CONSTRAINT "github_account_checkpoints_ref_leases" CHECK (("github_account_checkpoints"."head_ref_lease_token" IS NULL) = ("github_account_checkpoints"."head_ref_lease_until" IS NULL) AND ("github_account_checkpoints"."tag_ref_lease_token" IS NULL) = ("github_account_checkpoints"."tag_ref_lease_until" IS NULL));--> statement-breakpoint
+ALTER TABLE "github_account_checkpoints" ADD CONSTRAINT "github_account_checkpoints_ref_scans" CHECK (("github_account_checkpoints"."head_ref_next_page" IS NULL AND "github_account_checkpoints"."head_ref_scan_started_at" IS NULL OR "github_account_checkpoints"."head_ref_next_page" >= 2 AND "github_account_checkpoints"."head_ref_scan_started_at" IS NOT NULL) AND ("github_account_checkpoints"."tag_ref_next_page" IS NULL AND "github_account_checkpoints"."tag_ref_scan_started_at" IS NULL OR "github_account_checkpoints"."tag_ref_next_page" >= 2 AND "github_account_checkpoints"."tag_ref_scan_started_at" IS NOT NULL));--> statement-breakpoint
+ALTER TABLE "github_commits" ADD CONSTRAINT "github_commits_nonnegative_attempts" CHECK ("github_commits"."enrichment_attempts" >= 0 AND "github_commits"."pr_discovery_attempts" >= 0);--> statement-breakpoint
+-- Intentionally installed by the idempotent evidence-recovery transaction
+-- after legacy unverified merge SHAs and their derived aliases are invalidated.
+-- Fresh databases reach the same invariant on the first authenticated worker
+-- run (or the manual evidence-recovery Action) even when no rows need repair.
+ALTER TABLE "github_pull_requests" ADD CONSTRAINT "github_pull_requests_nonnegative_attempts" CHECK ("github_pull_requests"."reconcile_attempts" >= 0);--> statement-breakpoint
+ALTER TABLE "github_push_observations" ADD CONSTRAINT "github_push_observations_nonnegative_count" CHECK ("github_push_observations"."attempt_count" >= 0 AND ("github_push_observations"."expected_commit_count" IS NULL OR "github_push_observations"."expected_commit_count" >= 0));--> statement-breakpoint
+ALTER TABLE "github_summary_attempts" ADD CONSTRAINT "github_summary_attempts_positive_revision" CHECK ("github_summary_attempts"."revision" > 0 AND "github_summary_attempts"."attempt_count" >= 0);

--- a/drizzle/meta/0011_snapshot.json
+++ b/drizzle/meta/0011_snapshot.json
@@ -1,0 +1,2744 @@
+{
+  "id": "ba994443-532b-4c79-9777-3ac5b75fb5a4",
+  "prevId": "a1f9673c-8edd-4220-a397-556ffe788aa7",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.github_account_checkpoints": {
+      "name": "github_account_checkpoints",
+      "schema": "",
+      "columns": {
+        "account": {
+          "name": "account",
+          "type": "varchar(39)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "events_etag": {
+          "name": "events_etag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "events_last_attempted_at": {
+          "name": "events_last_attempted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "events_last_succeeded_at": {
+          "name": "events_last_succeeded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "events_next_poll_at": {
+          "name": "events_next_poll_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gap_detected_at": {
+          "name": "gap_detected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gap_expected_event_id": {
+          "name": "gap_expected_event_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gap_oldest_available_event_id": {
+          "name": "gap_oldest_available_event_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gap_state": {
+          "name": "gap_state",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'clear'"
+        },
+        "latest_event_id": {
+          "name": "latest_event_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "paused": {
+          "name": "paused",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "head_ref_cursor_repository_id": {
+          "name": "head_ref_cursor_repository_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "head_ref_cycle_started_at": {
+          "name": "head_ref_cycle_started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "head_ref_last_attempted_at": {
+          "name": "head_ref_last_attempted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "head_ref_last_succeeded_at": {
+          "name": "head_ref_last_succeeded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "head_ref_lease_token": {
+          "name": "head_ref_lease_token",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "head_ref_lease_until": {
+          "name": "head_ref_lease_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "head_ref_next_page": {
+          "name": "head_ref_next_page",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "head_ref_scan_started_at": {
+          "name": "head_ref_scan_started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ref_backfill_since_at": {
+          "name": "ref_backfill_since_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "tag_ref_cursor_repository_id": {
+          "name": "tag_ref_cursor_repository_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tag_ref_cycle_started_at": {
+          "name": "tag_ref_cycle_started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tag_ref_last_attempted_at": {
+          "name": "tag_ref_last_attempted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tag_ref_last_succeeded_at": {
+          "name": "tag_ref_last_succeeded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tag_ref_lease_token": {
+          "name": "tag_ref_lease_token",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tag_ref_lease_until": {
+          "name": "tag_ref_lease_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tag_ref_next_page": {
+          "name": "tag_ref_next_page",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tag_ref_scan_started_at": {
+          "name": "tag_ref_scan_started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "github_account_checkpoints_tracked_account": {
+          "name": "github_account_checkpoints_tracked_account",
+          "value": "\"github_account_checkpoints\".\"account\" IN ('f0rr0', 'yuppiestechdev')"
+        },
+        "github_account_checkpoints_event_id_shape": {
+          "name": "github_account_checkpoints_event_id_shape",
+          "value": "(\"github_account_checkpoints\".\"latest_event_id\" IS NULL OR \"github_account_checkpoints\".\"latest_event_id\" ~ '^[0-9]{1,64}$') AND (\"github_account_checkpoints\".\"gap_expected_event_id\" IS NULL OR \"github_account_checkpoints\".\"gap_expected_event_id\" ~ '^[0-9]{1,64}$') AND (\"github_account_checkpoints\".\"gap_oldest_available_event_id\" IS NULL OR \"github_account_checkpoints\".\"gap_oldest_available_event_id\" ~ '^[0-9]{1,64}$')"
+        },
+        "github_account_checkpoints_gap_state": {
+          "name": "github_account_checkpoints_gap_state",
+          "value": "\"github_account_checkpoints\".\"gap_state\" IN ('clear', 'detected')"
+        },
+        "github_account_checkpoints_gap_details": {
+          "name": "github_account_checkpoints_gap_details",
+          "value": "(\"github_account_checkpoints\".\"gap_state\" = 'detected' AND \"github_account_checkpoints\".\"gap_detected_at\" IS NOT NULL) OR (\"github_account_checkpoints\".\"gap_state\" = 'clear' AND \"github_account_checkpoints\".\"gap_detected_at\" IS NULL AND \"github_account_checkpoints\".\"gap_expected_event_id\" IS NULL AND \"github_account_checkpoints\".\"gap_oldest_available_event_id\" IS NULL)"
+        },
+        "github_account_checkpoints_ref_cursor_shape": {
+          "name": "github_account_checkpoints_ref_cursor_shape",
+          "value": "(\"github_account_checkpoints\".\"head_ref_cursor_repository_id\" IS NULL OR \"github_account_checkpoints\".\"head_ref_cursor_repository_id\" ~ '^[0-9]{1,32}$') AND (\"github_account_checkpoints\".\"tag_ref_cursor_repository_id\" IS NULL OR \"github_account_checkpoints\".\"tag_ref_cursor_repository_id\" ~ '^[0-9]{1,32}$')"
+        },
+        "github_account_checkpoints_ref_leases": {
+          "name": "github_account_checkpoints_ref_leases",
+          "value": "(\"github_account_checkpoints\".\"head_ref_lease_token\" IS NULL) = (\"github_account_checkpoints\".\"head_ref_lease_until\" IS NULL) AND (\"github_account_checkpoints\".\"tag_ref_lease_token\" IS NULL) = (\"github_account_checkpoints\".\"tag_ref_lease_until\" IS NULL)"
+        },
+        "github_account_checkpoints_ref_scans": {
+          "name": "github_account_checkpoints_ref_scans",
+          "value": "(\"github_account_checkpoints\".\"head_ref_next_page\" IS NULL AND \"github_account_checkpoints\".\"head_ref_scan_started_at\" IS NULL OR \"github_account_checkpoints\".\"head_ref_next_page\" >= 2 AND \"github_account_checkpoints\".\"head_ref_scan_started_at\" IS NOT NULL) AND (\"github_account_checkpoints\".\"tag_ref_next_page\" IS NULL AND \"github_account_checkpoints\".\"tag_ref_scan_started_at\" IS NULL OR \"github_account_checkpoints\".\"tag_ref_next_page\" >= 2 AND \"github_account_checkpoints\".\"tag_ref_scan_started_at\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.github_commits": {
+      "name": "github_commits",
+      "schema": "",
+      "columns": {
+        "activity_public_id": {
+          "name": "activity_public_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "additions": {
+          "name": "additions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_login": {
+          "name": "author_login",
+          "type": "varchar(39)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "authored_at": {
+          "name": "authored_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_user_id": {
+          "name": "author_user_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canonicalized_at": {
+          "name": "canonicalized_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "changed_files": {
+          "name": "changed_files",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "change_fingerprint": {
+          "name": "change_fingerprint",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "committed_at": {
+          "name": "committed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "committer_at": {
+          "name": "committer_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "committer_user_id": {
+          "name": "committer_user_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deletions": {
+          "name": "deletions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enrichment_error": {
+          "name": "enrichment_error",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enrichment_attempts": {
+          "name": "enrichment_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "enrichment_lease_token": {
+          "name": "enrichment_lease_token",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enrichment_lease_until": {
+          "name": "enrichment_lease_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enrichment_state": {
+          "name": "enrichment_state",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "fingerprint_complete": {
+          "name": "fingerprint_complete",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "first_observed_at": {
+          "name": "first_observed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "full_message": {
+          "name": "full_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "languages": {
+          "name": "languages",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_shas": {
+          "name": "parent_shas",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_file_cap_reached": {
+          "name": "provider_file_cap_reached",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "pr_discovery_error": {
+          "name": "pr_discovery_error",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_discovery_attempts": {
+          "name": "pr_discovery_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "pr_discovery_lease_token": {
+          "name": "pr_discovery_lease_token",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_discovery_lease_until": {
+          "name": "pr_discovery_lease_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_discovery_state": {
+          "name": "pr_discovery_state",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "repository": {
+          "name": "repository",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository_owner_avatar_url": {
+          "name": "repository_owner_avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repository_owner_login": {
+          "name": "repository_owner_login",
+          "type": "varchar(39)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repository_owner_type": {
+          "name": "repository_owner_type",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repository_private": {
+          "name": "repository_private",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sha": {
+          "name": "sha",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "substantive_loc": {
+          "name": "substantive_loc",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary_attempted_at": {
+          "name": "summary_attempted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary_error": {
+          "name": "summary_error",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary_headline": {
+          "name": "summary_headline",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary_input_hash": {
+          "name": "summary_input_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary_model": {
+          "name": "summary_model",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary_recipe": {
+          "name": "summary_recipe",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary_short": {
+          "name": "summary_short",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tree_sha": {
+          "name": "tree_sha",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "github_commits_activity_public_id_unique": {
+          "name": "github_commits_activity_public_id_unique",
+          "columns": [
+            {
+              "expression": "activity_public_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_commits_activity_cursor_idx": {
+          "name": "github_commits_activity_cursor_idx",
+          "columns": [
+            {
+              "expression": "committed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "activity_public_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_commits_committed_at_idx": {
+          "name": "github_commits_committed_at_idx",
+          "columns": [
+            {
+              "expression": "committed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_commits_summary_pending_idx": {
+          "name": "github_commits_summary_pending_idx",
+          "columns": [
+            {
+              "expression": "summary_attempted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "committed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_commits_enrichment_pending_idx": {
+          "name": "github_commits_enrichment_pending_idx",
+          "columns": [
+            {
+              "expression": "enrichment_state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "enrichment_lease_until",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "committed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_commits_canonicalization_pending_idx": {
+          "name": "github_commits_canonicalization_pending_idx",
+          "columns": [
+            {
+              "expression": "canonicalized_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "first_observed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_commits_pr_discovery_pending_idx": {
+          "name": "github_commits_pr_discovery_pending_idx",
+          "columns": [
+            {
+              "expression": "pr_discovery_state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pr_discovery_lease_until",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "first_observed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "github_commits_repository_id_sha_pk": {
+          "name": "github_commits_repository_id_sha_pk",
+          "columns": ["repository_id", "sha"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "github_commits_sha_shape": {
+          "name": "github_commits_sha_shape",
+          "value": "\"github_commits\".\"sha\" ~ '^[a-f0-9]{40}$'"
+        },
+        "github_commits_tree_sha_shape": {
+          "name": "github_commits_tree_sha_shape",
+          "value": "\"github_commits\".\"tree_sha\" IS NULL OR \"github_commits\".\"tree_sha\" ~ '^[a-f0-9]{40}$'"
+        },
+        "github_commits_fingerprint_shape": {
+          "name": "github_commits_fingerprint_shape",
+          "value": "\"github_commits\".\"change_fingerprint\" IS NULL OR \"github_commits\".\"change_fingerprint\" ~ '^[a-f0-9]{64}$'"
+        },
+        "github_commits_fingerprint_completeness": {
+          "name": "github_commits_fingerprint_completeness",
+          "value": "NOT \"github_commits\".\"fingerprint_complete\" OR \"github_commits\".\"change_fingerprint\" IS NOT NULL"
+        },
+        "github_commits_parent_shas_array": {
+          "name": "github_commits_parent_shas_array",
+          "value": "\"github_commits\".\"parent_shas\" IS NULL OR jsonb_typeof(\"github_commits\".\"parent_shas\") = 'array'"
+        },
+        "github_commits_enrichment_state": {
+          "name": "github_commits_enrichment_state",
+          "value": "\"github_commits\".\"enrichment_state\" IN ('pending', 'processing', 'complete', 'unavailable')"
+        },
+        "github_commits_enrichment_lease": {
+          "name": "github_commits_enrichment_lease",
+          "value": "(\"github_commits\".\"enrichment_state\" = 'processing') = (\"github_commits\".\"enrichment_lease_token\" IS NOT NULL) AND (\"github_commits\".\"enrichment_state\" <> 'processing' OR \"github_commits\".\"enrichment_lease_until\" IS NOT NULL) AND (\"github_commits\".\"enrichment_state\" NOT IN ('complete', 'unavailable') OR \"github_commits\".\"enrichment_lease_until\" IS NULL)"
+        },
+        "github_commits_pr_discovery_state": {
+          "name": "github_commits_pr_discovery_state",
+          "value": "\"github_commits\".\"pr_discovery_state\" IN ('pending', 'processing', 'complete', 'unavailable')"
+        },
+        "github_commits_pr_discovery_lease": {
+          "name": "github_commits_pr_discovery_lease",
+          "value": "(\"github_commits\".\"pr_discovery_state\" = 'processing') = (\"github_commits\".\"pr_discovery_lease_token\" IS NOT NULL) AND (\"github_commits\".\"pr_discovery_state\" <> 'processing' OR \"github_commits\".\"pr_discovery_lease_until\" IS NOT NULL) AND (\"github_commits\".\"pr_discovery_state\" NOT IN ('complete', 'unavailable') OR \"github_commits\".\"pr_discovery_lease_until\" IS NULL)"
+        },
+        "github_commits_tracked_author": {
+          "name": "github_commits_tracked_author",
+          "value": "\"github_commits\".\"author_login\" IN ('f0rr0', 'yuppiestechdev')"
+        },
+        "github_commits_nonnegative_activity_counts": {
+          "name": "github_commits_nonnegative_activity_counts",
+          "value": "(\"github_commits\".\"changed_files\" IS NULL OR \"github_commits\".\"changed_files\" >= 0) AND (\"github_commits\".\"additions\" IS NULL OR \"github_commits\".\"additions\" >= 0) AND (\"github_commits\".\"deletions\" IS NULL OR \"github_commits\".\"deletions\" >= 0) AND (\"github_commits\".\"substantive_loc\" IS NULL OR \"github_commits\".\"substantive_loc\" >= 0)"
+        },
+        "github_commits_nonnegative_attempts": {
+          "name": "github_commits_nonnegative_attempts",
+          "value": "\"github_commits\".\"enrichment_attempts\" >= 0 AND \"github_commits\".\"pr_discovery_attempts\" >= 0"
+        },
+        "github_commits_owner_type": {
+          "name": "github_commits_owner_type",
+          "value": "\"github_commits\".\"repository_owner_type\" IS NULL OR \"github_commits\".\"repository_owner_type\" IN ('Organization', 'User')"
+        },
+        "github_commits_summary_hash_shape": {
+          "name": "github_commits_summary_hash_shape",
+          "value": "\"github_commits\".\"summary_input_hash\" IS NULL OR \"github_commits\".\"summary_input_hash\" ~ '^[a-f0-9]{64}$'"
+        },
+        "github_commits_summary_pair": {
+          "name": "github_commits_summary_pair",
+          "value": "(\"github_commits\".\"summary_headline\" IS NULL) = (\"github_commits\".\"summary_short\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.github_issues": {
+      "name": "github_issues",
+      "schema": "",
+      "columns": {
+        "account": {
+          "name": "account",
+          "type": "varchar(39)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_login": {
+          "name": "author_login",
+          "type": "varchar(39)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_user_id": {
+          "name": "author_user_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_observed_at": {
+          "name": "first_observed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "varchar(128)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "number": {
+          "name": "number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title_snapshot": {
+          "name": "title_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url_snapshot": {
+          "name": "url_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "github_issues_repository_number_unique": {
+          "name": "github_issues_repository_number_unique",
+          "columns": [
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_issues_author_idx": {
+          "name": "github_issues_author_idx",
+          "columns": [
+            {
+              "expression": "author_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_issues_repository_id_github_repositories_id_fk": {
+          "name": "github_issues_repository_id_github_repositories_id_fk",
+          "tableFrom": "github_issues",
+          "tableTo": "github_repositories",
+          "columnsFrom": ["repository_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "github_issues_tracked_account": {
+          "name": "github_issues_tracked_account",
+          "value": "\"github_issues\".\"account\" IN ('f0rr0', 'yuppiestechdev')"
+        },
+        "github_issues_positive_number": {
+          "name": "github_issues_positive_number",
+          "value": "\"github_issues\".\"number\" > 0"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.github_public_activities": {
+      "name": "github_public_activities",
+      "schema": "",
+      "columns": {
+        "alias_evidence": {
+          "name": "alias_evidence",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alias_reason": {
+          "name": "alias_reason",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canonical_public_id": {
+          "name": "canonical_public_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "hidden_at": {
+          "name": "hidden_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_id": {
+          "name": "public_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revision": {
+          "name": "revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "source_node_id": {
+          "name": "source_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "github_public_activities_source_unique": {
+          "name": "github_public_activities_source_unique",
+          "columns": [
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_public_activities_cursor_idx": {
+          "name": "github_public_activities_cursor_idx",
+          "columns": [
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "public_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_public_activities_canonical_idx": {
+          "name": "github_public_activities_canonical_idx",
+          "columns": [
+            {
+              "expression": "canonical_public_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_public_activities_canonical_fk": {
+          "name": "github_public_activities_canonical_fk",
+          "tableFrom": "github_public_activities",
+          "tableTo": "github_public_activities",
+          "columnsFrom": ["canonical_public_id"],
+          "columnsTo": ["public_id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "github_public_activities_kind": {
+          "name": "github_public_activities_kind",
+          "value": "\"github_public_activities\".\"kind\" IN ('commit', 'pull_request', 'issue')"
+        },
+        "github_public_activities_not_self_canonical": {
+          "name": "github_public_activities_not_self_canonical",
+          "value": "\"github_public_activities\".\"canonical_public_id\" IS NULL OR \"github_public_activities\".\"canonical_public_id\" <> \"github_public_activities\".\"public_id\""
+        },
+        "github_public_activities_positive_revision": {
+          "name": "github_public_activities_positive_revision",
+          "value": "\"github_public_activities\".\"revision\" > 0"
+        },
+        "github_public_activities_alias_audit": {
+          "name": "github_public_activities_alias_audit",
+          "value": "(\"github_public_activities\".\"canonical_public_id\" IS NULL AND \"github_public_activities\".\"alias_reason\" IS NULL AND \"github_public_activities\".\"alias_evidence\" IS NULL) OR (\"github_public_activities\".\"canonical_public_id\" IS NOT NULL AND \"github_public_activities\".\"alias_reason\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.github_pull_request_memberships": {
+      "name": "github_pull_request_memberships",
+      "schema": "",
+      "columns": {
+        "commit_repository_id": {
+          "name": "commit_repository_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "commit_sha": {
+          "name": "commit_sha",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_head": {
+          "name": "is_head",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version_id": {
+          "name": "version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "github_pull_request_memberships_position_unique": {
+          "name": "github_pull_request_memberships_position_unique",
+          "columns": [
+            {
+              "expression": "version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_pull_request_memberships_commit_lookup_idx": {
+          "name": "github_pull_request_memberships_commit_lookup_idx",
+          "columns": [
+            {
+              "expression": "commit_repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "commit_sha",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gh_pr_memberships_version_fk": {
+          "name": "gh_pr_memberships_version_fk",
+          "tableFrom": "github_pull_request_memberships",
+          "tableTo": "github_pull_request_versions",
+          "columnsFrom": ["version_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "gh_pr_memberships_pk": {
+          "name": "gh_pr_memberships_pk",
+          "columns": ["version_id", "commit_repository_id", "commit_sha"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "github_pull_request_memberships_sha_shape": {
+          "name": "github_pull_request_memberships_sha_shape",
+          "value": "\"github_pull_request_memberships\".\"commit_sha\" ~ '^[a-f0-9]{40}$'"
+        },
+        "github_pull_request_memberships_nonnegative_position": {
+          "name": "github_pull_request_memberships_nonnegative_position",
+          "value": "\"github_pull_request_memberships\".\"position\" >= 0"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.github_pull_request_signals": {
+      "name": "github_pull_request_signals",
+      "schema": "",
+      "columns": {
+        "account": {
+          "name": "account",
+          "type": "varchar(39)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "lease_token": {
+          "name": "lease_token",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lease_until": {
+          "name": "lease_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "number": {
+          "name": "number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "observed_at": {
+          "name": "observed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository_name_snapshot": {
+          "name": "repository_name_snapshot",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        }
+      },
+      "indexes": {
+        "github_pull_request_signals_event_unique": {
+          "name": "github_pull_request_signals_event_unique",
+          "columns": [
+            {
+              "expression": "account",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_pull_request_signals_pending_idx": {
+          "name": "github_pull_request_signals_pending_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lease_until",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "observed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "github_pull_request_signals_account": {
+          "name": "github_pull_request_signals_account",
+          "value": "\"github_pull_request_signals\".\"account\" IN ('f0rr0', 'yuppiestechdev')"
+        },
+        "github_pull_request_signals_event_id": {
+          "name": "github_pull_request_signals_event_id",
+          "value": "\"github_pull_request_signals\".\"event_id\" ~ '^[0-9]{1,64}$'"
+        },
+        "github_pull_request_signals_repository_id": {
+          "name": "github_pull_request_signals_repository_id",
+          "value": "\"github_pull_request_signals\".\"repository_id\" ~ '^[0-9]{1,32}$'"
+        },
+        "github_pull_request_signals_state": {
+          "name": "github_pull_request_signals_state",
+          "value": "\"github_pull_request_signals\".\"state\" IN ('pending', 'processing', 'complete', 'unavailable')"
+        },
+        "github_pull_request_signals_lease": {
+          "name": "github_pull_request_signals_lease",
+          "value": "(\"github_pull_request_signals\".\"state\" = 'processing') = (\"github_pull_request_signals\".\"lease_token\" IS NOT NULL) AND (\"github_pull_request_signals\".\"state\" <> 'processing' OR \"github_pull_request_signals\".\"lease_until\" IS NOT NULL)"
+        },
+        "github_pull_request_signals_values": {
+          "name": "github_pull_request_signals_values",
+          "value": "\"github_pull_request_signals\".\"number\" > 0 AND \"github_pull_request_signals\".\"attempt_count\" >= 0"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.github_pull_request_versions": {
+      "name": "github_pull_request_versions",
+      "schema": "",
+      "columns": {
+        "base_ref_name": {
+          "name": "base_ref_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_repository_id": {
+          "name": "base_repository_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_sha": {
+          "name": "base_sha",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "commit_count": {
+          "name": "commit_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "head_ref_name": {
+          "name": "head_ref_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "head_repository_id": {
+          "name": "head_repository_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "head_sha": {
+          "name": "head_sha",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "is_current": {
+          "name": "is_current",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "membership_complete": {
+          "name": "membership_complete",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "merge_snapshot": {
+          "name": "merge_snapshot",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "observed_at": {
+          "name": "observed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "provider_updated_at": {
+          "name": "provider_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pull_request_node_id": {
+          "name": "pull_request_node_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "github_pull_request_versions_head_unique": {
+          "name": "github_pull_request_versions_head_unique",
+          "columns": [
+            {
+              "expression": "pull_request_node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "head_sha",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_pull_request_versions_current_unique": {
+          "name": "github_pull_request_versions_current_unique",
+          "columns": [
+            {
+              "expression": "pull_request_node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"github_pull_request_versions\".\"is_current\"",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gh_pr_versions_pull_request_fk": {
+          "name": "gh_pr_versions_pull_request_fk",
+          "tableFrom": "github_pull_request_versions",
+          "tableTo": "github_pull_requests",
+          "columnsFrom": ["pull_request_node_id"],
+          "columnsTo": ["node_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "github_pull_request_versions_sha_shapes": {
+          "name": "github_pull_request_versions_sha_shapes",
+          "value": "\"github_pull_request_versions\".\"base_sha\" ~ '^[a-f0-9]{40}$' AND \"github_pull_request_versions\".\"head_sha\" ~ '^[a-f0-9]{40}$'"
+        },
+        "github_pull_request_versions_nonnegative_count": {
+          "name": "github_pull_request_versions_nonnegative_count",
+          "value": "\"github_pull_request_versions\".\"commit_count\" IS NULL OR \"github_pull_request_versions\".\"commit_count\" >= 0"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.github_pull_requests": {
+      "name": "github_pull_requests",
+      "schema": "",
+      "columns": {
+        "account": {
+          "name": "account",
+          "type": "varchar(39)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "additions": {
+          "name": "additions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_login": {
+          "name": "author_login",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_user_id": {
+          "name": "author_user_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "base_ref_name": {
+          "name": "base_ref_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_repository_id": {
+          "name": "base_repository_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_sha": {
+          "name": "base_sha",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body_snapshot": {
+          "name": "body_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "changed_files": {
+          "name": "changed_files",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commit_count": {
+          "name": "commit_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deletions": {
+          "name": "deletions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "draft": {
+          "name": "draft",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "first_observed_at": {
+          "name": "first_observed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "head_ref_name": {
+          "name": "head_ref_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "head_repository_id": {
+          "name": "head_repository_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "head_sha": {
+          "name": "head_sha",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_reconciled_at": {
+          "name": "last_reconciled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "merged_at": {
+          "name": "merged_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "merge_sha": {
+          "name": "merge_sha",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "merge_sha_verified_at": {
+          "name": "merge_sha_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_reconcile_at": {
+          "name": "next_reconcile_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "varchar(128)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "number": {
+          "name": "number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_file_cap_reached": {
+          "name": "provider_file_cap_reached",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "provider_updated_at": {
+          "name": "provider_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reconcile_attempts": {
+          "name": "reconcile_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reconcile_error": {
+          "name": "reconcile_error",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "terminal_at": {
+          "name": "terminal_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title_snapshot": {
+          "name": "title_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "github_pull_requests_repository_number_unique": {
+          "name": "github_pull_requests_repository_number_unique",
+          "columns": [
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_pull_requests_reconciliation_idx": {
+          "name": "github_pull_requests_reconciliation_idx",
+          "columns": [
+            {
+              "expression": "account",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_reconcile_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_pull_requests_author_idx": {
+          "name": "github_pull_requests_author_idx",
+          "columns": [
+            {
+              "expression": "author_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_pull_requests_repository_id_github_repositories_id_fk": {
+          "name": "github_pull_requests_repository_id_github_repositories_id_fk",
+          "tableFrom": "github_pull_requests",
+          "tableTo": "github_repositories",
+          "columnsFrom": ["repository_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "github_pull_requests_tracked_account": {
+          "name": "github_pull_requests_tracked_account",
+          "value": "\"github_pull_requests\".\"account\" IN ('f0rr0', 'yuppiestechdev')"
+        },
+        "github_pull_requests_state": {
+          "name": "github_pull_requests_state",
+          "value": "\"github_pull_requests\".\"state\" IN ('open', 'closed', 'merged')"
+        },
+        "github_pull_requests_terminal_state": {
+          "name": "github_pull_requests_terminal_state",
+          "value": "(\"github_pull_requests\".\"state\" = 'open' AND \"github_pull_requests\".\"terminal_at\" IS NULL) OR (\"github_pull_requests\".\"state\" IN ('closed', 'merged') AND \"github_pull_requests\".\"terminal_at\" IS NOT NULL)"
+        },
+        "github_pull_requests_merged_state": {
+          "name": "github_pull_requests_merged_state",
+          "value": "(\"github_pull_requests\".\"state\" = 'merged') = (\"github_pull_requests\".\"merged_at\" IS NOT NULL)"
+        },
+        "github_pull_requests_sha_shapes": {
+          "name": "github_pull_requests_sha_shapes",
+          "value": "(\"github_pull_requests\".\"base_sha\" IS NULL OR \"github_pull_requests\".\"base_sha\" ~ '^[a-f0-9]{40}$') AND (\"github_pull_requests\".\"head_sha\" IS NULL OR \"github_pull_requests\".\"head_sha\" ~ '^[a-f0-9]{40}$') AND (\"github_pull_requests\".\"merge_sha\" IS NULL OR \"github_pull_requests\".\"merge_sha\" ~ '^[a-f0-9]{40}$')"
+        },
+        "github_pull_requests_verified_merge_sha": {
+          "name": "github_pull_requests_verified_merge_sha",
+          "value": "(\"github_pull_requests\".\"merge_sha\" IS NULL AND \"github_pull_requests\".\"merge_sha_verified_at\" IS NULL) OR (\"github_pull_requests\".\"state\" = 'merged' AND \"github_pull_requests\".\"merge_sha_verified_at\" IS NOT NULL)"
+        },
+        "github_pull_requests_positive_number": {
+          "name": "github_pull_requests_positive_number",
+          "value": "\"github_pull_requests\".\"number\" > 0"
+        },
+        "github_pull_requests_nonnegative_counts": {
+          "name": "github_pull_requests_nonnegative_counts",
+          "value": "(\"github_pull_requests\".\"changed_files\" IS NULL OR \"github_pull_requests\".\"changed_files\" >= 0) AND (\"github_pull_requests\".\"additions\" IS NULL OR \"github_pull_requests\".\"additions\" >= 0) AND (\"github_pull_requests\".\"deletions\" IS NULL OR \"github_pull_requests\".\"deletions\" >= 0) AND (\"github_pull_requests\".\"commit_count\" IS NULL OR \"github_pull_requests\".\"commit_count\" >= 0)"
+        },
+        "github_pull_requests_nonnegative_attempts": {
+          "name": "github_pull_requests_nonnegative_attempts",
+          "value": "\"github_pull_requests\".\"reconcile_attempts\" >= 0"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.github_push_observation_commits": {
+      "name": "github_push_observation_commits",
+      "schema": "",
+      "columns": {
+        "observation_id": {
+          "name": "observation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sha": {
+          "name": "sha",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "github_push_observation_commits_position_unique": {
+          "name": "github_push_observation_commits_position_unique",
+          "columns": [
+            {
+              "expression": "observation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gh_push_observation_commits_observation_fk": {
+          "name": "gh_push_observation_commits_observation_fk",
+          "tableFrom": "github_push_observation_commits",
+          "tableTo": "github_push_observations",
+          "columnsFrom": ["observation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "gh_push_observation_commits_pk": {
+          "name": "gh_push_observation_commits_pk",
+          "columns": ["observation_id", "repository_id", "sha"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "github_push_observation_commits_sha_shape": {
+          "name": "github_push_observation_commits_sha_shape",
+          "value": "\"github_push_observation_commits\".\"sha\" ~ '^[a-f0-9]{40}$'"
+        },
+        "github_push_observation_commits_nonnegative_position": {
+          "name": "github_push_observation_commits_nonnegative_position",
+          "value": "\"github_push_observation_commits\".\"position\" >= 0"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.github_push_observations": {
+      "name": "github_push_observations",
+      "schema": "",
+      "columns": {
+        "account": {
+          "name": "account",
+          "type": "varchar(39)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "after_sha": {
+          "name": "after_sha",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "before_sha": {
+          "name": "before_sha",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expected_commit_count": {
+          "name": "expected_commit_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "history_since_at": {
+          "name": "history_since_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "history_until_at": {
+          "name": "history_until_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "lease_token": {
+          "name": "lease_token",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lease_until": {
+          "name": "lease_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "observed_at": {
+          "name": "observed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "provider_created_at": {
+          "name": "provider_created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ref_name": {
+          "name": "ref_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository_name_snapshot": {
+          "name": "repository_name_snapshot",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        }
+      },
+      "indexes": {
+        "github_push_observations_source_unique": {
+          "name": "github_push_observations_source_unique",
+          "columns": [
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_push_observations_push_unique": {
+          "name": "github_push_observations_push_unique",
+          "columns": [
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ref_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "before_sha",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "after_sha",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"github_push_observations\".\"source\" <> 'backfill'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_push_observations_pending_idx": {
+          "name": "github_push_observations_pending_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lease_until",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "observed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_push_observations_account_idx": {
+          "name": "github_push_observations_account_idx",
+          "columns": [
+            {
+              "expression": "account",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "observed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gh_push_observations_repository_fk": {
+          "name": "gh_push_observations_repository_fk",
+          "tableFrom": "github_push_observations",
+          "tableTo": "github_repositories",
+          "columnsFrom": ["repository_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "github_push_observations_tracked_account": {
+          "name": "github_push_observations_tracked_account",
+          "value": "\"github_push_observations\".\"account\" IN ('f0rr0', 'yuppiestechdev')"
+        },
+        "github_push_observations_source": {
+          "name": "github_push_observations_source",
+          "value": "\"github_push_observations\".\"source\" IN ('webhook', 'events', 'refs', 'backfill')"
+        },
+        "github_push_observations_sha_shape": {
+          "name": "github_push_observations_sha_shape",
+          "value": "\"github_push_observations\".\"before_sha\" ~ '^[a-f0-9]{40}$' AND \"github_push_observations\".\"after_sha\" ~ '^[a-f0-9]{40}$'"
+        },
+        "github_push_observations_nonnegative_count": {
+          "name": "github_push_observations_nonnegative_count",
+          "value": "\"github_push_observations\".\"attempt_count\" >= 0 AND (\"github_push_observations\".\"expected_commit_count\" IS NULL OR \"github_push_observations\".\"expected_commit_count\" >= 0)"
+        },
+        "github_push_observations_history_bounds": {
+          "name": "github_push_observations_history_bounds",
+          "value": "(\"github_push_observations\".\"source\" <> 'backfill' AND \"github_push_observations\".\"history_since_at\" IS NULL AND \"github_push_observations\".\"history_until_at\" IS NULL) OR (\"github_push_observations\".\"source\" = 'backfill' AND \"github_push_observations\".\"history_since_at\" IS NOT NULL AND \"github_push_observations\".\"history_until_at\" IS NOT NULL AND \"github_push_observations\".\"history_since_at\" <= \"github_push_observations\".\"history_until_at\" AND \"github_push_observations\".\"expected_commit_count\" IS NULL AND \"github_push_observations\".\"before_sha\" = repeat('0', 40))"
+        },
+        "github_push_observations_state": {
+          "name": "github_push_observations_state",
+          "value": "\"github_push_observations\".\"state\" IN ('pending', 'processing', 'complete', 'deferred', 'unavailable')"
+        },
+        "github_push_observations_lease": {
+          "name": "github_push_observations_lease",
+          "value": "(\"github_push_observations\".\"state\" = 'processing') = (\"github_push_observations\".\"lease_token\" IS NOT NULL) AND (\"github_push_observations\".\"state\" <> 'processing' OR \"github_push_observations\".\"lease_until\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.github_repositories": {
+      "name": "github_repositories",
+      "schema": "",
+      "columns": {
+        "default_branch": {
+          "name": "default_branch",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_observed_at": {
+          "name": "first_observed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "homepage_url": {
+          "name": "homepage_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "heads_last_reconciled_at": {
+          "name": "heads_last_reconciled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "html_url": {
+          "name": "html_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar(32)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "last_observed_at": {
+          "name": "last_observed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "owner_avatar_url": {
+          "name": "owner_avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_login": {
+          "name": "owner_login",
+          "type": "varchar(39)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_type": {
+          "name": "owner_type",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "topics": {
+          "name": "topics",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags_last_reconciled_at": {
+          "name": "tags_last_reconciled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "github_repositories_full_name_idx": {
+          "name": "github_repositories_full_name_idx",
+          "columns": [
+            {
+              "expression": "full_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "github_repositories_owner_type": {
+          "name": "github_repositories_owner_type",
+          "value": "\"github_repositories\".\"owner_type\" IS NULL OR \"github_repositories\".\"owner_type\" IN ('Organization', 'User')"
+        },
+        "github_repositories_visibility": {
+          "name": "github_repositories_visibility",
+          "value": "\"github_repositories\".\"visibility\" IS NULL OR \"github_repositories\".\"visibility\" IN ('public', 'private', 'internal')"
+        },
+        "github_repositories_topics_array": {
+          "name": "github_repositories_topics_array",
+          "value": "\"github_repositories\".\"topics\" IS NULL OR jsonb_typeof(\"github_repositories\".\"topics\") = 'array'"
+        },
+        "github_repositories_observation_order": {
+          "name": "github_repositories_observation_order",
+          "value": "\"github_repositories\".\"last_observed_at\" >= \"github_repositories\".\"first_observed_at\""
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.github_repository_refs": {
+      "name": "github_repository_refs",
+      "schema": "",
+      "columns": {
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "first_observed_at": {
+          "name": "first_observed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "head_sha": {
+          "name": "head_sha",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_observed_at": {
+          "name": "last_observed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ref_name": {
+          "name": "ref_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "github_repository_refs_active_idx": {
+          "name": "github_repository_refs_active_idx",
+          "columns": [
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_repository_refs_repository_fk": {
+          "name": "github_repository_refs_repository_fk",
+          "tableFrom": "github_repository_refs",
+          "tableTo": "github_repositories",
+          "columnsFrom": ["repository_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "github_repository_refs_repository_id_ref_name_pk": {
+          "name": "github_repository_refs_repository_id_ref_name_pk",
+          "columns": ["repository_id", "ref_name"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "github_repository_refs_kind": {
+          "name": "github_repository_refs_kind",
+          "value": "\"github_repository_refs\".\"kind\" IN ('head', 'tag')"
+        },
+        "github_repository_refs_name": {
+          "name": "github_repository_refs_name",
+          "value": "(\"github_repository_refs\".\"kind\" = 'head' AND \"github_repository_refs\".\"ref_name\" LIKE 'refs/heads/%') OR (\"github_repository_refs\".\"kind\" = 'tag' AND \"github_repository_refs\".\"ref_name\" LIKE 'refs/tags/%')"
+        },
+        "github_repository_refs_sha_shape": {
+          "name": "github_repository_refs_sha_shape",
+          "value": "\"github_repository_refs\".\"head_sha\" ~ '^[a-f0-9]{40}$'"
+        },
+        "github_repository_refs_observation_order": {
+          "name": "github_repository_refs_observation_order",
+          "value": "\"github_repository_refs\".\"last_observed_at\" >= \"github_repository_refs\".\"first_observed_at\""
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.github_summary_attempts": {
+      "name": "github_summary_attempts",
+      "schema": "",
+      "columns": {
+        "activity_public_id": {
+          "name": "activity_public_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "attempted_at": {
+          "name": "attempted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_hash": {
+          "name": "input_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lease_token": {
+          "name": "lease_token",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lease_until": {
+          "name": "lease_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recipe": {
+          "name": "recipe",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revision": {
+          "name": "revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "summary_headline": {
+          "name": "summary_headline",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary_short": {
+          "name": "summary_short",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "github_summary_attempts_pending_idx": {
+          "name": "github_summary_attempts_pending_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gh_summary_attempts_activity_fk": {
+          "name": "gh_summary_attempts_activity_fk",
+          "tableFrom": "github_summary_attempts",
+          "tableTo": "github_public_activities",
+          "columnsFrom": ["activity_public_id"],
+          "columnsTo": ["public_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "gh_summary_attempts_pk": {
+          "name": "gh_summary_attempts_pk",
+          "columns": ["activity_public_id", "revision"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "github_summary_attempts_state": {
+          "name": "github_summary_attempts_state",
+          "value": "\"github_summary_attempts\".\"state\" IN ('pending', 'processing', 'complete', 'failed', 'indeterminate')"
+        },
+        "github_summary_attempts_positive_revision": {
+          "name": "github_summary_attempts_positive_revision",
+          "value": "\"github_summary_attempts\".\"revision\" > 0 AND \"github_summary_attempts\".\"attempt_count\" >= 0"
+        },
+        "github_summary_attempts_input_hash_shape": {
+          "name": "github_summary_attempts_input_hash_shape",
+          "value": "\"github_summary_attempts\".\"input_hash\" IS NULL OR \"github_summary_attempts\".\"input_hash\" ~ '^[a-f0-9]{64}$'"
+        },
+        "github_summary_attempts_summary_pair": {
+          "name": "github_summary_attempts_summary_pair",
+          "value": "(\"github_summary_attempts\".\"summary_headline\" IS NULL) = (\"github_summary_attempts\".\"summary_short\" IS NULL)"
+        },
+        "github_summary_attempts_complete_output": {
+          "name": "github_summary_attempts_complete_output",
+          "value": "\"github_summary_attempts\".\"state\" <> 'complete' OR (\"github_summary_attempts\".\"summary_headline\" IS NOT NULL AND \"github_summary_attempts\".\"completed_at\" IS NOT NULL)"
+        },
+        "github_summary_attempts_lease": {
+          "name": "github_summary_attempts_lease",
+          "value": "(\"github_summary_attempts\".\"state\" = 'processing') = (\"github_summary_attempts\".\"lease_token\" IS NOT NULL) AND (\"github_summary_attempts\".\"state\" <> 'processing' OR \"github_summary_attempts\".\"lease_until\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.github_webhook_deliveries": {
+      "name": "github_webhook_deliveries",
+      "schema": "",
+      "columns": {
+        "accepted": {
+          "name": "accepted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account": {
+          "name": "account",
+          "type": "varchar(39)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_id": {
+          "name": "delivery_id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event": {
+          "name": "event",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "observed_at": {
+          "name": "observed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "github_webhook_deliveries_audit_idx": {
+          "name": "github_webhook_deliveries_audit_idx",
+          "columns": [
+            {
+              "expression": "event",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "observed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "github_webhook_deliveries_id_shape": {
+          "name": "github_webhook_deliveries_id_shape",
+          "value": "\"github_webhook_deliveries\".\"delivery_id\" ~ '^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$'"
+        },
+        "github_webhook_deliveries_event_shape": {
+          "name": "github_webhook_deliveries_event_shape",
+          "value": "\"github_webhook_deliveries\".\"event\" ~ '^[a-z][a-z0-9_]{0,39}$'"
+        },
+        "github_webhook_deliveries_action_shape": {
+          "name": "github_webhook_deliveries_action_shape",
+          "value": "\"github_webhook_deliveries\".\"action\" IS NULL OR \"github_webhook_deliveries\".\"action\" ~ '^[a-z][a-z0-9_]{0,39}$'"
+        },
+        "github_webhook_deliveries_repository_id_shape": {
+          "name": "github_webhook_deliveries_repository_id_shape",
+          "value": "\"github_webhook_deliveries\".\"repository_id\" IS NULL OR \"github_webhook_deliveries\".\"repository_id\" ~ '^[0-9]{1,32}$'"
+        },
+        "github_webhook_deliveries_tracked_account": {
+          "name": "github_webhook_deliveries_tracked_account",
+          "value": "\"github_webhook_deliveries\".\"account\" IS NULL OR \"github_webhook_deliveries\".\"account\" IN ('f0rr0', 'yuppiestechdev')"
+        }
+      },
+      "isRLSEnabled": true
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -78,6 +78,13 @@
       "when": 1788020225272,
       "tag": "0010_clear_wonder_man",
       "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "7",
+      "when": 1788087185472,
+      "tag": "0011_vengeful_reavers",
+      "breakpoints": true
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "next dev",
-    "build": "bun scripts/migrate-production-database.ts && next build",
+    "build": "bun scripts/migrate-production-database.ts && next build && bun scripts/configure-supabase-cron.ts --production-build",
     "start": "next start",
     "test": "bun test",
     "typecheck": "tsgo --noEmit",

--- a/scripts/backfill-github-activity.ts
+++ b/scripts/backfill-github-activity.ts
@@ -1,15 +1,18 @@
 import { closeDatabase } from "../src/db/client";
 import { env } from "../src/env";
 import { runGitHubActivityWorker } from "../src/lib/github-activity-worker";
-import { MAXIMUM_GITHUB_ACTIVITY_WORKER_BATCH_SIZE } from "../src/lib/github-activity-worker-core";
+import { ensureGitHubEvidenceIntegrity } from "../src/lib/github-activity-worker-store";
 import {
-  githubBackfillRequestSeriesFrom,
-  splitGitHubBackfillRequest,
+  GITHUB_BACKFILL_WORKER_BATCH_SIZE,
+  githubBackfillProcessingCountsFrom,
+  githubBackfillRequestFrom,
 } from "../src/lib/github-backfill-core";
-import type { GitHubBackfillRequest } from "../src/lib/github-backfill-core";
-import { queueGitHubBackfill } from "../src/lib/github-commits";
+import type { GitHubBackfillProcessingCounts } from "../src/lib/github-backfill-core";
+import { assertGitHubTokenIdentity } from "../src/lib/github-commits";
+import type { TrackedGitHubAccount } from "../src/lib/github-commits-core";
+import { backfillGitHubCommitsFromCurrentRefs } from "../src/lib/github-direct-backfill";
+import { backfillGitHubPullRequests } from "../src/lib/github-pull-request-backfill";
 
-const CAPACITY_ERROR_NAME = "GitHubBackfillCapacityError";
 const MAXIMUM_ACTION_MINUTES = 330;
 const WORKER_CLEANUP_MARGIN_MS = 30_000;
 const WORKER_PASS_DURATION_MS = 240_000;
@@ -22,22 +25,28 @@ interface BackfillArguments {
   startDate: string;
 }
 
-interface BackfillTotals {
-  duplicates: number;
-  observations: number;
-  repositories: number;
-  requests: number;
-}
-
 const argumentValues = (arguments_: readonly string[]) => {
+  const allowed = new Set([
+    "account",
+    "end-date",
+    "maximum-minutes",
+    "repository-id",
+    "start-date",
+  ]);
   const values = new Map<string, string>();
   for (let index = 0; index < arguments_.length; index += 2) {
     const name = arguments_[index];
     const value = arguments_[index + 1];
-    if (name === undefined || value === undefined || !name.startsWith("--")) {
+    const key = name?.startsWith("--") ? name.slice(2) : null;
+    if (
+      key === null ||
+      value === undefined ||
+      !allowed.has(key) ||
+      values.has(key)
+    ) {
       throw new TypeError("The backfill command arguments are invalid.");
     }
-    values.set(name.slice(2), value);
+    values.set(key, value);
   }
   return values;
 };
@@ -53,7 +62,7 @@ const requiredArgument = (
   return value;
 };
 
-const backfillArgumentsFrom = (
+export const backfillArgumentsFrom = (
   arguments_: readonly string[]
 ): BackfillArguments => {
   const values = argumentValues(arguments_);
@@ -84,9 +93,6 @@ const requireEnvironment = (input: BackfillArguments) => {
   if (env.DATABASE_URL === undefined) {
     throw new Error("DATABASE_URL is not configured.");
   }
-  if (env.OPENAI_API_KEY === undefined) {
-    throw new Error("OPENAI_API_KEY is not configured.");
-  }
   const accounts =
     input.account === "all" ? ["f0rr0", "yuppiestechdev"] : [input.account];
   if (accounts.includes("f0rr0") && env.GITHUB_F0RR0_TOKEN === undefined) {
@@ -100,70 +106,44 @@ const requireEnvironment = (input: BackfillArguments) => {
   }
 };
 
-const requestValue = (
-  input: BackfillArguments,
-  startDate: string,
-  endDate: string
-) => ({
+const requestValue = (input: BackfillArguments) => ({
   account: input.account,
-  endDate,
+  endDate: input.endDate,
   repositoryId: input.repositoryId,
-  startDate,
+  startDate: input.startDate,
 });
 
-const queueRequest = async (
-  request: GitHubBackfillRequest,
-  deadlineAt: number,
-  totals: BackfillTotals
-): Promise<void> => {
-  if (Date.now() >= deadlineAt) {
-    throw new Error(
-      "The Action time budget expired before every date chunk was queued; rerun the same range to continue idempotently."
-    );
-  }
-  const result = await queueGitHubBackfill(request);
-  totals.duplicates += result.duplicates;
-  totals.observations += result.observations;
-  totals.repositories += result.repositories;
-  totals.requests += 1;
-  if (result.failedAccounts.length === 0) {
-    process.stdout.write(
-      `Queued ${request.startDate} through ${request.endDate}: ${String(result.observations)} observations (${String(result.duplicates)} already durable).\n`
-    );
-    return;
-  }
-  const capacityOnly = result.failedAccounts.every(
-    ({ error }) => error === CAPACITY_ERROR_NAME
-  );
-  const split = capacityOnly ? splitGitHubBackfillRequest(request) : null;
-  if (split !== null) {
-    process.stdout.write(
-      `Splitting ${request.startDate} through ${request.endDate} to preserve the per-request observation bound.\n`
-    );
-    await queueRequest(split[0], deadlineAt, totals);
-    await queueRequest(split[1], deadlineAt, totals);
-    return;
-  }
-  const failures = result.failedAccounts
-    .map(({ account, error }) => `${account}:${error}`)
-    .join(", ");
-  throw new Error(
-    `Backfill queueing failed for ${request.startDate} through ${request.endDate} (${failures}).`
-  );
+interface BackfillProcessingTotals extends GitHubBackfillProcessingCounts {
+  passes: number;
+  stopReason: "no_immediately_claimable_work" | "time_budget";
+}
+
+const emptyProcessingCounts = (): GitHubBackfillProcessingCounts => ({
+  aliases: 0,
+  claimed: 0,
+  deferred: 0,
+  failed: 0,
+  processed: 0,
+  unavailable: 0,
+});
+
+const addProcessingCounts = (
+  totals: GitHubBackfillProcessingCounts,
+  counts: GitHubBackfillProcessingCounts
+) => {
+  totals.aliases += counts.aliases;
+  totals.claimed += counts.claimed;
+  totals.deferred += counts.deferred;
+  totals.failed += counts.failed;
+  totals.processed += counts.processed;
+  totals.unavailable += counts.unavailable;
 };
 
-const claimedItems = (
-  result: Awaited<ReturnType<typeof runGitHubActivityWorker>>
-) =>
-  result.commits.claimed +
-  result.observations.claimed +
-  result.pullRequestDiscovery.claimed +
-  result.pullRequests.claimed +
-  result.summaries.claimed;
-
-const processQueue = async (deadlineAt: number) => {
+const processQueue = async (
+  deadlineAt: number
+): Promise<BackfillProcessingTotals> => {
   let passes = 0;
-  let totalClaimed = 0;
+  const totals = emptyProcessingCounts();
   while (Date.now() + WORKER_CLEANUP_MARGIN_MS < deadlineAt) {
     const maximumDurationMs = Math.min(
       WORKER_PASS_DURATION_MS,
@@ -173,52 +153,129 @@ const processQueue = async (deadlineAt: number) => {
       break;
     }
     const result = await runGitHubActivityWorker({
-      commitLimit: MAXIMUM_GITHUB_ACTIVITY_WORKER_BATCH_SIZE,
+      commitLimit: GITHUB_BACKFILL_WORKER_BATCH_SIZE,
       maximumDurationMs,
-      observationLimit: MAXIMUM_GITHUB_ACTIVITY_WORKER_BATCH_SIZE,
-      pullRequestDiscoveryLimit: MAXIMUM_GITHUB_ACTIVITY_WORKER_BATCH_SIZE,
-      summaryLimit: MAXIMUM_GITHUB_ACTIVITY_WORKER_BATCH_SIZE,
+      observationLimit: GITHUB_BACKFILL_WORKER_BATCH_SIZE,
+      pullRequestDiscoveryLimit: GITHUB_BACKFILL_WORKER_BATCH_SIZE,
+      pullRequestLimit: GITHUB_BACKFILL_WORKER_BATCH_SIZE,
+      pullRequestSignalLimit: GITHUB_BACKFILL_WORKER_BATCH_SIZE,
+      summaryLimit: GITHUB_BACKFILL_WORKER_BATCH_SIZE,
     });
-    const claimed = claimedItems(result);
+    const counts = githubBackfillProcessingCountsFrom(result);
     passes += 1;
-    totalClaimed += claimed;
+    addProcessingCounts(totals, counts);
     process.stdout.write(
-      `Worker pass ${String(passes)} claimed ${String(claimed)} items.\n`
+      `Worker pass ${String(passes)}: claimed ${String(counts.claimed)}, processed ${String(counts.processed)}, deferred ${String(counts.deferred)}, unavailable ${String(counts.unavailable)}, failed ${String(counts.failed)}, aliases ${String(counts.aliases)}.\n`
     );
-    if (claimed === 0) {
-      return { drained: true, passes, totalClaimed };
+    if (counts.claimed === 0) {
+      return {
+        ...totals,
+        passes,
+        stopReason: "no_immediately_claimable_work",
+      };
     }
   }
-  return { drained: false, passes, totalClaimed };
+  return { ...totals, passes, stopReason: "time_budget" };
+};
+
+const tokenFor = (account: TrackedGitHubAccount) => {
+  const token =
+    account === "f0rr0"
+      ? env.GITHUB_F0RR0_TOKEN
+      : env.GITHUB_YUPPIESTECHDEV_TOKEN;
+  if (token === undefined) {
+    throw new Error(`The GitHub token for ${account} is not configured.`);
+  }
+  return token;
+};
+
+const logAccount = (account: TrackedGitHubAccount, message: string) => {
+  process.stdout.write(`[${account}] ${message}\n`);
 };
 
 const main = async () => {
   const input = backfillArgumentsFrom(process.argv.slice(2));
   requireEnvironment(input);
-  const requests = githubBackfillRequestSeriesFrom(
-    requestValue(input, input.startDate, input.endDate)
-  );
-  if (requests === null) {
+  const request = githubBackfillRequestFrom(requestValue(input));
+  if (request === null) {
     throw new TypeError(
-      "The account, repository, or date range is invalid; dates must use YYYY-MM-DD and cannot be in the future."
+      "The backfill input is invalid: --start-date is the earliest included UTC day and must not follow --end-date, the latest included UTC day. Dates must use YYYY-MM-DD, the end cannot be in the future, and the account and repository ID must be valid."
     );
   }
-  const deadlineAt = Date.now() + input.maximumMinutes * 60_000;
-  const totals: BackfillTotals = {
-    duplicates: 0,
-    observations: 0,
-    repositories: 0,
-    requests: 0,
-  };
+  const { sinceAt, untilAt } = request;
   try {
-    for (const request of requests) {
-      await queueRequest(request, deadlineAt, totals);
-    }
+    const evidenceRecovery = await ensureGitHubEvidenceIntegrity();
+    const deadlineAt = Date.now() + input.maximumMinutes * 60_000;
+    const inventories = await Promise.all(
+      request.accounts.map(async (account) => {
+        const token = tokenFor(account);
+        await assertGitHubTokenIdentity(account, token, { deadlineAt });
+        logAccount(account, "authenticated token identity");
+        const pullRequests = await backfillGitHubPullRequests({
+          account,
+          deadlineAt,
+          onRateLimitWait: (retryAt) => {
+            logAccount(
+              account,
+              `PR rate limit resets at ${retryAt.toISOString()}; waiting within budget`
+            );
+          },
+          repositoryId: request.repositoryId,
+          sinceAt,
+          token,
+          untilAt,
+        });
+        logAccount(
+          account,
+          `pull requests: ${String(pullRequests.pullRequests)} persisted after ${String(pullRequests.scannedPullRequests)} candidates (${pullRequests.stopReason})`
+        );
+        if (Date.now() + WORKER_CLEANUP_MARGIN_MS >= deadlineAt) {
+          return { account, direct: null, pullRequests };
+        }
+        const direct = await backfillGitHubCommitsFromCurrentRefs({
+          account,
+          deadlineAt,
+          onRateLimitWait: (retryAt) => {
+            logAccount(
+              account,
+              `current-ref rate limit resets at ${retryAt.toISOString()}; waiting within budget`
+            );
+          },
+          repositoryId: request.repositoryId,
+          sinceAt,
+          token,
+          untilAt,
+        });
+        logAccount(
+          account,
+          `current refs: ${String(direct.uniqueCommits)} unique commits from ${String(direct.heads)} distinct heads (${direct.stopReason})`
+        );
+        return { account, direct, pullRequests };
+      })
+    );
+    const inventoryComplete = inventories.every(
+      ({ direct, pullRequests }) =>
+        direct?.complete === true && pullRequests.complete
+    );
     const worker = await processQueue(deadlineAt);
-    process.stdout.write(`${JSON.stringify({ queued: totals, worker })}\n`);
-    if (!worker.drained) {
+    process.stdout.write(
+      `${JSON.stringify({ evidenceRecovery: evidenceRecovery.status, inventories, inventoryComplete, processing: worker })}\n`
+    );
+    process.stdout.write(
+      "Processing totals cover the shared global queue; inventoryComplete proves only that this invocation finished both selected discovery passes.\n"
+    );
+    if (worker.stopReason === "time_budget") {
       process.stdout.write(
-        "The Action time budget ended with durable work remaining; Supabase Cron will continue it.\n"
+        "The Action time budget ended; durable or retry-delayed work may remain, and Supabase Cron will continue it.\n"
+      );
+    } else {
+      process.stdout.write(
+        "No work was immediately claimable; durable retry-delayed work may still remain for Supabase Cron.\n"
+      );
+    }
+    if (!inventoryComplete) {
+      throw new Error(
+        "The GitHub inventory did not finish within the provider/time budget. Persisted evidence is safe; rerun the same inputs idempotently. If an all-repository scan repeatedly exceeds 330 minutes, dispatch one numeric --repository-id at a time to shard the inventory."
       );
     }
   } finally {

--- a/scripts/configure-supabase-cron.ts
+++ b/scripts/configure-supabase-cron.ts
@@ -1,16 +1,35 @@
 import postgres from "postgres";
 
 import { env } from "../src/env";
+import {
+  GITHUB_EVENTS_CRON_JOB,
+  GITHUB_HEAD_REFS_CRON_JOB,
+  GITHUB_REF_REPOSITORY_BATCH_SIZE,
+  GITHUB_TAG_REFS_CRON_JOB,
+  GITHUB_WORKER_CRON_JOB,
+} from "../src/lib/github-cron-config";
+import { CANONICAL_SITE_URL } from "../src/lib/site-url";
+import { shouldApplyProductionMigrations } from "./migrate-production-database";
 
-const JOB_NAME = "github-sync-every-three-hours";
-const JOB_SCHEDULE = "7 */3 * * *";
 const CRON_HTTP_TIMEOUT_MS = 120_000;
-const WORKER_JOB_NAME = "github-activity-worker-every-five-minutes";
-const WORKER_JOB_SCHEDULE = "*/5 * * * *";
 const SECRET_DESCRIPTION = "Vercel GitHub sync cron configuration";
 const SECRET_NAME = "github_sync_bearer_secret";
 const URL_NAME = "github_sync_url";
+const HEAD_REFS_URL_NAME = "github_head_refs_url";
+const TAG_REFS_URL_NAME = "github_tag_refs_url";
 const WORKER_URL_NAME = "github_worker_url";
+const LEGACY_JOB_NAME = "github-sync-every-three-hours";
+const LEGACY_REFS_JOB_NAME = "github-refs-every-fifteen-minutes";
+const CRON_CONFIGURATION_LOCK_NAME = "f0rr0.dev:supabase-cron";
+
+interface SupabaseCronEnvironment {
+  CRON_SECRET?: string;
+  DATABASE_URL?: string;
+  DATABASE_URL_UNPOOLED?: string;
+  VERCEL?: string;
+  VERCEL_ENV?: string;
+  VERCEL_PROJECT_PRODUCTION_URL?: string;
+}
 
 const requiredEnvironmentValue = (
   name: string,
@@ -23,31 +42,53 @@ const requiredEnvironmentValue = (
   return value;
 };
 
-const unpooledDatabaseUrl = env.DATABASE_URL_UNPOOLED?.trim();
-const databaseUrl =
-  unpooledDatabaseUrl === undefined || unpooledDatabaseUrl.length === 0
-    ? requiredEnvironmentValue("DATABASE_URL", env.DATABASE_URL)
+export const supabaseCronDatabaseUrlFrom = (
+  environment: SupabaseCronEnvironment
+) => {
+  const unpooledDatabaseUrl = environment.DATABASE_URL_UNPOOLED?.trim();
+  return unpooledDatabaseUrl === undefined || unpooledDatabaseUrl.length === 0
+    ? requiredEnvironmentValue("DATABASE_URL", environment.DATABASE_URL)
     : unpooledDatabaseUrl;
-const cronSecret = requiredEnvironmentValue("CRON_SECRET", env.CRON_SECRET);
-if (cronSecret.length < 32) {
-  throw new Error("CRON_SECRET must contain at least 32 characters.");
-}
+};
 
-const siteUrl = new URL(requiredEnvironmentValue("SITE_URL", env.SITE_URL));
-if (siteUrl.protocol !== "https:") {
-  throw new Error("SITE_URL must use HTTPS so Supabase can reach Vercel.");
-}
-const syncUrl = new URL("/api/cron/github-sync", siteUrl).toString();
-const workerUrl = new URL("/api/cron/github-worker", siteUrl).toString();
+export const supabaseCronUrlsFrom = (configuredSiteUrl: string) => {
+  const siteUrl = new URL(configuredSiteUrl);
+  if (siteUrl.protocol !== "https:") {
+    throw new Error(
+      "The Supabase cron target must use HTTPS so it can reach Vercel."
+    );
+  }
+  const events = new URL("/api/cron/github-sync", siteUrl).toString();
+  const ref = (kind: "head" | "tag") => {
+    const url = new URL("/api/cron/github-refs", siteUrl);
+    url.searchParams.set("kind", kind);
+    url.searchParams.set(
+      "repositories",
+      String(GITHUB_REF_REPOSITORY_BATCH_SIZE)
+    );
+    return url.toString();
+  };
+  return {
+    events,
+    headRefs: ref("head"),
+    tagRefs: ref("tag"),
+    worker: new URL("/api/cron/github-worker", siteUrl).toString(),
+  };
+};
 
-const sql = postgres(databaseUrl, {
-  connect_timeout: 10,
-  idle_timeout: 20,
-  max: 1,
-  prepare: false,
-});
+export const supabaseCronSiteUrlFrom = (
+  environment: SupabaseCronEnvironment
+) => {
+  const productionHostname = environment.VERCEL_PROJECT_PRODUCTION_URL?.trim();
+  return productionHostname === undefined || productionHostname.length === 0
+    ? CANONICAL_SITE_URL
+    : `https://${productionHostname}`;
+};
 
-const upsertVaultSecret = async (input: { name: string; value: string }) => {
+const upsertVaultSecret = async (
+  sql: ReturnType<typeof postgres>,
+  input: { name: string; value: string }
+) => {
   const [existing] = await sql<{ id: string }[]>`
     select id::text
     from vault.secrets
@@ -76,83 +117,170 @@ const upsertVaultSecret = async (input: { name: string; value: string }) => {
   `;
 };
 
-try {
-  await sql`create schema if not exists extensions`;
-  await sql`create schema if not exists vault`;
-  await sql`create extension if not exists pg_cron`;
-  await sql`create extension if not exists pg_net with schema extensions`;
-  await sql`create extension if not exists supabase_vault with schema vault`;
-
-  await upsertVaultSecret({ name: URL_NAME, value: syncUrl });
-  await upsertVaultSecret({ name: WORKER_URL_NAME, value: workerUrl });
-  await upsertVaultSecret({ name: SECRET_NAME, value: cronSecret });
-
-  await sql`
-    select cron.unschedule(jobid)
-    from cron.job
-    where jobname in (${JOB_NAME}, ${WORKER_JOB_NAME})
-  `;
-
-  const command = `
-    select net.http_post(
-      url := (
+const cronHttpPostCommand = (urlSecretName: string) => `
+  select net.http_post(
+    url := (
+      select decrypted_secret
+      from vault.decrypted_secrets
+      where name = '${urlSecretName}'
+    ),
+    headers := jsonb_build_object(
+      'Content-Type', 'application/json',
+      'Authorization', 'Bearer ' || (
         select decrypted_secret
         from vault.decrypted_secrets
-        where name = '${URL_NAME}'
-      ),
-      headers := jsonb_build_object(
-        'Content-Type', 'application/json',
-        'Authorization', 'Bearer ' || (
-          select decrypted_secret
-          from vault.decrypted_secrets
-          where name = '${SECRET_NAME}'
-        )
-      ),
-      body := jsonb_build_object('source', 'supabase-cron'),
-      timeout_milliseconds := ${CRON_HTTP_TIMEOUT_MS}
-    ) as request_id
-  `;
-  const [job] = await sql<{ jobId: number }[]>`
-    select cron.schedule(
-      ${JOB_NAME},
-      ${JOB_SCHEDULE},
-      ${command}
-    ) as "jobId"
-  `;
-  const workerCommand = `
-    select net.http_post(
-      url := (
-        select decrypted_secret
-        from vault.decrypted_secrets
-        where name = '${WORKER_URL_NAME}'
-      ),
-      headers := jsonb_build_object(
-        'Content-Type', 'application/json',
-        'Authorization', 'Bearer ' || (
-          select decrypted_secret
-          from vault.decrypted_secrets
-          where name = '${SECRET_NAME}'
-        )
-      ),
-      body := jsonb_build_object('source', 'supabase-cron'),
-      timeout_milliseconds := ${CRON_HTTP_TIMEOUT_MS}
-    ) as request_id
-  `;
-  const [workerJob] = await sql<{ jobId: number }[]>`
-    select cron.schedule(
-      ${WORKER_JOB_NAME},
-      ${WORKER_JOB_SCHEDULE},
-      ${workerCommand}
-    ) as "jobId"
-  `;
+        where name = '${SECRET_NAME}'
+      )
+    ),
+    body := jsonb_build_object('source', 'supabase-cron'),
+    timeout_milliseconds := ${String(CRON_HTTP_TIMEOUT_MS)}
+  ) as request_id
+`;
 
-  process.stdout.write(
-    `Configured Supabase cron jobs ${String(job?.jobId)} and ${String(workerJob?.jobId)} for GitHub intake and processing.\n`
+export const configureSupabaseCron = async (
+  environment: SupabaseCronEnvironment = env
+) => {
+  const databaseUrl = supabaseCronDatabaseUrlFrom(environment);
+  const cronSecret = requiredEnvironmentValue(
+    "CRON_SECRET",
+    environment.CRON_SECRET
   );
-} catch (error) {
-  const message = error instanceof Error ? error.message : "Unknown error";
-  process.stderr.write(`Supabase cron configuration failed: ${message}\n`);
-  process.exitCode = 1;
-} finally {
-  await sql.end({ timeout: 5 });
+  if (cronSecret.length < 32) {
+    throw new Error("CRON_SECRET must contain at least 32 characters.");
+  }
+  const urls = supabaseCronUrlsFrom(supabaseCronSiteUrlFrom(environment));
+  const sql = postgres(databaseUrl, {
+    connect_timeout: 10,
+    idle_timeout: 20,
+    max: 1,
+    prepare: false,
+  });
+
+  try {
+    const jobs = await sql.begin(async (transaction) => {
+      await transaction`
+        select pg_advisory_xact_lock(
+          hashtextextended(${CRON_CONFIGURATION_LOCK_NAME}, 0)
+        )
+      `;
+      await transaction`create schema if not exists extensions`;
+      await transaction`create schema if not exists vault`;
+      await transaction`create extension if not exists pg_cron`;
+      await transaction`create extension if not exists pg_net with schema extensions`;
+      await transaction`create extension if not exists supabase_vault with schema vault`;
+
+      await upsertVaultSecret(transaction, {
+        name: URL_NAME,
+        value: urls.events,
+      });
+      await upsertVaultSecret(transaction, {
+        name: HEAD_REFS_URL_NAME,
+        value: urls.headRefs,
+      });
+      await upsertVaultSecret(transaction, {
+        name: TAG_REFS_URL_NAME,
+        value: urls.tagRefs,
+      });
+      await upsertVaultSecret(transaction, {
+        name: WORKER_URL_NAME,
+        value: urls.worker,
+      });
+      await upsertVaultSecret(transaction, {
+        name: SECRET_NAME,
+        value: cronSecret,
+      });
+
+      await transaction`
+        select cron.unschedule(jobid)
+        from cron.job
+        where jobname in (
+          ${LEGACY_JOB_NAME},
+          ${LEGACY_REFS_JOB_NAME},
+          ${GITHUB_EVENTS_CRON_JOB.name},
+          ${GITHUB_HEAD_REFS_CRON_JOB.name},
+          ${GITHUB_TAG_REFS_CRON_JOB.name},
+          ${GITHUB_WORKER_CRON_JOB.name}
+        )
+      `;
+
+      const [eventsJob] = await transaction<{ jobId: number }[]>`
+        select cron.schedule(
+          ${GITHUB_EVENTS_CRON_JOB.name},
+          ${GITHUB_EVENTS_CRON_JOB.schedule},
+          ${cronHttpPostCommand(URL_NAME)}
+        ) as "jobId"
+      `;
+      const [headRefsJob] = await transaction<{ jobId: number }[]>`
+        select cron.schedule(
+          ${GITHUB_HEAD_REFS_CRON_JOB.name},
+          ${GITHUB_HEAD_REFS_CRON_JOB.schedule},
+          ${cronHttpPostCommand(HEAD_REFS_URL_NAME)}
+        ) as "jobId"
+      `;
+      const [tagRefsJob] = await transaction<{ jobId: number }[]>`
+        select cron.schedule(
+          ${GITHUB_TAG_REFS_CRON_JOB.name},
+          ${GITHUB_TAG_REFS_CRON_JOB.schedule},
+          ${cronHttpPostCommand(TAG_REFS_URL_NAME)}
+        ) as "jobId"
+      `;
+      const [workerJob] = await transaction<{ jobId: number }[]>`
+        select cron.schedule(
+          ${GITHUB_WORKER_CRON_JOB.name},
+          ${GITHUB_WORKER_CRON_JOB.schedule},
+          ${cronHttpPostCommand(WORKER_URL_NAME)}
+        ) as "jobId"
+      `;
+      if (
+        eventsJob === undefined ||
+        headRefsJob === undefined ||
+        tagRefsJob === undefined ||
+        workerJob === undefined
+      ) {
+        throw new Error("Supabase did not return every scheduled cron job.");
+      }
+      return { eventsJob, headRefsJob, tagRefsJob, workerJob };
+    });
+
+    process.stdout.write(
+      `Configured Supabase cron jobs ${String(jobs.eventsJob.jobId)}, ${String(jobs.headRefsJob.jobId)}, ${String(jobs.tagRefsJob.jobId)}, and ${String(jobs.workerJob.jobId)} for GitHub intake, head refs, tag refs, and processing.\n`
+    );
+    return jobs;
+  } finally {
+    await sql.end({ timeout: 5 });
+  }
+};
+
+export const shouldConfigureSupabaseCronForProduction = (
+  environment: SupabaseCronEnvironment
+) => shouldApplyProductionMigrations(environment);
+
+export const configureProductionSupabaseCron = async (
+  environment: SupabaseCronEnvironment = env
+) => {
+  if (!shouldConfigureSupabaseCronForProduction(environment)) {
+    process.stdout.write("Skipping production Supabase cron configuration.\n");
+    return false;
+  }
+  await configureSupabaseCron(environment);
+  return true;
+};
+
+if (import.meta.main) {
+  try {
+    const arguments_ = process.argv.slice(2);
+    if (
+      arguments_.length > 1 ||
+      (arguments_.length === 1 && arguments_[0] !== "--production-build")
+    ) {
+      throw new TypeError("The Supabase cron arguments are invalid.");
+    }
+    await (arguments_[0] === "--production-build"
+      ? configureProductionSupabaseCron()
+      : configureSupabaseCron());
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Unknown error";
+    process.stderr.write(`Supabase cron configuration failed: ${message}\n`);
+    process.exitCode = 1;
+  }
 }

--- a/scripts/migrate-production-database.ts
+++ b/scripts/migrate-production-database.ts
@@ -10,7 +10,6 @@ const MIGRATION_LOCK_NAME = "f0rr0.dev:drizzle-migrations";
 interface Environment {
   DATABASE_URL?: string;
   DATABASE_URL_UNPOOLED?: string;
-  POSTGRES_URL_NON_POOLING?: string;
   VERCEL?: string;
   VERCEL_ENV?: string;
 }
@@ -48,7 +47,6 @@ export const shouldApplyProductionMigrations = (environment: Environment) => {
 export const productionMigrationDatabaseUrl = (environment: Environment) => {
   const configured =
     configuredValue(environment.DATABASE_URL_UNPOOLED) ??
-    configuredValue(environment.POSTGRES_URL_NON_POOLING) ??
     configuredValue(environment.DATABASE_URL);
   if (configured === null) {
     throw new ProductionMigrationConfigurationError(

--- a/scripts/repair-github-evidence.ts
+++ b/scripts/repair-github-evidence.ts
@@ -1,0 +1,103 @@
+import { closeDatabase } from "../src/db/client";
+import { env } from "../src/env";
+import {
+  GITHUB_EVIDENCE_RECOVERY_CONFIRMATION,
+  inspectGitHubEvidenceRecovery,
+  repairLegacyGitHubEvidence,
+} from "../src/lib/github-activity-worker-store";
+import { reportOperationalError } from "../src/lib/operational-error";
+
+type RepairMode = "apply" | "preview";
+
+const SAFE_USAGE_ERRORS = new Set([
+  "--mode must be preview or apply.",
+  "The GitHub evidence repair arguments are invalid.",
+  "The GitHub evidence repair confirmation is invalid.",
+]);
+
+const argumentValues = (arguments_: readonly string[]) => {
+  const values = new Map<string, string>();
+  for (let index = 0; index < arguments_.length; index += 2) {
+    const name = arguments_[index];
+    const value = arguments_[index + 1];
+    if (
+      name === undefined ||
+      value === undefined ||
+      !name.startsWith("--") ||
+      values.has(name)
+    ) {
+      throw new TypeError("The GitHub evidence repair arguments are invalid.");
+    }
+    values.set(name, value.trim());
+  }
+  return values;
+};
+
+const repairArgumentsFrom = (arguments_: readonly string[]) => {
+  const values = argumentValues(arguments_);
+  if (
+    [...values.keys()].some((name) => !["--confirm", "--mode"].includes(name))
+  ) {
+    throw new TypeError("The GitHub evidence repair arguments are invalid.");
+  }
+  const rawMode = values.get("--mode");
+  if (rawMode !== "apply" && rawMode !== "preview") {
+    throw new TypeError("--mode must be preview or apply.");
+  }
+  return {
+    confirmation: values.get("--confirm") ?? "",
+    mode: rawMode as RepairMode,
+  };
+};
+
+const main = async () => {
+  if ((env.DATABASE_URL?.trim().length ?? 0) === 0) {
+    throw new Error("DATABASE_URL is not configured.");
+  }
+  const input = repairArgumentsFrom(process.argv.slice(2));
+  try {
+    if (input.mode === "preview") {
+      const plan = await inspectGitHubEvidenceRecovery();
+      process.stdout.write(
+        `${JSON.stringify({ mode: input.mode, plan, status: "preview" })}\n`
+      );
+      process.stdout.write(
+        plan.constraintInstalled
+          ? "The versioned GitHub evidence recovery was already applied.\n"
+          : `Preview only; no rows changed. Database integrity is not finalized until the compatible worker runs or apply is invoked with --confirm ${GITHUB_EVIDENCE_RECOVERY_CONFIRMATION}.\n`
+      );
+      return;
+    }
+
+    const result = await repairLegacyGitHubEvidence(input.confirmation);
+    process.stdout.write(
+      `${JSON.stringify({ mode: input.mode, ...result })}\n`
+    );
+    process.stdout.write(
+      result.status === "applied"
+        ? "The repair committed atomically. Scheduled GitHub workers will rebuild discovery, reconciliation, canonicalization, and publication.\n"
+        : "The versioned GitHub evidence recovery was already applied; no rows changed.\n"
+    );
+  } finally {
+    await closeDatabase();
+  }
+};
+
+if (import.meta.main) {
+  try {
+    await main();
+  } catch (error) {
+    const errorName = reportOperationalError(
+      "github_evidence_recovery_action",
+      error
+    );
+    const usageMessage =
+      error instanceof TypeError && SAFE_USAGE_ERRORS.has(error.message)
+        ? error.message
+        : null;
+    process.stderr.write(
+      `${usageMessage ?? `GitHub evidence recovery failed (${errorName}).`}\n`
+    );
+    process.exitCode = 1;
+  }
+}

--- a/src/app/api/cron/github-refs/route.ts
+++ b/src/app/api/cron/github-refs/route.ts
@@ -1,10 +1,10 @@
-import { revalidateTag } from "next/cache";
-
 import { env } from "@/env";
-import { syncGitHubAccounts } from "@/lib/github-commits";
+import { reconcileGitHubRefs } from "@/lib/github-commits";
 import {
   GITHUB_CRON_EXECUTION_DURATION_MS,
   githubCronStatusFromFailedAccounts,
+  githubRefKindFrom,
+  githubRefRepositoryLimitFrom,
 } from "@/lib/github-cron-config";
 import { reportOperationalError } from "@/lib/operational-error";
 import { hasBearerSecret } from "@/lib/request-auth";
@@ -17,31 +17,34 @@ export async function POST(request: Request) {
   if (!hasBearerSecret(request.headers.get("authorization"), env.CRON_SECRET)) {
     return Response.json({ ok: false }, { status: 401 });
   }
+  const { searchParams } = new URL(request.url);
+  const kind = githubRefKindFrom(searchParams.get("kind"));
+  const repositoryLimit = githubRefRepositoryLimitFrom(
+    searchParams.get("repositories")
+  );
+  if (kind === null || repositoryLimit === null) {
+    return Response.json({ ok: false }, { status: 400 });
+  }
 
   const deadlineAt = Date.now() + GITHUB_CRON_EXECUTION_DURATION_MS;
   try {
-    const result = await syncGitHubAccounts({ deadlineAt });
-    if (result.issues > 0) {
-      revalidateTag("github-activity", "max");
-    }
+    const result = await reconcileGitHubRefs({
+      deadlineAt,
+      kind,
+      repositoryLimit,
+    });
     const status = githubCronStatusFromFailedAccounts(result.failedAccounts);
     if (status === 503) {
       for (const failure of result.failedAccounts) {
-        const error = new Error("GitHub Events intake failed.");
+        const error = new Error("GitHub ref reconciliation failed.");
         error.name = failure.error;
-        reportOperationalError(`github_sync_${failure.account}`, error);
+        reportOperationalError(`github_refs_${failure.account}`, error);
       }
       return Response.json({ ok: false, ...result }, { status });
     }
     return Response.json({ ok: true, ...result });
   } catch (error) {
-    const errorName = reportOperationalError("github_sync", error);
-    return Response.json(
-      {
-        error: errorName,
-        ok: false,
-      },
-      { status: 503 }
-    );
+    const errorName = reportOperationalError("github_refs", error);
+    return Response.json({ error: errorName, ok: false }, { status: 503 });
   }
 }

--- a/src/app/api/cron/github-worker/route.ts
+++ b/src/app/api/cron/github-worker/route.ts
@@ -3,6 +3,7 @@ import { revalidateTag } from "next/cache";
 import { env } from "@/env";
 import { runGitHubActivityWorker } from "@/lib/github-activity-worker";
 import { workerBatchSizeFrom } from "@/lib/github-activity-worker-core";
+import { ensureGitHubEvidenceIntegrity } from "@/lib/github-activity-worker-store";
 import { reportOperationalError } from "@/lib/operational-error";
 import { hasBearerSecret } from "@/lib/request-auth";
 
@@ -22,6 +23,23 @@ export async function POST(request: Request) {
     return Response.json({ ok: false }, { status: 400 });
   }
 
+  let evidenceRecovery: Awaited<
+    ReturnType<typeof ensureGitHubEvidenceIntegrity>
+  >;
+  try {
+    evidenceRecovery = await ensureGitHubEvidenceIntegrity();
+  } catch (error) {
+    const errorName = reportOperationalError("github_evidence_recovery", error);
+    return Response.json(
+      {
+        error: errorName,
+        evidenceRecovery: "failed",
+        ok: false,
+      },
+      { status: 503 }
+    );
+  }
+
   try {
     const activity = await runGitHubActivityWorker(
       batchSize === undefined
@@ -30,17 +48,24 @@ export async function POST(request: Request) {
             commitLimit: batchSize,
             observationLimit: batchSize,
             pullRequestDiscoveryLimit: batchSize,
+            pullRequestLimit: batchSize,
+            pullRequestSignalLimit: batchSize,
             summaryLimit: batchSize,
           }
     );
     if (
+      evidenceRecovery.status === "applied" ||
       activity.summaries.completed > 0 ||
       activity.pullRequests.completed > 0 ||
       activity.aliases > 0
     ) {
       revalidateTag("github-activity", "max");
     }
-    return Response.json({ activity, ok: true });
+    return Response.json({
+      activity,
+      evidenceRecovery: evidenceRecovery.status,
+      ok: true,
+    });
   } catch (error) {
     const errorName = reportOperationalError("github_worker", error);
     return Response.json(

--- a/src/app/api/github/webhook/route.ts
+++ b/src/app/api/github/webhook/route.ts
@@ -10,6 +10,7 @@ import {
   issueFromWebhook,
   pullRequestObservationFromWebhook,
   pushFromWebhook,
+  trackedGitHubAccountFrom,
 } from "@/lib/github-commits-core";
 import {
   persistIgnoredGitHubWebhookDelivery,
@@ -25,6 +26,62 @@ const GITHUB_EVENT_NAME = /^[a-z][a-z0-9_]{0,39}$/;
 const SUPPORTED_GITHUB_EVENTS = new Set(["issues", "pull_request", "push"]);
 
 type SupportedGitHubEvent = "issues" | "pull_request" | "push";
+type JsonObject = Record<string, unknown>;
+
+class InvalidGitHubWebhookPayloadError extends Error {
+  constructor() {
+    super("A supported GitHub webhook payload was malformed.");
+    this.name = "InvalidGitHubWebhookPayloadError";
+  }
+}
+
+const isObject = (value: unknown): value is JsonObject =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const githubActorLogin = (value: unknown) =>
+  typeof value === "string" &&
+  value.length <= 100 &&
+  /^(?:[a-z\d](?:[a-z\d-]*[a-z\d])?|[a-z\d](?:[a-z\d-]*[a-z\d])?\[bot\])$/iu.test(
+    value
+  )
+    ? value
+    : null;
+
+const hasForeignActor = (value: unknown) => {
+  const login = isObject(value) ? githubActorLogin(value.login) : null;
+  return login !== null && trackedGitHubAccountFrom(login) === null;
+};
+
+const intentionallyIgnoredPush = (payload: unknown) => {
+  if (!isObject(payload)) {
+    return false;
+  }
+  if (payload.deleted === true) {
+    return true;
+  }
+  if (
+    typeof payload.ref === "string" &&
+    payload.ref.startsWith("refs/") &&
+    !payload.ref.startsWith("refs/heads/")
+  ) {
+    return true;
+  }
+  return isObject(payload.sender)
+    ? hasForeignActor(payload.sender)
+    : hasForeignActor(payload.pusher);
+};
+
+const intentionallyIgnoredIssue = (payload: unknown) => {
+  const action = issueActionFromWebhook(payload);
+  if (action !== "opened") {
+    return action !== null;
+  }
+  return (
+    isObject(payload) &&
+    isObject(payload.issue) &&
+    hasForeignActor(payload.issue.user)
+  );
+};
 
 const supportedGitHubEventFrom = (event: string): SupportedGitHubEvent | null =>
   SUPPORTED_GITHUB_EVENTS.has(event) ? (event as SupportedGitHubEvent) : null;
@@ -79,6 +136,9 @@ const persistSupportedWebhook = async (
     if (push !== null) {
       return await persistGitHubWebhookPush(deliveryId, push);
     }
+    if (!intentionallyIgnoredPush(payload)) {
+      throw new InvalidGitHubWebhookPayloadError();
+    }
   } else if (eventType === "pull_request") {
     const observation = pullRequestObservationFromWebhook(payload);
     if (observation !== null) {
@@ -88,10 +148,14 @@ const persistSupportedWebhook = async (
         observation.pullRequest
       );
     }
+    throw new InvalidGitHubWebhookPayloadError();
   } else {
     const issue = issueFromWebhook(payload);
     if (issue !== null) {
       return await persistGitHubWebhookIssue(deliveryId, issue);
+    }
+    if (!intentionallyIgnoredIssue(payload)) {
+      throw new InvalidGitHubWebhookPayloadError();
     }
   }
   return await persistIgnoredGitHubWebhookDelivery({
@@ -101,6 +165,23 @@ const persistSupportedWebhook = async (
     event: eventType,
     repositoryId: null,
   });
+};
+
+const persistUnsupportedWebhook = async (deliveryId: string, event: string) => {
+  try {
+    return acceptedResponse(
+      await persistIgnoredGitHubWebhookDelivery({
+        account: null,
+        action: null,
+        deliveryId,
+        event,
+        repositoryId: null,
+      })
+    );
+  } catch (error) {
+    reportOperationalError("github_webhook_unsupported", error);
+    return Response.json({ ok: false }, { status: 503 });
+  }
 };
 
 export async function POST(request: Request) {
@@ -147,20 +228,7 @@ export async function POST(request: Request) {
   }
   const eventType = supportedGitHubEventFrom(eventName);
   if (eventType === null) {
-    try {
-      return acceptedResponse(
-        await persistIgnoredGitHubWebhookDelivery({
-          account: null,
-          action: null,
-          deliveryId,
-          event: eventName,
-          repositoryId: null,
-        })
-      );
-    } catch (error) {
-      reportOperationalError("github_webhook_unsupported", error);
-      return Response.json({ ok: false }, { status: 503 });
-    }
+    return await persistUnsupportedWebhook(deliveryId, eventName);
   }
 
   let payload: unknown;
@@ -193,6 +261,10 @@ export async function POST(request: Request) {
     }
     return acceptedResponse(result);
   } catch (error) {
+    if (error instanceof InvalidGitHubWebhookPayloadError) {
+      reportOperationalError("github_webhook_invalid_payload", error);
+      return Response.json({ ok: false }, { status: 400 });
+    }
     reportOperationalError("github_webhook_intake", error);
     return Response.json({ ok: false }, { status: 503 });
   }

--- a/src/components/github-activity-days.tsx
+++ b/src/components/github-activity-days.tsx
@@ -297,7 +297,7 @@ function groupCommitsByRepository(
       continue;
     }
 
-    const repositoryKey = item.repository.label ?? "private";
+    const repositoryKey = item.repository.key;
     const existingGroup = commitGroups.get(repositoryKey);
     if (existingGroup !== undefined) {
       existingGroup.commits.push(item);

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -45,6 +45,7 @@ export const githubCommits = pgTable(
     committerUserId: varchar("committer_user_id", { length: 32 }),
     deletions: integer("deletions"),
     enrichmentError: varchar("enrichment_error", { length: 80 }),
+    enrichmentAttempts: integer("enrichment_attempts").default(0).notNull(),
     enrichmentLeaseToken: uuid("enrichment_lease_token"),
     // Pending rows use this as a not-before time; processing rows use it as
     // the expiry of the current ownership lease.
@@ -72,6 +73,9 @@ export const githubCommits = pgTable(
       .default(false)
       .notNull(),
     pullRequestDiscoveryError: varchar("pr_discovery_error", { length: 80 }),
+    pullRequestDiscoveryAttempts: integer("pr_discovery_attempts")
+      .default(0)
+      .notNull(),
     pullRequestDiscoveryLeaseToken: uuid("pr_discovery_lease_token"),
     pullRequestDiscoveryLeaseUntil: timestamp("pr_discovery_lease_until", {
       mode: "date",
@@ -170,6 +174,10 @@ export const githubCommits = pgTable(
       sql`(${table.changedFiles} IS NULL OR ${table.changedFiles} >= 0) AND (${table.additions} IS NULL OR ${table.additions} >= 0) AND (${table.deletions} IS NULL OR ${table.deletions} >= 0) AND (${table.substantiveLoc} IS NULL OR ${table.substantiveLoc} >= 0)`
     ),
     check(
+      "github_commits_nonnegative_attempts",
+      sql`${table.enrichmentAttempts} >= 0 AND ${table.pullRequestDiscoveryAttempts} >= 0`
+    ),
+    check(
       "github_commits_owner_type",
       sql`${table.repositoryOwnerType} IS NULL OR ${table.repositoryOwnerType} IN ('Organization', 'User')`
     ),
@@ -188,6 +196,19 @@ export const githubAccountCheckpoints = pgTable(
   "github_account_checkpoints",
   {
     account: varchar("account", { length: 39 }).primaryKey(),
+    eventsEtag: text("events_etag"),
+    eventsLastAttemptedAt: timestamp("events_last_attempted_at", {
+      mode: "date",
+      withTimezone: true,
+    }),
+    eventsLastSucceededAt: timestamp("events_last_succeeded_at", {
+      mode: "date",
+      withTimezone: true,
+    }),
+    eventsNextPollAt: timestamp("events_next_poll_at", {
+      mode: "date",
+      withTimezone: true,
+    }),
     gapDetectedAt: timestamp("gap_detected_at", {
       mode: "date",
       withTimezone: true,
@@ -199,12 +220,62 @@ export const githubAccountCheckpoints = pgTable(
     gapState: varchar("gap_state", { length: 12 }).default("clear").notNull(),
     latestEventId: varchar("latest_event_id", { length: 64 }),
     paused: boolean("paused").default(false).notNull(),
+    headRefCursorRepositoryId: varchar("head_ref_cursor_repository_id", {
+      length: 32,
+    }),
+    headRefCycleStartedAt: timestamp("head_ref_cycle_started_at", {
+      mode: "date",
+      withTimezone: true,
+    }),
+    headRefLastAttemptedAt: timestamp("head_ref_last_attempted_at", {
+      mode: "date",
+      withTimezone: true,
+    }),
+    headRefLastSucceededAt: timestamp("head_ref_last_succeeded_at", {
+      mode: "date",
+      withTimezone: true,
+    }),
+    headRefLeaseToken: uuid("head_ref_lease_token"),
+    headRefLeaseUntil: timestamp("head_ref_lease_until", {
+      mode: "date",
+      withTimezone: true,
+    }),
+    headRefNextPage: integer("head_ref_next_page"),
+    headRefScanStartedAt: timestamp("head_ref_scan_started_at", {
+      mode: "date",
+      withTimezone: true,
+    }),
     refBackfillSinceAt: timestamp("ref_backfill_since_at", {
       mode: "date",
       withTimezone: true,
     })
       .defaultNow()
       .notNull(),
+    tagRefCursorRepositoryId: varchar("tag_ref_cursor_repository_id", {
+      length: 32,
+    }),
+    tagRefCycleStartedAt: timestamp("tag_ref_cycle_started_at", {
+      mode: "date",
+      withTimezone: true,
+    }),
+    tagRefLastAttemptedAt: timestamp("tag_ref_last_attempted_at", {
+      mode: "date",
+      withTimezone: true,
+    }),
+    tagRefLastSucceededAt: timestamp("tag_ref_last_succeeded_at", {
+      mode: "date",
+      withTimezone: true,
+    }),
+    tagRefLeaseToken: uuid("tag_ref_lease_token"),
+    tagRefLeaseUntil: timestamp("tag_ref_lease_until", {
+      mode: "date",
+      withTimezone: true,
+    }),
+    tagRefNextPage: integer("tag_ref_next_page"),
+    tagRefScanStartedAt: timestamp("tag_ref_scan_started_at", {
+      mode: "date",
+      withTimezone: true,
+    }),
   },
   (table) => [
     check(
@@ -223,6 +294,18 @@ export const githubAccountCheckpoints = pgTable(
       "github_account_checkpoints_gap_details",
       sql`(${table.gapState} = 'detected' AND ${table.gapDetectedAt} IS NOT NULL) OR (${table.gapState} = 'clear' AND ${table.gapDetectedAt} IS NULL AND ${table.gapExpectedEventId} IS NULL AND ${table.gapOldestAvailableEventId} IS NULL)`
     ),
+    check(
+      "github_account_checkpoints_ref_cursor_shape",
+      sql`(${table.headRefCursorRepositoryId} IS NULL OR ${table.headRefCursorRepositoryId} ~ '^[0-9]{1,32}$') AND (${table.tagRefCursorRepositoryId} IS NULL OR ${table.tagRefCursorRepositoryId} ~ '^[0-9]{1,32}$')`
+    ),
+    check(
+      "github_account_checkpoints_ref_leases",
+      sql`(${table.headRefLeaseToken} IS NULL) = (${table.headRefLeaseUntil} IS NULL) AND (${table.tagRefLeaseToken} IS NULL) = (${table.tagRefLeaseUntil} IS NULL)`
+    ),
+    check(
+      "github_account_checkpoints_ref_scans",
+      sql`(${table.headRefNextPage} IS NULL AND ${table.headRefScanStartedAt} IS NULL OR ${table.headRefNextPage} >= 2 AND ${table.headRefScanStartedAt} IS NOT NULL) AND (${table.tagRefNextPage} IS NULL AND ${table.tagRefScanStartedAt} IS NULL OR ${table.tagRefNextPage} >= 2 AND ${table.tagRefScanStartedAt} IS NOT NULL)`
+    ),
   ]
 ).enableRLS();
 
@@ -239,6 +322,10 @@ export const githubRepositories = pgTable(
       .notNull(),
     fullName: varchar("full_name", { length: 200 }).notNull(),
     homepageUrl: text("homepage_url"),
+    headsLastReconciledAt: timestamp("heads_last_reconciled_at", {
+      mode: "date",
+      withTimezone: true,
+    }),
     htmlUrl: text("html_url"),
     id: varchar("id", { length: 32 }).primaryKey(),
     lastObservedAt: timestamp("last_observed_at", {
@@ -252,6 +339,10 @@ export const githubRepositories = pgTable(
     ownerLogin: varchar("owner_login", { length: 39 }),
     ownerType: varchar("owner_type", { length: 12 }),
     topics: jsonb("topics").$type<readonly string[]>(),
+    tagsLastReconciledAt: timestamp("tags_last_reconciled_at", {
+      mode: "date",
+      withTimezone: true,
+    }),
     visibility: varchar("visibility", { length: 12 }),
   },
   (table) => [
@@ -371,6 +462,7 @@ export const githubPushObservations = pgTable(
   "github_push_observations",
   {
     account: varchar("account", { length: 39 }).notNull(),
+    attemptCount: integer("attempt_count").default(0).notNull(),
     afterSha: varchar("after_sha", { length: 40 }).notNull(),
     beforeSha: varchar("before_sha", { length: 40 }).notNull(),
     completedAt: timestamp("completed_at", {
@@ -448,7 +540,7 @@ export const githubPushObservations = pgTable(
     ),
     check(
       "github_push_observations_nonnegative_count",
-      sql`${table.expectedCommitCount} IS NULL OR ${table.expectedCommitCount} >= 0`
+      sql`${table.attemptCount} >= 0 AND (${table.expectedCommitCount} IS NULL OR ${table.expectedCommitCount} >= 0)`
     ),
     check(
       "github_push_observations_history_bounds",
@@ -540,6 +632,10 @@ export const githubPullRequests = pgTable(
       withTimezone: true,
     }),
     mergeSha: varchar("merge_sha", { length: 40 }),
+    mergeShaVerifiedAt: timestamp("merge_sha_verified_at", {
+      mode: "date",
+      withTimezone: true,
+    }),
     nextReconcileAt: timestamp("next_reconcile_at", {
       mode: "date",
       withTimezone: true,
@@ -553,6 +649,8 @@ export const githubPullRequests = pgTable(
       mode: "date",
       withTimezone: true,
     }).notNull(),
+    reconcileAttempts: integer("reconcile_attempts").default(0).notNull(),
+    reconcileError: varchar("reconcile_error", { length: 80 }),
     repositoryId: varchar("repository_id", { length: 32 })
       .notNull()
       .references(() => githubRepositories.id),
@@ -600,10 +698,90 @@ export const githubPullRequests = pgTable(
       "github_pull_requests_sha_shapes",
       sql`(${table.baseSha} IS NULL OR ${table.baseSha} ~ '^[a-f0-9]{40}$') AND (${table.headSha} IS NULL OR ${table.headSha} ~ '^[a-f0-9]{40}$') AND (${table.mergeSha} IS NULL OR ${table.mergeSha} ~ '^[a-f0-9]{40}$')`
     ),
+    check(
+      "github_pull_requests_verified_merge_sha",
+      sql`(${table.mergeSha} IS NULL AND ${table.mergeShaVerifiedAt} IS NULL) OR (${table.state} = 'merged' AND ${table.mergeShaVerifiedAt} IS NOT NULL)`
+    ),
     check("github_pull_requests_positive_number", sql`${table.number} > 0`),
     check(
       "github_pull_requests_nonnegative_counts",
       sql`(${table.changedFiles} IS NULL OR ${table.changedFiles} >= 0) AND (${table.additions} IS NULL OR ${table.additions} >= 0) AND (${table.deletions} IS NULL OR ${table.deletions} >= 0) AND (${table.commitCount} IS NULL OR ${table.commitCount} >= 0)`
+    ),
+    check(
+      "github_pull_requests_nonnegative_attempts",
+      sql`${table.reconcileAttempts} >= 0`
+    ),
+  ]
+).enableRLS();
+
+export const githubPullRequestSignals = pgTable(
+  "github_pull_request_signals",
+  {
+    account: varchar("account", { length: 39 }).notNull(),
+    action: varchar("action", { length: 40 }).notNull(),
+    attemptCount: integer("attempt_count").default(0).notNull(),
+    completedAt: timestamp("completed_at", {
+      mode: "date",
+      withTimezone: true,
+    }),
+    errorCode: varchar("error_code", { length: 80 }),
+    eventId: varchar("event_id", { length: 64 }).notNull(),
+    id: uuid("id").defaultRandom().primaryKey(),
+    leaseToken: uuid("lease_token"),
+    leaseUntil: timestamp("lease_until", {
+      mode: "date",
+      withTimezone: true,
+    }),
+    number: integer("number").notNull(),
+    observedAt: timestamp("observed_at", {
+      mode: "date",
+      withTimezone: true,
+    })
+      .defaultNow()
+      .notNull(),
+    occurredAt: timestamp("occurred_at", {
+      mode: "date",
+      withTimezone: true,
+    }).notNull(),
+    repositoryId: varchar("repository_id", { length: 32 }).notNull(),
+    repositoryNameSnapshot: varchar("repository_name_snapshot", {
+      length: 200,
+    }).notNull(),
+    state: varchar("state", { length: 16 }).default("pending").notNull(),
+  },
+  (table) => [
+    uniqueIndex("github_pull_request_signals_event_unique").on(
+      table.account,
+      table.eventId
+    ),
+    index("github_pull_request_signals_pending_idx").on(
+      table.state,
+      table.leaseUntil,
+      table.observedAt
+    ),
+    check(
+      "github_pull_request_signals_account",
+      sql`${table.account} IN ('f0rr0', 'yuppiestechdev')`
+    ),
+    check(
+      "github_pull_request_signals_event_id",
+      sql`${table.eventId} ~ '^[0-9]{1,64}$'`
+    ),
+    check(
+      "github_pull_request_signals_repository_id",
+      sql`${table.repositoryId} ~ '^[0-9]{1,32}$'`
+    ),
+    check(
+      "github_pull_request_signals_state",
+      sql`${table.state} IN ('pending', 'processing', 'complete', 'unavailable')`
+    ),
+    check(
+      "github_pull_request_signals_lease",
+      sql`(${table.state} = 'processing') = (${table.leaseToken} IS NOT NULL) AND (${table.state} <> 'processing' OR ${table.leaseUntil} IS NOT NULL)`
+    ),
+    check(
+      "github_pull_request_signals_values",
+      sql`${table.number} > 0 AND ${table.attemptCount} >= 0`
     ),
   ]
 ).enableRLS();
@@ -808,6 +986,7 @@ export const githubSummaryAttempts = pgTable(
   "github_summary_attempts",
   {
     activityPublicId: uuid("activity_public_id").notNull(),
+    attemptCount: integer("attempt_count").default(0).notNull(),
     attemptedAt: timestamp("attempted_at", {
       mode: "date",
       withTimezone: true,
@@ -856,7 +1035,7 @@ export const githubSummaryAttempts = pgTable(
     ),
     check(
       "github_summary_attempts_positive_revision",
-      sql`${table.revision} > 0`
+      sql`${table.revision} > 0 AND ${table.attemptCount} >= 0`
     ),
     check(
       "github_summary_attempts_input_hash_shape",

--- a/src/env.ts
+++ b/src/env.ts
@@ -23,8 +23,6 @@ export const env = createEnv({
     NODE_ENV: z.enum(["development", "production", "test"]).optional(),
     OPENAI_API_KEY: optionalString,
     PORT: optionalString,
-    POSTGRES_URL_NON_POOLING: z.url().optional(),
-    SITE_URL: optionalString,
     VERCEL: z.literal("1").optional(),
     VERCEL_ENV: z.enum(["development", "preview", "production"]).optional(),
     VERCEL_PROJECT_PRODUCTION_URL: optionalString,

--- a/src/lib/github-activity-alias-store.ts
+++ b/src/lib/github-activity-alias-store.ts
@@ -1,0 +1,85 @@
+import { and, eq, inArray, isNotNull, sql } from "drizzle-orm";
+
+import type { getDatabase } from "@/db/client";
+import {
+  githubCommits,
+  githubPublicActivities,
+  githubSummaryAttempts,
+} from "@/db/schema";
+
+type DatabaseTransaction = Parameters<
+  Parameters<ReturnType<typeof getDatabase>["transaction"]>[0]
+>[0];
+
+/**
+ * Invalidates public aliases derived from a PR whose head, state, or complete
+ * membership changed. Reset aliases stay unpublished until conservative
+ * canonicalization runs again against the refreshed evidence.
+ */
+export const invalidateGitHubPullRequestDerivedAliases = async (
+  transaction: DatabaseTransaction,
+  pullRequestNodeId: string,
+  repositoryIds: readonly (string | null | undefined)[]
+) => {
+  const affectedRepositoryIds = [
+    ...new Set(
+      repositoryIds.filter(
+        (repositoryId): repositoryId is string =>
+          repositoryId !== null && repositoryId !== undefined
+      )
+    ),
+  ];
+  if (affectedRepositoryIds.length === 0) {
+    return 0;
+  }
+  const resetActivities = await transaction
+    .update(githubPublicActivities)
+    .set({
+      aliasEvidence: null,
+      aliasReason: null,
+      canonicalPublicId: null,
+      hiddenAt: null,
+      publishedAt: null,
+    })
+    .where(
+      and(
+        eq(githubPublicActivities.kind, "commit"),
+        inArray(githubPublicActivities.repositoryId, affectedRepositoryIds),
+        isNotNull(githubPublicActivities.canonicalPublicId),
+        sql`${githubPublicActivities.aliasEvidence} ->> 'pullRequestNodeId' = ${pullRequestNodeId}`
+      )
+    )
+    .returning({ publicId: githubPublicActivities.publicId });
+  if (resetActivities.length > 0) {
+    await transaction
+      .update(githubSummaryAttempts)
+      .set({
+        attemptCount: 0,
+        attemptedAt: null,
+        completedAt: null,
+        errorCode: null,
+        inputHash: null,
+        leaseToken: null,
+        leaseUntil: null,
+        model: null,
+        state: "pending",
+        summaryHeadline: null,
+        summaryShort: null,
+      })
+      .where(
+        and(
+          inArray(
+            githubSummaryAttempts.activityPublicId,
+            resetActivities.map(({ publicId }) => publicId)
+          ),
+          eq(githubSummaryAttempts.state, "indeterminate"),
+          eq(githubSummaryAttempts.errorCode, "canonical_alias")
+        )
+      );
+  }
+  await transaction
+    .update(githubCommits)
+    .set({ canonicalizedAt: null })
+    .where(inArray(githubCommits.repositoryId, affectedRepositoryIds));
+  return resetActivities.length;
+};

--- a/src/lib/github-activity-processor.ts
+++ b/src/lib/github-activity-processor.ts
@@ -1,12 +1,13 @@
 import { createHash } from "node:crypto";
 
 import { openai } from "@ai-sdk/openai";
-import { APICallError, generateText } from "ai";
+import { generateText } from "ai";
 
 import { env } from "@/env";
 import {
   formatPublicCommitSummaryMarkdown,
   parseCommitPublicSummary,
+  PUBLIC_COMMIT_SUMMARY_RECIPE,
   PUBLIC_COMMIT_SUMMARY_SYSTEM_PROMPT,
 } from "@/lib/github-activity-public-summary";
 import type {
@@ -34,11 +35,14 @@ import type {
 } from "@/lib/github-commits-core";
 
 export const GITHUB_ACTIVITY_SUMMARY_MODEL = "gpt-5-nano-2025-08-07";
+export const GITHUB_ACTIVITY_FALLBACK_SUMMARY_MODEL = "deterministic";
+export const GITHUB_ACTIVITY_FALLBACK_SUMMARY_RECIPE =
+  "commit-message-summary-v1";
 const GITHUB_FILE_PAGE_SIZE = 100;
 const MAXIMUM_GITHUB_FILE_PAGES = 30;
-const MAXIMUM_GITHUB_PULL_REQUEST_PAGES = 10;
 const MAXIMUM_GITHUB_PULL_REQUEST_COMMIT_PAGES = 3;
-const MAXIMUM_GITHUB_PULL_REQUEST_GRAPHQL_PAGES = 30;
+const GITHUB_GRAPHQL_NODE_BATCH_SIZE = 100;
+const GITHUB_GRAPHQL_SECONDARY_LIMIT_WAIT_MS = 60_000;
 const ZERO_SHA = "0".repeat(40);
 
 type JsonObject = Record<string, unknown>;
@@ -100,13 +104,24 @@ export interface GitHubActivityPullRequestReference {
 
 export interface GitHubActivityPullRequestSource {
   commitShas: readonly string[];
+  commits: readonly GitHubCommit[];
   membershipComplete: boolean;
   pullRequest: GitHubPullRequest;
+}
+
+export interface GitHubActivityPullRequestMembershipSource {
+  commitShas: readonly string[];
+  commits: readonly GitHubCommit[];
+  membershipComplete: boolean;
 }
 
 export interface GitHubActivityPullRequestSnapshot {
   expectedCommitCount: number;
   pullRequest: GitHubPullRequest;
+}
+
+export interface GitHubProviderRequestOptions {
+  deadlineAt?: number;
 }
 
 export class ActivityProcessingError extends Error {
@@ -119,8 +134,148 @@ export class ActivityProcessingError extends Error {
   }
 }
 
+export type GitHubGraphQlResponseErrorKind =
+  | "invalid_response"
+  | "partial_response"
+  | "rate_limited"
+  | "request_failed"
+  | "request_rejected"
+  | "unresolved_merge_commit";
+
+// oxlint-disable-next-line max-classes-per-file -- This provider error carries retry metadata across worker boundaries.
+export class GitHubGraphQlResponseError extends ActivityProcessingError {
+  readonly kind: GitHubGraphQlResponseErrorKind;
+  readonly retryable: boolean;
+  readonly retryAt: Date | null;
+
+  constructor(
+    kind: GitHubGraphQlResponseErrorKind,
+    options: { retryable: boolean; retryAt?: Date | null }
+  ) {
+    super(
+      options.retryable ? "source_incomplete" : "source_invalid",
+      kind === "rate_limited"
+        ? "GitHub GraphQL is rate limited."
+        : kind === "unresolved_merge_commit"
+          ? "GitHub has not returned an authoritative pull request merge commit."
+          : "GitHub returned an unusable GraphQL response."
+    );
+    this.name = "GitHubGraphQlResponseError";
+    this.kind = kind;
+    this.retryable = options.retryable;
+    this.retryAt = options.retryAt ?? null;
+  }
+}
+
+export interface GitHubPullRequestMergeCommitResolution {
+  mergeCommitSha: string | null;
+  nodeId: string;
+}
+
 const isObject = (value: unknown): value is JsonObject =>
   typeof value === "object" && value !== null && !Array.isArray(value);
+
+const retryAtFromHeaders = (headers: Headers, now = Date.now()) => {
+  const retryAfter = headers.get("retry-after")?.trim();
+  if (retryAfter !== undefined && retryAfter !== "") {
+    if (/^\d+$/.test(retryAfter)) {
+      const timestamp = now + Number(retryAfter) * 1000;
+      if (Number.isFinite(timestamp) && timestamp <= 8_640_000_000_000_000) {
+        return new Date(timestamp);
+      }
+    }
+    const parsed = new Date(retryAfter);
+    if (!Number.isNaN(parsed.getTime())) {
+      return parsed;
+    }
+  }
+
+  const reset = headers.get("x-ratelimit-reset")?.trim();
+  if (reset !== undefined && /^\d+$/.test(reset)) {
+    const timestamp = Number(reset) * 1000;
+    if (Number.isFinite(timestamp) && timestamp <= 8_640_000_000_000_000) {
+      return new Date(timestamp);
+    }
+  }
+  return null;
+};
+
+const graphQlErrorSignals = (
+  errors: readonly JsonObject[],
+  includeMessages: boolean
+) => {
+  const signals: string[] = [];
+  for (const error of errors) {
+    const extensions = isObject(error.extensions) ? error.extensions : null;
+    const values = [
+      ...(includeMessages ? [error.message] : []),
+      error.type,
+      extensions?.classification,
+      extensions?.code,
+      extensions?.type,
+    ];
+    for (const value of values) {
+      if (typeof value === "string") {
+        signals.push(value.toUpperCase());
+      }
+    }
+  }
+  return signals;
+};
+
+const graphQlErrorIsRateLimited = (
+  errors: readonly JsonObject[],
+  headers: Headers
+) => {
+  if (
+    headers.get("x-ratelimit-remaining")?.trim() === "0" ||
+    headers.has("retry-after")
+  ) {
+    return true;
+  }
+  return graphQlErrorSignals(errors, true).some(
+    (signal) =>
+      signal.includes("RATE_LIMIT") ||
+      signal.includes("RATE LIMIT") ||
+      signal.includes("SECONDARY RATE")
+  );
+};
+
+const graphQlErrorIsPermanent = (errors: readonly JsonObject[]) => {
+  const permanentSignals = [
+    "BAD_USER_INPUT",
+    "FORBIDDEN",
+    "GRAPHQL_VALIDATION_FAILED",
+    "NOT_FOUND",
+    "UNAUTHORIZED",
+    "UNDEFINED_FIELD",
+  ];
+  const signals = graphQlErrorSignals(errors, false);
+  return signals.some((signal) =>
+    permanentSignals.some((permanent) => signal.includes(permanent))
+  );
+};
+
+const graphQlErrorsFrom = (payload: JsonObject) => {
+  if (!Object.hasOwn(payload, "errors")) {
+    return null;
+  }
+  if (
+    !Array.isArray(payload.errors) ||
+    payload.errors.length === 0 ||
+    payload.errors.some(
+      (item) =>
+        !isObject(item) ||
+        typeof item.message !== "string" ||
+        item.message.length === 0
+    )
+  ) {
+    throw new GitHubGraphQlResponseError("invalid_response", {
+      retryable: false,
+    });
+  }
+  return payload.errors as JsonObject[];
+};
 
 const requiredString = (value: unknown, label: string) => {
   if (typeof value !== "string" || value.length === 0) {
@@ -258,14 +413,229 @@ const withGitHubTokenCandidate = async <Value>(
       );
 };
 
-const fetchJson = async (path: string, token: string) => {
-  const response = await fetchGitHub(githubApiUrl(path), { token });
+const fetchJson = async (
+  path: string,
+  token: string,
+  options: GitHubProviderRequestOptions = {}
+) => {
+  const response = await fetchGitHub(githubApiUrl(path), {
+    deadlineAt: options.deadlineAt,
+    token,
+  });
   return (await response.json()) as unknown;
 };
 
-const fetchJsonWithResponse = async (url: URL, token: string) => {
-  const response = await fetchGitHub(url, { token });
+const fetchJsonWithResponse = async (
+  url: URL,
+  token: string,
+  options: GitHubProviderRequestOptions = {}
+) => {
+  const response = await fetchGitHub(url, {
+    deadlineAt: options.deadlineAt,
+    token,
+  });
   return { payload: (await response.json()) as unknown, response };
+};
+
+const PULL_REQUEST_MERGE_COMMITS_QUERY = `query PullRequestMergeCommits($ids: [ID!]!) {
+  nodes(ids: $ids) {
+    __typename
+    ... on PullRequest {
+      id
+      merged
+      mergeCommit { oid }
+    }
+  }
+}`;
+
+const graphQlNodeIdFrom = (value: unknown) =>
+  typeof value === "string" &&
+  value.length > 0 &&
+  value.length <= 100 &&
+  !/\s/u.test(value)
+    ? value
+    : null;
+
+export const githubGraphQlPayloadFrom = async (response: Response) => {
+  let value: unknown;
+  try {
+    value = await response.json();
+  } catch {
+    throw new GitHubGraphQlResponseError("invalid_response", {
+      retryable: false,
+    });
+  }
+  if (!isObject(value)) {
+    throw new GitHubGraphQlResponseError("invalid_response", {
+      retryable: false,
+    });
+  }
+  const errors = graphQlErrorsFrom(value);
+  if (errors !== null) {
+    if (graphQlErrorIsRateLimited(errors, response.headers)) {
+      throw new GitHubGraphQlResponseError("rate_limited", {
+        retryAt:
+          retryAtFromHeaders(response.headers) ??
+          new Date(Date.now() + GITHUB_GRAPHQL_SECONDARY_LIMIT_WAIT_MS),
+        retryable: true,
+      });
+    }
+    const retryable = !graphQlErrorIsPermanent(errors);
+    const hasPartialData = Object.hasOwn(value, "data") && value.data !== null;
+    throw new GitHubGraphQlResponseError(
+      hasPartialData
+        ? "partial_response"
+        : retryable
+          ? "request_failed"
+          : "request_rejected",
+      { retryable }
+    );
+  }
+  return value;
+};
+
+const resolveGitHubPullRequestMergeCommitBatch = async (
+  nodeIds: readonly string[],
+  token: string,
+  options: GitHubProviderRequestOptions
+) => {
+  const response = await fetchGitHub(githubApiUrl("/graphql"), {
+    body: JSON.stringify({
+      query: PULL_REQUEST_MERGE_COMMITS_QUERY,
+      variables: { ids: nodeIds },
+    }),
+    deadlineAt: options.deadlineAt,
+    method: "POST",
+    token,
+  });
+  const payload = await githubGraphQlPayloadFrom(response);
+  const nodes = isObject(payload.data) ? payload.data.nodes : null;
+  if (!Array.isArray(nodes) || nodes.length !== nodeIds.length) {
+    throw new GitHubGraphQlResponseError("invalid_response", {
+      retryable: false,
+    });
+  }
+
+  const requestedNodeIds = new Set(nodeIds);
+  const resolutions = new Map<string, GitHubPullRequestMergeCommitResolution>();
+  for (const node of nodes) {
+    if (node === null) {
+      throw new GitHubGraphQlResponseError("unresolved_merge_commit", {
+        retryable: true,
+      });
+    }
+    if (!isObject(node) || node.__typename !== "PullRequest") {
+      throw new GitHubGraphQlResponseError("invalid_response", {
+        retryable: false,
+      });
+    }
+    const nodeId = graphQlNodeIdFrom(node.id);
+    if (
+      nodeId === null ||
+      !requestedNodeIds.has(nodeId) ||
+      resolutions.has(nodeId)
+    ) {
+      throw new GitHubGraphQlResponseError("invalid_response", {
+        retryable: false,
+      });
+    }
+    if (node.merged !== true) {
+      throw new GitHubGraphQlResponseError("unresolved_merge_commit", {
+        retryable: true,
+      });
+    }
+    if (node.mergeCommit === null) {
+      resolutions.set(nodeId, { mergeCommitSha: null, nodeId });
+      continue;
+    }
+    const mergeCommitSha = isObject(node.mergeCommit)
+      ? commitShaFrom(node.mergeCommit.oid)
+      : null;
+    if (mergeCommitSha === null) {
+      throw new GitHubGraphQlResponseError("invalid_response", {
+        retryable: false,
+      });
+    }
+    resolutions.set(nodeId, { mergeCommitSha, nodeId });
+  }
+  if (resolutions.size !== requestedNodeIds.size) {
+    throw new GitHubGraphQlResponseError("unresolved_merge_commit", {
+      retryable: true,
+    });
+  }
+  return nodeIds.map((nodeId) => {
+    const resolution = resolutions.get(nodeId);
+    if (resolution === undefined) {
+      throw new GitHubGraphQlResponseError("unresolved_merge_commit", {
+        retryable: true,
+      });
+    }
+    return resolution;
+  });
+};
+
+/** Resolves only GitHub's authoritative post-merge commit identity. */
+export const resolveGitHubPullRequestMergeCommits = async (
+  rawNodeIds: readonly string[],
+  token: string,
+  options: GitHubProviderRequestOptions = {}
+): Promise<readonly GitHubPullRequestMergeCommitResolution[]> => {
+  const nodeIds = [...new Set(rawNodeIds)];
+  if (
+    rawNodeIds.some((nodeId) => graphQlNodeIdFrom(nodeId) === null) ||
+    nodeIds.length !== rawNodeIds.length
+  ) {
+    throw new ActivityProcessingError(
+      "source_invalid",
+      "The GitHub pull request node IDs are invalid."
+    );
+  }
+  const resolutions: GitHubPullRequestMergeCommitResolution[] = [];
+  for (
+    let offset = 0;
+    offset < nodeIds.length;
+    offset += GITHUB_GRAPHQL_NODE_BATCH_SIZE
+  ) {
+    resolutions.push(
+      ...(await resolveGitHubPullRequestMergeCommitBatch(
+        nodeIds.slice(offset, offset + GITHUB_GRAPHQL_NODE_BATCH_SIZE),
+        token,
+        options
+      ))
+    );
+  }
+  return resolutions;
+};
+
+const withAuthoritativeMergeCommits = async (
+  pullRequests: readonly GitHubPullRequest[],
+  token: string,
+  options: GitHubProviderRequestOptions = {}
+) => {
+  const merged = pullRequests.filter((pullRequest) => pullRequest.merged);
+  if (merged.length === 0) {
+    return pullRequests;
+  }
+  const resolutions = await resolveGitHubPullRequestMergeCommits(
+    merged.map((pullRequest) => pullRequest.nodeId),
+    token,
+    options
+  );
+  const mergeCommitShas = new Map(
+    resolutions.map(({ mergeCommitSha, nodeId }) => [nodeId, mergeCommitSha])
+  );
+  return pullRequests.map((pullRequest) => {
+    if (!pullRequest.merged) {
+      return pullRequest;
+    }
+    const mergeCommitSha = mergeCommitShas.get(pullRequest.nodeId);
+    if (!mergeCommitShas.has(pullRequest.nodeId)) {
+      throw new GitHubGraphQlResponseError("unresolved_merge_commit", {
+        retryable: true,
+      });
+    }
+    return { ...pullRequest, mergeCommitSha };
+  });
 };
 
 const safeAvatarUrl = (value: unknown) => {
@@ -435,11 +805,13 @@ const commitEvidenceFrom = (
 
 const fetchCommitSourceWithToken = async (
   row: GitHubActivityCommitReference,
-  token: string
+  token: string,
+  options: GitHubProviderRequestOptions = {}
 ): Promise<GitHubActivityCommitSource> => {
   const repositoryPayload = await fetchJson(
     repositoryApiPath(row.repository),
-    token
+    token,
+    options
   );
   const repository = repositoryEvidenceFrom(
     repositoryPayload,
@@ -454,7 +826,8 @@ const fetchCommitSourceWithToken = async (
         repository.fullName,
         `/commits/${encodeURIComponent(row.sha)}?per_page=${GITHUB_FILE_PAGE_SIZE}&page=${page}`
       ),
-      token
+      token,
+      options
     );
     if (!isObject(value) || !Array.isArray(value.files)) {
       throw new ActivityProcessingError(
@@ -515,16 +888,18 @@ const fetchCommitSourceWithToken = async (
 };
 
 export const fetchGitHubActivityCommitSource = async (
-  row: GitHubActivityCommitReference
+  row: GitHubActivityCommitReference,
+  options: GitHubProviderRequestOptions = {}
 ) =>
   await withGitHubTokenCandidate(
     row.author,
-    async (token) => await fetchCommitSourceWithToken(row, token)
+    async (token) => await fetchCommitSourceWithToken(row, token, options)
   );
 
 const compareCommitValuesWithToken = async (
   row: GitHubActivityPushObservationReference,
-  token: string
+  token: string,
+  options: GitHubProviderRequestOptions = {}
 ) => {
   const repository = repositoryReferenceFrom(row);
   const values: unknown[] = [];
@@ -547,7 +922,7 @@ const compareCommitValuesWithToken = async (
       );
     }
     visited.add(url.href);
-    const result = await fetchJsonWithResponse(url, token);
+    const result = await fetchJsonWithResponse(url, token, options);
     const pageValues = isObject(result.payload) ? result.payload.commits : null;
     const pageAheadBy = isObject(result.payload)
       ? requiredInteger(result.payload.ahead_by, "compare ahead count")
@@ -597,7 +972,8 @@ const compareCommitValuesWithToken = async (
 // oxlint-disable-next-line complexity -- Every GraphQL history invariant fails closed.
 const newBranchCommitValuesWithToken = async (
   row: GitHubActivityPushObservationReference,
-  token: string
+  token: string,
+  options: GitHubProviderRequestOptions = {}
 ) => {
   const { expectedCommitCount } = row;
   const historySinceAt =
@@ -628,6 +1004,7 @@ const newBranchCommitValuesWithToken = async (
               oid
               message
               authoredDate
+              committedDate
               url
               author { user { login } }
             }
@@ -658,10 +1035,11 @@ const newBranchCommitValuesWithToken = async (
           until: historyUntilAt,
         },
       }),
+      deadlineAt: options.deadlineAt,
       method: "POST",
       token,
     });
-    const payload = (await response.json()) as unknown;
+    const payload = await githubGraphQlPayloadFrom(response);
     const repository =
       isObject(payload) && isObject(payload.data)
         ? payload.data.repository
@@ -706,6 +1084,7 @@ const newBranchCommitValuesWithToken = async (
         author: isObject(user) ? { login: user.login } : null,
         commit: {
           author: { date: node.authoredDate },
+          committer: { date: node.committedDate },
           message: node.message,
         },
         html_url: node.url,
@@ -740,13 +1119,14 @@ const newBranchCommitValuesWithToken = async (
 
 const pushCommitValuesWithToken = async (
   row: GitHubActivityPushObservationReference,
-  token: string
+  token: string,
+  options: GitHubProviderRequestOptions = {}
 ) => {
   if (row.beforeSha === ZERO_SHA) {
-    return await newBranchCommitValuesWithToken(row, token);
+    return await newBranchCommitValuesWithToken(row, token, options);
   }
   try {
-    return await compareCommitValuesWithToken(row, token);
+    return await compareCommitValuesWithToken(row, token, options);
   } catch (error) {
     if (
       !(error instanceof GitHubResponseError) ||
@@ -757,7 +1137,8 @@ const pushCommitValuesWithToken = async (
     try {
       return await newBranchCommitValuesWithToken(
         { ...row, beforeSha: ZERO_SHA, expectedCommitCount: null },
-        token
+        token,
+        options
       );
     } catch {
       // Preserve the response error so token fallback can try another identity.
@@ -821,17 +1202,17 @@ const trackedCommitFromPushValue = (
     return null;
   }
   const rawCommit = isObject(value.commit) ? value.commit : null;
-  const rawDate = isObject(rawCommit?.author)
-    ? rawCommit.author.date
-    : isObject(rawCommit?.committer)
-      ? rawCommit.committer.date
+  const rawDate = isObject(rawCommit?.committer)
+    ? rawCommit.committer.date
+    : isObject(rawCommit?.author)
+      ? rawCommit.author.date
       : null;
   const providerDate =
     typeof rawDate === "string" ? new Date(rawDate) : new Date(Number.NaN);
   if (Number.isNaN(providerDate.getTime())) {
     throw new ActivityProcessingError(
       "source_invalid",
-      "GitHub returned an invalid commit author date."
+      "GitHub returned an invalid commit timestamp."
     );
   }
   const message =
@@ -852,12 +1233,41 @@ const trackedCommitFromPushValue = (
   };
 };
 
+const trackedCommitFromPullRequestValue = (
+  value: unknown,
+  sha: string,
+  repository: GitHubRepository
+) => {
+  if (!isObject(value)) {
+    throw new ActivityProcessingError(
+      "source_invalid",
+      "GitHub returned an invalid pull request commit."
+    );
+  }
+  const author = isObject(value.author)
+    ? trackedGitHubAccountFrom(value.author.login)
+    : null;
+  if (author === null) {
+    return null;
+  }
+  if (!isObject(value.commit)) {
+    throw new ActivityProcessingError(
+      "source_invalid",
+      "GitHub returned incomplete tracked pull request commit evidence."
+    );
+  }
+  // Backfill window semantics and final activity ordering both use the
+  // committer timestamp; author identity remains the top-level user.
+  return trackedCommitFromPushValue(value, sha, repository);
+};
+
 const pushObservationSourceWithToken = async (
   row: GitHubActivityPushObservationReference,
-  token: string
+  token: string,
+  options: GitHubProviderRequestOptions = {}
 ): Promise<GitHubActivityPushObservationSource> => {
   const repository = repositoryReferenceFrom(row);
-  const values = await pushCommitValuesWithToken(row, token);
+  const values = await pushCommitValuesWithToken(row, token, options);
   const commitShas: string[] = [];
   const commits: GitHubCommit[] = [];
   const seen = new Set<string>();
@@ -884,16 +1294,18 @@ const pushObservationSourceWithToken = async (
 };
 
 export const fetchGitHubPushObservationSource = async (
-  row: GitHubActivityPushObservationReference
+  row: GitHubActivityPushObservationReference,
+  options: GitHubProviderRequestOptions = {}
 ) =>
   await withGitHubTokenCandidate(
     row.account,
-    async (token) => await pushObservationSourceWithToken(row, token)
+    async (token) => await pushObservationSourceWithToken(row, token, options)
   );
 
 const fetchAssociatedPullRequestsWithToken = async (
   row: GitHubActivityCommitReference,
-  token: string
+  token: string,
+  options: GitHubProviderRequestOptions = {}
 ) => {
   const repository = repositoryReferenceFrom(row);
   let url: URL | null = githubApiUrl(
@@ -904,13 +1316,17 @@ const fetchAssociatedPullRequestsWithToken = async (
   );
   url.searchParams.set("per_page", "100");
   const pullRequests = new Map<string, GitHubPullRequest>();
+  const seenPages = new Set<string>();
 
-  for (
-    let page = 0;
-    url !== null && page < MAXIMUM_GITHUB_PULL_REQUEST_PAGES;
-    page += 1
-  ) {
-    const result = await fetchJsonWithResponse(url, token);
+  while (url !== null) {
+    if (seenPages.has(url.href)) {
+      throw new ActivityProcessingError(
+        "source_invalid",
+        "GitHub returned cyclic associated pull request pagination."
+      );
+    }
+    seenPages.add(url.href);
+    const result = await fetchJsonWithResponse(url, token, options);
     if (!Array.isArray(result.payload)) {
       throw new ActivityProcessingError(
         "source_invalid",
@@ -926,19 +1342,22 @@ const fetchAssociatedPullRequestsWithToken = async (
         baseRepository === null
           ? null
           : pullRequestFromGitHub(value, baseRepository);
-      if (pullRequest !== null) {
-        pullRequests.set(pullRequest.nodeId, pullRequest);
+      if (pullRequest === null) {
+        throw new ActivityProcessingError(
+          "source_invalid",
+          "GitHub returned an invalid associated pull request."
+        );
       }
+      pullRequests.set(pullRequest.nodeId, pullRequest);
     }
     url = nextGitHubPage(result.response);
   }
-  if (url !== null) {
-    throw new ActivityProcessingError(
-      "source_invalid",
-      "GitHub associated pull requests exceeded the pagination limit."
-    );
-  }
-  return [...pullRequests.values()].toSorted((left, right) => {
+  const resolved = await withAuthoritativeMergeCommits(
+    [...pullRequests.values()],
+    token,
+    options
+  );
+  return resolved.toSorted((left, right) => {
     if (left.createdAt !== right.createdAt) {
       return left.createdAt < right.createdAt ? -1 : 1;
     }
@@ -947,7 +1366,8 @@ const fetchAssociatedPullRequestsWithToken = async (
 };
 
 export const fetchGitHubAssociatedPullRequests = async (
-  row: GitHubActivityCommitReference
+  row: GitHubActivityCommitReference,
+  options: GitHubProviderRequestOptions = {}
 ) => {
   const tokens = tokenCandidatesFor(row.author);
   if (tokens.length === 0) {
@@ -961,7 +1381,11 @@ export const fetchGitHubAssociatedPullRequests = async (
   let lastError: unknown;
   for (const token of tokens) {
     try {
-      const visible = await fetchAssociatedPullRequestsWithToken(row, token);
+      const visible = await fetchAssociatedPullRequestsWithToken(
+        row,
+        token,
+        options
+      );
       successfulTokens += 1;
       for (const pullRequest of visible) {
         pullRequests.set(pullRequest.nodeId, pullRequest);
@@ -993,16 +1417,21 @@ export const fetchGitHubAssociatedPullRequests = async (
   });
 };
 
-const fetchPullRequestSnapshotWithToken = async (
+/**
+ * Reads the versioned REST snapshot without claiming merge-SHA authority.
+ * A merged snapshot can contain `mergeCommitSha: undefined` under REST 2026.
+ */
+export const fetchGitHubPullRequestRestSnapshotWithToken = async (
   row: GitHubActivityPullRequestReference,
-  token: string
+  token: string,
+  options: GitHubProviderRequestOptions = {}
 ): Promise<GitHubActivityPullRequestSnapshot> => {
   const repository = repositoryReferenceFrom(row);
   const pullRequestPath = repositoryApiPath(
     repository.fullName,
     `/pulls/${String(row.number)}`
   );
-  const root = await fetchJson(pullRequestPath, token);
+  const root = await fetchJson(pullRequestPath, token, options);
   const pullRequest = pullRequestFromGitHub(root, repository, "reconciled");
   if (pullRequest === null) {
     throw new ActivityProcessingError(
@@ -1023,11 +1452,41 @@ const fetchPullRequestSnapshotWithToken = async (
   return { expectedCommitCount, pullRequest };
 };
 
+const fetchPullRequestSnapshotWithToken = async (
+  row: GitHubActivityPullRequestReference,
+  token: string,
+  options: GitHubProviderRequestOptions = {}
+): Promise<GitHubActivityPullRequestSnapshot> => {
+  const snapshot = await fetchGitHubPullRequestRestSnapshotWithToken(
+    row,
+    token,
+    options
+  );
+  const [resolved] = await withAuthoritativeMergeCommits(
+    [snapshot.pullRequest],
+    token,
+    options
+  );
+  if (resolved === undefined) {
+    throw new ActivityProcessingError(
+      "source_invalid",
+      "GitHub returned an invalid pull request snapshot."
+    );
+  }
+  return {
+    expectedCommitCount: snapshot.expectedCommitCount,
+    pullRequest: resolved,
+  };
+};
+
 // oxlint-disable-next-line complexity -- Every GraphQL pagination invariant is validated fail-closed.
-const pullRequestCommitShasFromGraphQl = async (
+const pullRequestMembershipFromGraphQl = async (
   row: GitHubActivityPullRequestReference,
   expectedCommitCount: number,
-  token: string
+  token: string,
+  commitRepository: GitHubRepository,
+  expectedHeadSha: string | null,
+  deadlineAt: number | undefined
 ) => {
   const [owner, name] = row.repository.split("/");
   if (owner === undefined || name === undefined) {
@@ -1041,34 +1500,37 @@ const pullRequestCommitShasFromGraphQl = async (
       pullRequest(number: $number) {
         commits(first: 100, after: $cursor) {
           totalCount
-          nodes { commit { oid } }
+          nodes {
+            commit {
+              oid
+              message
+              committedDate
+              author { user { login } }
+            }
+          }
           pageInfo { hasNextPage endCursor }
         }
       }
     }
   }`;
   const commitShas: string[] = [];
+  const commits: GitHubCommit[] = [];
   const seen = new Set<string>();
+  const seenCursors = new Set<string>();
   let cursor: string | null = null;
   let hasNextPage = true;
-  for (
-    let page = 0;
-    hasNextPage && page < MAXIMUM_GITHUB_PULL_REQUEST_GRAPHQL_PAGES;
-    page += 1
-  ) {
+  while (hasNextPage) {
     const response = await fetchGitHub(githubApiUrl("/graphql"), {
       body: JSON.stringify({
         query,
         variables: { cursor, name, number: row.number, owner },
       }),
+      deadlineAt,
       method: "POST",
       token,
     });
-    const payload = (await response.json()) as unknown;
-    const repository =
-      isObject(payload) && isObject(payload.data)
-        ? payload.data.repository
-        : null;
+    const payload = await githubGraphQlPayloadFrom(response);
+    const repository = isObject(payload.data) ? payload.data.repository : null;
     const pullRequest = isObject(repository) ? repository.pullRequest : null;
     const connection = isObject(pullRequest) ? pullRequest.commits : null;
     if (
@@ -1084,6 +1546,7 @@ const pullRequestCommitShasFromGraphQl = async (
         "GitHub returned invalid GraphQL pull request membership."
       );
     }
+    const commitsBeforePage = commitShas.length;
     for (const node of connection.nodes) {
       const sha =
         isObject(node) && isObject(node.commit)
@@ -1098,34 +1561,91 @@ const pullRequestCommitShasFromGraphQl = async (
       if (!seen.has(sha)) {
         seen.add(sha);
         commitShas.push(sha);
+        const commitValue = isObject(node) ? node.commit : null;
+        const user =
+          isObject(commitValue) && isObject(commitValue.author)
+            ? commitValue.author.user
+            : null;
+        const commit = trackedCommitFromPushValue(
+          {
+            author: isObject(user) ? { login: user.login } : null,
+            commit: {
+              committer: {
+                date: isObject(commitValue) ? commitValue.committedDate : null,
+              },
+              message: isObject(commitValue) ? commitValue.message : null,
+            },
+            sha,
+          },
+          sha,
+          commitRepository
+        );
+        if (commit !== null) {
+          commits.push(commit);
+        }
       }
     }
     ({ hasNextPage } = connection.pageInfo);
+    if (
+      commitShas.length > expectedCommitCount ||
+      (hasNextPage && commitShas.length === commitsBeforePage)
+    ) {
+      throw new ActivityProcessingError(
+        "source_invalid",
+        "GitHub returned inconsistent GraphQL pull request membership."
+      );
+    }
     const nextCursor = connection.pageInfo.endCursor;
     if (
       hasNextPage &&
-      (typeof nextCursor !== "string" || nextCursor.length === 0)
+      (typeof nextCursor !== "string" ||
+        nextCursor.length === 0 ||
+        seenCursors.has(nextCursor))
     ) {
       throw new ActivityProcessingError(
         "source_invalid",
         "GitHub returned an invalid pull request membership cursor."
       );
     }
+    if (typeof nextCursor === "string") {
+      seenCursors.add(nextCursor);
+    }
     cursor = typeof nextCursor === "string" ? nextCursor : null;
   }
   return {
     commitShas,
+    commits,
     membershipComplete:
-      !hasNextPage && commitShas.length === expectedCommitCount,
+      !hasNextPage &&
+      commitShas.length === expectedCommitCount &&
+      (expectedHeadSha === null ||
+        expectedCommitCount === 0 ||
+        commitShas.at(-1) === expectedHeadSha),
   };
 };
 
-const fetchPullRequestMembershipWithToken = async (
+export const fetchGitHubPullRequestMembershipWithToken = async (
   row: GitHubActivityPullRequestReference,
   expectedCommitCount: number,
-  token: string
-) => {
+  token: string,
+  options: {
+    commitRepository?: GitHubRepository;
+    deadlineAt?: number;
+    expectedHeadSha?: string;
+  } = {}
+): Promise<GitHubActivityPullRequestMembershipSource> => {
   const repository = repositoryReferenceFrom(row);
+  const commitRepository = options.commitRepository ?? repository;
+  const expectedHeadSha =
+    options.expectedHeadSha === undefined
+      ? null
+      : commitShaFrom(options.expectedHeadSha);
+  if (options.expectedHeadSha !== undefined && expectedHeadSha === null) {
+    throw new ActivityProcessingError(
+      "source_invalid",
+      "The expected GitHub pull request head is invalid."
+    );
+  }
   const pullRequestPath = repositoryApiPath(
     repository.fullName,
     `/pulls/${String(row.number)}`
@@ -1133,6 +1653,7 @@ const fetchPullRequestMembershipWithToken = async (
   let url: URL | null = githubApiUrl(`${pullRequestPath}/commits`);
   url.searchParams.set("per_page", "100");
   const commitShas: string[] = [];
+  const commits: GitHubCommit[] = [];
   const seen = new Set<string>();
 
   for (
@@ -1140,7 +1661,7 @@ const fetchPullRequestMembershipWithToken = async (
     url !== null && page < MAXIMUM_GITHUB_PULL_REQUEST_COMMIT_PAGES;
     page += 1
   ) {
-    const result = await fetchJsonWithResponse(url, token);
+    const result = await fetchJsonWithResponse(url, token, options);
     if (!Array.isArray(result.payload)) {
       throw new ActivityProcessingError(
         "source_invalid",
@@ -1158,43 +1679,82 @@ const fetchPullRequestMembershipWithToken = async (
       if (!seen.has(sha)) {
         seen.add(sha);
         commitShas.push(sha);
+        const commit = trackedCommitFromPullRequestValue(
+          value,
+          sha,
+          commitRepository
+        );
+        if (commit !== null) {
+          commits.push(commit);
+        }
       }
     }
     url = nextGitHubPage(result.response);
   }
 
   const membershipComplete =
-    url === null && commitShas.length === expectedCommitCount;
+    url === null &&
+    commitShas.length === expectedCommitCount &&
+    (expectedHeadSha === null ||
+      expectedCommitCount === 0 ||
+      commitShas.at(-1) === expectedHeadSha);
   return membershipComplete
-    ? { commitShas, membershipComplete }
-    : await pullRequestCommitShasFromGraphQl(row, expectedCommitCount, token);
+    ? { commitShas, commits, membershipComplete }
+    : await pullRequestMembershipFromGraphQl(
+        row,
+        expectedCommitCount,
+        token,
+        commitRepository,
+        expectedHeadSha,
+        options.deadlineAt
+      );
 };
 
 export const fetchGitHubPullRequestSnapshot = async (
-  row: GitHubActivityPullRequestReference
-) =>
-  await withGitHubTokenCandidate(
-    row.account,
-    async (token) => await fetchPullRequestSnapshotWithToken(row, token)
-  );
-
-export const fetchGitHubPullRequestMembership = async (
   row: GitHubActivityPullRequestReference,
-  expectedCommitCount: number
+  options: GitHubProviderRequestOptions = {}
 ) =>
   await withGitHubTokenCandidate(
     row.account,
     async (token) =>
-      await fetchPullRequestMembershipWithToken(row, expectedCommitCount, token)
+      await fetchPullRequestSnapshotWithToken(row, token, options)
+  );
+
+export const fetchGitHubPullRequestMembership = async (
+  row: GitHubActivityPullRequestReference,
+  expectedCommitCount: number,
+  options: {
+    commitRepository?: GitHubRepository;
+    deadlineAt?: number;
+    expectedHeadSha?: string;
+  } = {}
+) =>
+  await withGitHubTokenCandidate(
+    row.account,
+    async (token) =>
+      await fetchGitHubPullRequestMembershipWithToken(
+        row,
+        expectedCommitCount,
+        token,
+        options
+      )
   );
 
 export const fetchGitHubPullRequestSource = async (
-  row: GitHubActivityPullRequestReference
+  row: GitHubActivityPullRequestReference,
+  options: GitHubProviderRequestOptions = {}
 ) => {
-  const snapshot = await fetchGitHubPullRequestSnapshot(row);
+  const snapshot = await fetchGitHubPullRequestSnapshot(row, options);
   const membership = await fetchGitHubPullRequestMembership(
     row,
-    snapshot.expectedCommitCount
+    snapshot.expectedCommitCount,
+    {
+      commitRepository:
+        snapshot.pullRequest.headRepository ??
+        snapshot.pullRequest.baseRepository,
+      deadlineAt: options.deadlineAt,
+      expectedHeadSha: snapshot.pullRequest.headSha,
+    }
   );
   return { ...membership, pullRequest: snapshot.pullRequest };
 };
@@ -1202,7 +1762,22 @@ export const fetchGitHubPullRequestSource = async (
 const directlyOwnedRepository = (source: GitHubActivityCommitSource) =>
   trackedGitHubAccountFrom(source.repository.ownerLogin) !== null;
 
-const generateCommitSummary = async (source: GitHubActivityCommitSource) => {
+const MAXIMUM_ABORT_SIGNAL_TIMEOUT_MS = 2_147_483_647;
+
+const abortSignalBefore = (deadlineAt: number) => {
+  const remaining = Math.floor(deadlineAt - Date.now());
+  if (!Number.isFinite(deadlineAt) || deadlineAt < 0 || remaining <= 0) {
+    return null;
+  }
+  return AbortSignal.timeout(
+    Math.min(remaining, MAXIMUM_ABORT_SIGNAL_TIMEOUT_MS)
+  );
+};
+
+const generateCommitSummary = async (
+  source: GitHubActivityCommitSource,
+  options: GitHubProviderRequestOptions
+) => {
   const modelInput = await buildCommitPublicSummaryModelInput(source.commit, {
     avatarUrl: source.repository.avatarUrl,
     description: source.repository.description,
@@ -1219,7 +1794,17 @@ const generateCommitSummary = async (source: GitHubActivityCommitSource) => {
     .update("\n")
     .update(modelInput)
     .digest("hex");
+  const { deadlineAt } = options;
+  const abortSignal =
+    deadlineAt === undefined ? null : abortSignalBefore(deadlineAt);
+  if (deadlineAt !== undefined && abortSignal === null) {
+    throw new ActivityProcessingError(
+      "worker_deadline",
+      "The activity-summary deadline was reached."
+    );
+  }
   const result = await generateText({
+    ...(abortSignal === null ? {} : { abortSignal }),
     maxRetries: 0,
     model: openai(GITHUB_ACTIVITY_SUMMARY_MODEL),
     prompt: modelInput,
@@ -1235,24 +1820,54 @@ const generateCommitSummary = async (source: GitHubActivityCommitSource) => {
   return { inputHash, text: result.text };
 };
 
-const modelFailureCode = (error: unknown) => {
-  if (APICallError.isInstance(error) && error.statusCode !== undefined) {
-    return `model_${error.statusCode}`;
-  }
-  return "model_failed";
+const conventionalCommitPrefix =
+  /^(?:revert:\s*)?(?:build|chore|ci|docs|feat|fix|perf|refactor|style|test)(?:\([^\r\n)]*\))?!?:\s*/iu;
+
+const deterministicCommitSummary = (source: GitHubActivityCommitSource) => {
+  const firstLine = source.commit.message.split(/\r?\n/u, 1)[0] ?? "";
+  const unprefixed = firstLine.replace(conventionalCommitPrefix, "").trim();
+  const normalized = (unprefixed || "Updated the repository")
+    .replaceAll(/\s+/gu, " ")
+    .slice(0, 240);
+  const headline = normalized.replace(/^([a-z])/u, (first) =>
+    first.toUpperCase()
+  );
+  const summary = formatPublicCommitSummaryMarkdown(
+    { headline, short: headline },
+    source.commit
+  );
+  const inputHash = createHash("sha256")
+    .update(GITHUB_ACTIVITY_FALLBACK_SUMMARY_RECIPE)
+    .update("\n")
+    .update(source.commit.sha)
+    .update("\n")
+    .update(source.commit.message)
+    .digest("hex");
+  return {
+    inputHash,
+    model: GITHUB_ACTIVITY_FALLBACK_SUMMARY_MODEL,
+    recipe: GITHUB_ACTIVITY_FALLBACK_SUMMARY_RECIPE,
+    summary,
+  };
 };
 
 export const generateValidatedGitHubActivitySummary = async (
-  source: GitHubActivityCommitSource
+  source: GitHubActivityCommitSource,
+  options: GitHubProviderRequestOptions = {}
 ) => {
+  // Private patches never leave the application. The deterministic path also
+  // keeps publication independent of optional model credentials and uptime.
+  if (
+    source.repository.private ||
+    (env.OPENAI_API_KEY?.trim().length ?? 0) === 0
+  ) {
+    return deterministicCommitSummary(source);
+  }
   let generated: Awaited<ReturnType<typeof generateCommitSummary>>;
   try {
-    generated = await generateCommitSummary(source);
-  } catch (error) {
-    throw new ActivityProcessingError(
-      modelFailureCode(error),
-      error instanceof Error ? error.message : "The model request failed."
-    );
+    generated = await generateCommitSummary(source, options);
+  } catch {
+    return deterministicCommitSummary(source);
   }
   let summary;
   try {
@@ -1260,11 +1875,13 @@ export const generateValidatedGitHubActivitySummary = async (
       parseCommitPublicSummary(generated.text),
       source.commit
     );
-  } catch (error) {
-    throw new ActivityProcessingError(
-      "output_invalid",
-      error instanceof Error ? error.message : "The model output was invalid."
-    );
+  } catch {
+    return deterministicCommitSummary(source);
   }
-  return { inputHash: generated.inputHash, summary };
+  return {
+    inputHash: generated.inputHash,
+    model: GITHUB_ACTIVITY_SUMMARY_MODEL,
+    recipe: PUBLIC_COMMIT_SUMMARY_RECIPE,
+    summary,
+  };
 };

--- a/src/lib/github-activity-store.ts
+++ b/src/lib/github-activity-store.ts
@@ -76,6 +76,13 @@ const activityDay = sql<string>`to_char(${githubPublicActivities.occurredAt} AT 
 const commitKey = (repositoryId: string, sha: string) =>
   `${repositoryId}:${sha}`;
 
+const publicRepositoryKey = (identity: string) =>
+  createHash("sha256")
+    .update("public-github-repository-group-v1\0")
+    .update(identity)
+    .digest("base64url")
+    .slice(0, 22);
+
 const publicPullRequestSliceId = (nodeId: string, day: string) =>
   `pr-${createHash("sha256")
     .update(nodeId)
@@ -109,7 +116,13 @@ const publicRepository = (
     repository.ownerLogin === null ||
     repository.visibility === null
   ) {
-    return { avatarUrl: null, label: null, url: null };
+    const identity = "sha" in destination ? destination.sha : destination.url;
+    return {
+      avatarUrl: null,
+      key: publicRepositoryKey(identity),
+      label: null,
+      url: null,
+    };
   }
   const privateRepository = repository.visibility !== "public";
   const display =
@@ -128,6 +141,7 @@ const publicRepository = (
         });
   return {
     avatarUrl: safeAvatarUrl(repository.ownerAvatarUrl),
+    key: publicRepositoryKey(repository.id),
     label: display.repositoryLabel,
     url: display.url,
   };
@@ -181,7 +195,8 @@ const publicCommit = (
       iconUrl: publicLanguageIconUrl(language.id),
     })),
     providerFileCapReached: commit.providerFileCapReached,
-    summary: showDetail ? summary.short : null,
+    summary:
+      showDetail && summary.short !== summary.headline ? summary.short : null,
   };
 };
 

--- a/src/lib/github-activity-types.ts
+++ b/src/lib/github-activity-types.ts
@@ -7,6 +7,7 @@ export interface PublicGitHubActivityLanguage {
 
 export interface PublicGitHubActivityRepository {
   avatarUrl: string | null;
+  key: string;
   label: string | null;
   url: string | null;
 }

--- a/src/lib/github-activity-worker-core.ts
+++ b/src/lib/github-activity-worker-core.ts
@@ -4,8 +4,11 @@ import type { PublicCommitEvidence } from "@/lib/github-activity-public-summary"
 
 export const GITHUB_EXACT_DIFF_DIGEST_RECIPE = "github-exact-diff-v2";
 export const DEFAULT_GITHUB_ACTIVITY_WORKER_BATCH_SIZE = 4;
-export const MAXIMUM_GITHUB_ACTIVITY_WORKER_BATCH_SIZE = 16;
-export const GITHUB_PR_RECONCILIATION_MAX_AGE_DAYS = 30;
+export const MAXIMUM_GITHUB_ACTIVITY_WORKER_BATCH_SIZE = 8;
+export const GITHUB_PR_RECONCILIATION_MAX_AGE_DAYS = Number.POSITIVE_INFINITY;
+
+const DEFAULT_RETRY_DELAY_MS = 15 * 60 * 1000;
+const MAXIMUM_RETRY_DELAY_MS = 24 * 60 * 60 * 1000;
 
 export interface GitHubExactDiffDigest {
   complete: boolean;
@@ -148,6 +151,23 @@ export const boundedWorkerLimit = (
   return selected;
 };
 
+export const githubActivityRetryAt = (
+  attemptCount: number,
+  now: Date,
+  requested: Date | null = null
+) => {
+  if (!Number.isSafeInteger(attemptCount) || attemptCount < 1) {
+    throw new RangeError("The GitHub activity attempt count is invalid.");
+  }
+  const exponent = Math.min(attemptCount - 1, 16);
+  const delay = Math.min(
+    DEFAULT_RETRY_DELAY_MS * 2 ** exponent,
+    MAXIMUM_RETRY_DELAY_MS
+  );
+  const fallback = new Date(now.getTime() + delay);
+  return requested !== null && requested > fallback ? requested : fallback;
+};
+
 export const workerBatchSizeFrom = (
   value: string | null
 ): number | null | undefined => {
@@ -208,12 +228,25 @@ export const githubCommitActivityOccurredAt = (source: {
 export const nextGitHubPullRequestReconciliationAt = (
   state: "closed" | "merged" | "open",
   now: Date,
-  intervalMs = 3 * 60 * 60 * 1000
+  createdAt = now
 ) => {
-  if (!Number.isSafeInteger(intervalMs) || intervalMs < 1) {
-    throw new RangeError("The GitHub PR reconciliation interval is invalid.");
+  if (Number.isNaN(now.getTime()) || Number.isNaN(createdAt.getTime())) {
+    throw new TypeError("The GitHub PR reconciliation time is invalid.");
   }
-  return state === "open" ? new Date(now.getTime() + intervalMs) : null;
+  if (state !== "open") {
+    return null;
+  }
+  const ageDays = Math.max(
+    0,
+    (now.getTime() - createdAt.getTime()) / (24 * 60 * 60 * 1000)
+  );
+  const intervalMs =
+    ageDays <= 30
+      ? 3 * 60 * 60 * 1000
+      : ageDays <= 180
+        ? 24 * 60 * 60 * 1000
+        : 7 * 24 * 60 * 60 * 1000;
+  return new Date(now.getTime() + intervalMs);
 };
 
 export const githubSummaryCanPublish = (input: {

--- a/src/lib/github-activity-worker-store.ts
+++ b/src/lib/github-activity-worker-store.ts
@@ -22,12 +22,14 @@ import {
   githubPublicActivities,
   githubPullRequestMemberships,
   githubPullRequests,
+  githubPullRequestSignals,
   githubPullRequestVersions,
   githubPushObservationCommits,
   githubPushObservations,
   githubRepositories,
   githubSummaryAttempts,
 } from "@/db/schema";
+import { invalidateGitHubPullRequestDerivedAliases } from "@/lib/github-activity-alias-store";
 import type {
   GitHubActivityCommitReference,
   GitHubActivityCommitSource,
@@ -41,6 +43,7 @@ import {
 } from "@/lib/github-activity-public-summary";
 import {
   githubCommitActivityOccurredAt,
+  githubActivityRetryAt,
   githubPullRequestSnapshotDisposition,
   githubPrReconciliationCutoff,
   githubSummaryCanPublish,
@@ -59,7 +62,6 @@ type DatabaseTransaction = Parameters<
 >[0];
 
 const DEFAULT_LEASE_MS = 5 * 60 * 1000;
-const DEFAULT_DEFER_MS = 15 * 60 * 1000;
 const isNonMergeCommit = sql<boolean>`
   ${githubCommits.parentShas} IS NOT NULL
   AND jsonb_array_length(${githubCommits.parentShas}) <= 1
@@ -80,13 +82,258 @@ const commitIdentity = (commit: { repositoryId: string; sha: string }) =>
 const observationIdentity = (observation: { id: string }) =>
   eq(githubPushObservations.id, observation.id);
 
-const dueAt = (now: Date, requested: Date | null = null) =>
-  requested !== null && requested > now
-    ? requested
-    : new Date(now.getTime() + DEFAULT_DEFER_MS);
+const dueAt = (
+  attemptCount: number,
+  now: Date,
+  requested: Date | null = null
+) => githubActivityRetryAt(attemptCount, now, requested);
+
+const GITHUB_EVIDENCE_RECOVERY_CONSTRAINT =
+  "github_pull_requests_verified_merge_sha";
+const GITHUB_EVIDENCE_RECOVERY_LOCK = "github-evidence-recovery-v1";
+export const GITHUB_EVIDENCE_RECOVERY_CONFIRMATION =
+  "REPAIR_GITHUB_EVIDENCE_V1";
+
+export interface GitHubEvidenceRecoveryPlan {
+  aliasesToClear: number;
+  canonicalizedCommitsToReset: number;
+  commitActivitiesToUnpublish: number;
+  commitsToRediscoverPullRequests: number;
+  constraintInstalled: boolean;
+  pullRequestsToReconcile: number;
+  summariesToRequeue: number;
+  unverifiedMergeShasToClear: number;
+}
+
+export interface GitHubEvidenceRecoveryResult {
+  plan: GitHubEvidenceRecoveryPlan;
+  repairedAt: string | null;
+  status: "already_applied" | "applied";
+}
+
+const appliedGitHubEvidenceRecoveryPlan = (): GitHubEvidenceRecoveryPlan => ({
+  aliasesToClear: 0,
+  canonicalizedCommitsToReset: 0,
+  commitActivitiesToUnpublish: 0,
+  commitsToRediscoverPullRequests: 0,
+  constraintInstalled: true,
+  pullRequestsToReconcile: 0,
+  summariesToRequeue: 0,
+  unverifiedMergeShasToClear: 0,
+});
+
+const invalidGitHubMergeEvidence = sql<boolean>`NOT (
+  (${githubPullRequests.mergeSha} IS NULL AND ${githubPullRequests.mergeShaVerifiedAt} IS NULL)
+  OR (
+    ${githubPullRequests.state} = 'merged'
+    AND ${githubPullRequests.mergeShaVerifiedAt} IS NOT NULL
+  )
+)`;
+
+const legacyGitHubCanonicalAlias = and(
+  eq(githubPublicActivities.kind, "commit"),
+  or(
+    isNotNull(githubPublicActivities.aliasEvidence),
+    isNotNull(githubPublicActivities.aliasReason),
+    isNotNull(githubPublicActivities.canonicalPublicId),
+    isNotNull(githubPublicActivities.hiddenAt)
+  )
+);
+
+const currentNoncompleteCommitSummary = and(
+  inArray(githubSummaryAttempts.state, [
+    "pending",
+    "failed",
+    "indeterminate",
+    "processing",
+  ]),
+  sql<boolean>`EXISTS (
+    SELECT 1
+    FROM ${githubPublicActivities} AS recovery_activity
+    WHERE recovery_activity.public_id = ${githubSummaryAttempts.activityPublicId}
+      AND recovery_activity.revision = ${githubSummaryAttempts.revision}
+      AND recovery_activity.kind = 'commit'
+  )`
+);
+
+const githubEvidenceRecoveryConstraintInstalled = async (
+  transaction: DatabaseTransaction
+) => {
+  const [row] = await transaction.execute<{ installed: boolean }>(sql`
+    SELECT EXISTS (
+      SELECT 1
+      FROM pg_constraint
+      WHERE conname = ${GITHUB_EVIDENCE_RECOVERY_CONSTRAINT}
+        AND conrelid = 'github_pull_requests'::regclass
+    ) AS installed
+  `);
+  return row?.installed ?? false;
+};
+
+const githubEvidenceRecoveryPlanInTransaction = async (
+  transaction: DatabaseTransaction
+): Promise<GitHubEvidenceRecoveryPlan> => {
+  const [unverifiedMergeShas] = await transaction
+    .select({ value: sql<number>`count(*)::integer` })
+    .from(githubPullRequests)
+    .where(invalidGitHubMergeEvidence);
+  const [aliases] = await transaction
+    .select({ value: sql<number>`count(*)::integer` })
+    .from(githubPublicActivities)
+    .where(legacyGitHubCanonicalAlias);
+  const [canonicalizedCommits] = await transaction
+    .select({ value: sql<number>`count(*)::integer` })
+    .from(githubCommits)
+    .where(isNotNull(githubCommits.canonicalizedAt));
+  const [publishedCommitActivities] = await transaction
+    .select({ value: sql<number>`count(*)::integer` })
+    .from(githubPublicActivities)
+    .where(
+      and(
+        legacyGitHubCanonicalAlias,
+        isNotNull(githubPublicActivities.publishedAt)
+      )
+    );
+  const [commits] = await transaction
+    .select({ value: sql<number>`count(*)::integer` })
+    .from(githubCommits)
+    .where(eq(githubCommits.enrichmentState, "complete"));
+  const [pullRequests] = await transaction
+    .select({ value: sql<number>`count(*)::integer` })
+    .from(githubPullRequests);
+  const [summaries] = await transaction
+    .select({ value: sql<number>`count(*)::integer` })
+    .from(githubSummaryAttempts)
+    .where(currentNoncompleteCommitSummary);
+
+  return {
+    aliasesToClear: aliases?.value ?? 0,
+    canonicalizedCommitsToReset: canonicalizedCommits?.value ?? 0,
+    commitActivitiesToUnpublish: publishedCommitActivities?.value ?? 0,
+    commitsToRediscoverPullRequests: commits?.value ?? 0,
+    constraintInstalled:
+      await githubEvidenceRecoveryConstraintInstalled(transaction),
+    pullRequestsToReconcile: pullRequests?.value ?? 0,
+    summariesToRequeue: summaries?.value ?? 0,
+    unverifiedMergeShasToClear: unverifiedMergeShas?.value ?? 0,
+  };
+};
+
+/**
+ * Previews the one-time repair without claiming work or mutating source rows.
+ * Counts describe the shared database, not a repository-scoped backfill.
+ */
+export const inspectGitHubEvidenceRecovery = async () =>
+  await getDatabase().transaction(githubEvidenceRecoveryPlanInTransaction);
+
+/**
+ * Completes the post-deploy evidence migration if its constraint marker is
+ * absent. The catalog fast path keeps this safe to call at every worker start.
+ *
+ * Invalidates legacy merge evidence and every projection derived from it.
+ * The transaction preserves commits, PR snapshots, memberships, and summaries;
+ * workers rebuild the canonical/public projection from authoritative evidence.
+ */
+export const ensureGitHubEvidenceIntegrity = async (
+  now = new Date()
+): Promise<GitHubEvidenceRecoveryResult> => {
+  if (Number.isNaN(now.getTime())) {
+    throw new TypeError("The GitHub evidence repair timestamp is invalid.");
+  }
+
+  return await getDatabase().transaction(async (transaction) => {
+    await transaction.execute(
+      sql`SELECT pg_advisory_xact_lock(hashtextextended(${GITHUB_EVIDENCE_RECOVERY_LOCK}, 0))`
+    );
+    if (await githubEvidenceRecoveryConstraintInstalled(transaction)) {
+      return {
+        plan: appliedGitHubEvidenceRecoveryPlan(),
+        repairedAt: null,
+        status: "already_applied",
+      };
+    }
+    const plan = await githubEvidenceRecoveryPlanInTransaction(transaction);
+
+    await transaction
+      .update(githubPullRequests)
+      .set({ mergeSha: null, mergeShaVerifiedAt: null })
+      .where(invalidGitHubMergeEvidence);
+    await transaction
+      .update(githubPublicActivities)
+      .set({
+        aliasEvidence: null,
+        aliasReason: null,
+        canonicalPublicId: null,
+        hiddenAt: null,
+        publishedAt: null,
+      })
+      .where(legacyGitHubCanonicalAlias);
+    await transaction
+      .update(githubCommits)
+      .set({
+        canonicalizedAt: null,
+        pullRequestDiscoveryAttempts: 0,
+        pullRequestDiscoveryError: null,
+        pullRequestDiscoveryLeaseToken: null,
+        pullRequestDiscoveryLeaseUntil: now,
+        pullRequestDiscoveryState: "pending",
+      })
+      .where(eq(githubCommits.enrichmentState, "complete"));
+    await transaction.update(githubPullRequests).set({
+      nextReconcileAt: now,
+      reconcileAttempts: 0,
+      reconcileError: null,
+    });
+    await transaction
+      .update(githubSummaryAttempts)
+      .set({
+        attemptCount: 0,
+        attemptedAt: null,
+        completedAt: null,
+        errorCode: null,
+        inputHash: null,
+        leaseToken: null,
+        leaseUntil: null,
+        model: null,
+        state: "pending",
+        summaryHeadline: null,
+        summaryShort: null,
+      })
+      .where(currentNoncompleteCommitSummary);
+    await transaction.execute(sql`
+      ALTER TABLE "github_pull_requests"
+      ADD CONSTRAINT "github_pull_requests_verified_merge_sha"
+      CHECK (
+        (merge_sha IS NULL AND merge_sha_verified_at IS NULL)
+        OR (
+          state = 'merged'
+          AND merge_sha_verified_at IS NOT NULL
+        )
+      )
+    `);
+
+    return {
+      plan,
+      repairedAt: now.toISOString(),
+      status: "applied",
+    };
+  });
+};
+
+/** Manual repair entry point guarded by an explicit workflow confirmation. */
+export const repairLegacyGitHubEvidence = async (
+  confirmation: string,
+  now = new Date()
+): Promise<GitHubEvidenceRecoveryResult> => {
+  if (confirmation !== GITHUB_EVIDENCE_RECOVERY_CONFIRMATION) {
+    throw new TypeError("The GitHub evidence repair confirmation is invalid.");
+  }
+  return await ensureGitHubEvidenceIntegrity(now);
+};
 
 export interface ClaimedGitHubPushObservation {
   account: TrackedGitHubAccount;
+  attemptCount: number;
   afterSha: string;
   beforeSha: string;
   expectedCommitCount: number | null;
@@ -96,17 +343,29 @@ export interface ClaimedGitHubPushObservation {
   knownShas: readonly string[];
   leaseToken: string;
   observedAt: Date;
+  priorAttemptCount: number;
+  priorErrorCode: string | null;
+  priorRetryAt: Date | null;
+  priorState: "deferred" | "pending";
   refName: string;
   repository: string;
   repositoryId: string;
 }
 
 export interface ClaimedGitHubCommit extends GitHubActivityCommitReference {
+  attemptCount: number;
   leaseToken: string;
+  priorAttemptCount: number;
+  priorErrorCode: string | null;
+  priorRetryAt: Date | null;
 }
 
 export interface ClaimedGitHubPullRequestDiscovery extends GitHubActivityCommitReference {
+  attemptCount: number;
   leaseToken: string;
+  priorAttemptCount: number;
+  priorErrorCode: string | null;
+  priorRetryAt: Date | null;
 }
 
 export interface HydratedGitHubCommit {
@@ -115,19 +374,26 @@ export interface HydratedGitHubCommit {
 }
 
 export interface StoredPullRequestSnapshot {
+  baseRepositoryId: string;
   commitRepositoryId: string;
   membershipRefreshRequired: boolean;
   pullRequestNodeId: string;
+  retryLifecycleReset: boolean;
   versionId: string;
 }
 
 export interface DueGitHubPullRequest {
   account: TrackedGitHubAccount;
+  attemptCount: number;
+  createdAt: Date;
   lastReconciledAt: Date | null;
   leaseUntil: Date;
   membershipComplete: boolean;
   nodeId: string;
   number: number;
+  priorAttemptCount: number;
+  priorErrorCode: string | null;
+  priorRetryAt: Date;
   repository: string;
   repositoryId: string;
   versionObservedAt: Date | null;
@@ -135,8 +401,27 @@ export interface DueGitHubPullRequest {
 
 export interface ClaimedGitHubSummary extends GitHubActivityCommitReference {
   activityPublicId: string;
+  attemptCount: number;
   leaseToken: string;
+  priorAttemptCount: number;
+  priorAttemptedAt: Date | null;
+  priorErrorCode: string | null;
+  priorRetryAt: Date | null;
   revision: number;
+}
+
+export interface ClaimedGitHubPullRequestSignal {
+  account: TrackedGitHubAccount;
+  action: string;
+  attemptCount: number;
+  id: string;
+  leaseToken: string;
+  number: number;
+  priorAttemptCount: number;
+  priorErrorCode: string | null;
+  priorRetryAt: Date | null;
+  repository: string;
+  repositoryId: string;
 }
 
 const isActiveAccount = (
@@ -161,11 +446,14 @@ export const claimGitHubPushObservations = async (
       .select({
         account: githubPushObservations.account,
         afterSha: githubPushObservations.afterSha,
+        attemptCount: githubPushObservations.attemptCount,
         beforeSha: githubPushObservations.beforeSha,
+        errorCode: githubPushObservations.errorCode,
         expectedCommitCount: githubPushObservations.expectedCommitCount,
         historySinceAt: sql<Date>`coalesce(${githubPushObservations.historySinceAt}, ${githubAccountCheckpoints.refBackfillSinceAt})`,
         historyUntilAt: githubPushObservations.historyUntilAt,
         id: githubPushObservations.id,
+        leaseUntil: githubPushObservations.leaseUntil,
         observedAt: githubPushObservations.observedAt,
         refName: githubPushObservations.refName,
         repository: githubPushObservations.repositoryNameSnapshot,
@@ -196,6 +484,8 @@ export const claimGitHubPushObservations = async (
         )
       )
       .orderBy(
+        sql`CASE WHEN ${githubPushObservations.state} = 'pending' THEN 0 ELSE 1 END`,
+        asc(githubPushObservations.leaseUntil),
         asc(githubPushObservations.observedAt),
         asc(githubPushObservations.id)
       )
@@ -210,6 +500,7 @@ export const claimGitHubPushObservations = async (
       const [updated] = await transaction
         .update(githubPushObservations)
         .set({
+          attemptCount: candidate.attemptCount + 1,
           errorCode: null,
           leaseToken,
           leaseUntil: new Date(now.getTime() + DEFAULT_LEASE_MS),
@@ -219,6 +510,7 @@ export const claimGitHubPushObservations = async (
           and(
             observationIdentity(candidate),
             eq(githubPushObservations.state, candidate.state),
+            eq(githubPushObservations.attemptCount, candidate.attemptCount),
             or(
               isNull(githubPushObservations.leaseUntil),
               lte(githubPushObservations.leaseUntil, now)
@@ -238,10 +530,24 @@ export const claimGitHubPushObservations = async (
         .where(eq(githubPushObservationCommits.observationId, candidate.id))
         .orderBy(asc(githubPushObservationCommits.position));
       claimed.push({
-        ...candidate,
         account: candidate.account,
+        afterSha: candidate.afterSha,
+        attemptCount: candidate.attemptCount + 1,
+        beforeSha: candidate.beforeSha,
+        expectedCommitCount: candidate.expectedCommitCount,
+        historySinceAt: candidate.historySinceAt,
+        historyUntilAt: candidate.historyUntilAt,
+        id: candidate.id,
         knownShas: known.map(({ sha }) => sha),
         leaseToken,
+        observedAt: candidate.observedAt,
+        priorAttemptCount: candidate.attemptCount,
+        priorErrorCode: candidate.errorCode,
+        priorRetryAt: candidate.leaseUntil,
+        priorState: candidate.state === "pending" ? "pending" : "deferred",
+        refName: candidate.refName,
+        repository: candidate.repository,
+        repositoryId: candidate.repositoryId,
       });
     }
     return claimed;
@@ -344,8 +650,29 @@ export const deferGitHubPushObservation = async (
     .set({
       errorCode,
       leaseToken: null,
-      leaseUntil: dueAt(now, retryAt),
+      leaseUntil: dueAt(observation.attemptCount, now, retryAt),
       state: "deferred",
+    })
+    .where(
+      and(
+        observationIdentity(observation),
+        eq(githubPushObservations.state, "processing"),
+        eq(githubPushObservations.leaseToken, observation.leaseToken)
+      )
+    );
+};
+
+export const releaseGitHubPushObservation = async (
+  observation: ClaimedGitHubPushObservation
+) => {
+  await getDatabase()
+    .update(githubPushObservations)
+    .set({
+      attemptCount: observation.priorAttemptCount,
+      errorCode: observation.priorErrorCode,
+      leaseToken: null,
+      leaseUntil: observation.priorRetryAt,
+      state: observation.priorState,
     })
     .where(
       and(
@@ -394,7 +721,10 @@ export const claimGitHubCommitsForEnrichment = async (
     const candidates = await transaction
       .select({
         author: githubCommits.author,
+        attemptCount: githubCommits.enrichmentAttempts,
         committedAt: githubCommits.committedAt,
+        errorCode: githubCommits.enrichmentError,
+        leaseUntil: githubCommits.enrichmentLeaseUntil,
         message: githubCommits.message,
         repository: githubCommits.repository,
         repositoryId: githubCommits.repositoryId,
@@ -432,6 +762,7 @@ export const claimGitHubCommitsForEnrichment = async (
       const [updated] = await transaction
         .update(githubCommits)
         .set({
+          enrichmentAttempts: candidate.attemptCount + 1,
           enrichmentError: null,
           enrichmentLeaseToken: leaseToken,
           enrichmentLeaseUntil: new Date(now.getTime() + DEFAULT_LEASE_MS),
@@ -451,9 +782,13 @@ export const claimGitHubCommitsForEnrichment = async (
       if (updated !== undefined) {
         claimed.push({
           author: account,
+          attemptCount: candidate.attemptCount + 1,
           committedAt: candidate.committedAt.toISOString(),
           leaseToken,
           message: candidate.message,
+          priorAttemptCount: candidate.attemptCount,
+          priorErrorCode: candidate.errorCode,
+          priorRetryAt: candidate.leaseUntil,
           repository: candidate.repository,
           repositoryId: candidate.repositoryId,
           sha: candidate.sha,
@@ -626,7 +961,28 @@ export const deferGitHubCommitEnrichment = async (
     .set({
       enrichmentError: errorCode,
       enrichmentLeaseToken: null,
-      enrichmentLeaseUntil: dueAt(now, retryAt),
+      enrichmentLeaseUntil: dueAt(commit.attemptCount, now, retryAt),
+      enrichmentState: "pending",
+    })
+    .where(
+      and(
+        commitIdentity(commit),
+        eq(githubCommits.enrichmentState, "processing"),
+        eq(githubCommits.enrichmentLeaseToken, commit.leaseToken)
+      )
+    );
+};
+
+export const releaseGitHubCommitEnrichment = async (
+  commit: ClaimedGitHubCommit
+) => {
+  await getDatabase()
+    .update(githubCommits)
+    .set({
+      enrichmentAttempts: commit.priorAttemptCount,
+      enrichmentError: commit.priorErrorCode,
+      enrichmentLeaseToken: null,
+      enrichmentLeaseUntil: commit.priorRetryAt,
       enrichmentState: "pending",
     })
     .where(
@@ -674,7 +1030,10 @@ export const claimGitHubCommitsForPullRequestDiscovery = async (
     const candidates = await transaction
       .select({
         author: githubCommits.author,
+        attemptCount: githubCommits.pullRequestDiscoveryAttempts,
         committedAt: githubCommits.committedAt,
+        errorCode: githubCommits.pullRequestDiscoveryError,
+        leaseUntil: githubCommits.pullRequestDiscoveryLeaseUntil,
         message: githubCommits.message,
         repository: githubCommits.repository,
         repositoryId: githubCommits.repositoryId,
@@ -713,6 +1072,7 @@ export const claimGitHubCommitsForPullRequestDiscovery = async (
       const [updated] = await transaction
         .update(githubCommits)
         .set({
+          pullRequestDiscoveryAttempts: candidate.attemptCount + 1,
           pullRequestDiscoveryError: null,
           pullRequestDiscoveryLeaseToken: leaseToken,
           pullRequestDiscoveryLeaseUntil: new Date(
@@ -734,9 +1094,13 @@ export const claimGitHubCommitsForPullRequestDiscovery = async (
       if (updated !== undefined) {
         claimed.push({
           author,
+          attemptCount: candidate.attemptCount + 1,
           committedAt: candidate.committedAt.toISOString(),
           leaseToken,
           message: candidate.message,
+          priorAttemptCount: candidate.attemptCount,
+          priorErrorCode: candidate.errorCode,
+          priorRetryAt: candidate.leaseUntil,
           repository: candidate.repository,
           repositoryId: candidate.repositoryId,
           sha: candidate.sha,
@@ -758,7 +1122,28 @@ export const deferGitHubPullRequestDiscovery = async (
     .set({
       pullRequestDiscoveryError: errorCode,
       pullRequestDiscoveryLeaseToken: null,
-      pullRequestDiscoveryLeaseUntil: dueAt(now, retryAt),
+      pullRequestDiscoveryLeaseUntil: dueAt(commit.attemptCount, now, retryAt),
+      pullRequestDiscoveryState: "pending",
+    })
+    .where(
+      and(
+        commitIdentity(commit),
+        eq(githubCommits.pullRequestDiscoveryState, "processing"),
+        eq(githubCommits.pullRequestDiscoveryLeaseToken, commit.leaseToken)
+      )
+    );
+};
+
+export const releaseGitHubPullRequestDiscovery = async (
+  commit: ClaimedGitHubPullRequestDiscovery
+) => {
+  await getDatabase()
+    .update(githubCommits)
+    .set({
+      pullRequestDiscoveryAttempts: commit.priorAttemptCount,
+      pullRequestDiscoveryError: commit.priorErrorCode,
+      pullRequestDiscoveryLeaseToken: null,
+      pullRequestDiscoveryLeaseUntil: commit.priorRetryAt,
       pullRequestDiscoveryState: "pending",
     })
     .where(
@@ -789,6 +1174,176 @@ export const markGitHubPullRequestDiscoveryUnavailable = async (
         eq(githubCommits.pullRequestDiscoveryLeaseToken, commit.leaseToken)
       )
     );
+};
+
+export const claimGitHubPullRequestSignals = async (
+  limit: number,
+  activeAccounts: readonly TrackedGitHubAccount[],
+  now = new Date()
+): Promise<readonly ClaimedGitHubPullRequestSignal[]> => {
+  if (!Number.isSafeInteger(limit) || limit < 1 || limit > 8) {
+    throw new RangeError("The GitHub PR signal claim limit is invalid.");
+  }
+  if (activeAccounts.length === 0) {
+    return [];
+  }
+  return await getDatabase().transaction(async (transaction) => {
+    const candidates = await transaction
+      .select({
+        account: githubPullRequestSignals.account,
+        action: githubPullRequestSignals.action,
+        attemptCount: githubPullRequestSignals.attemptCount,
+        errorCode: githubPullRequestSignals.errorCode,
+        id: githubPullRequestSignals.id,
+        leaseUntil: githubPullRequestSignals.leaseUntil,
+        number: githubPullRequestSignals.number,
+        repository: githubPullRequestSignals.repositoryNameSnapshot,
+        repositoryId: githubPullRequestSignals.repositoryId,
+        state: githubPullRequestSignals.state,
+      })
+      .from(githubPullRequestSignals)
+      .where(
+        and(
+          inArray(githubPullRequestSignals.account, [...activeAccounts]),
+          or(
+            and(
+              eq(githubPullRequestSignals.state, "pending"),
+              or(
+                isNull(githubPullRequestSignals.leaseUntil),
+                lte(githubPullRequestSignals.leaseUntil, now)
+              )
+            ),
+            and(
+              eq(githubPullRequestSignals.state, "processing"),
+              lte(githubPullRequestSignals.leaseUntil, now)
+            )
+          )
+        )
+      )
+      .orderBy(
+        sql`CASE WHEN ${githubPullRequestSignals.state} = 'pending' THEN 0 ELSE 1 END`,
+        asc(githubPullRequestSignals.leaseUntil),
+        asc(githubPullRequestSignals.observedAt),
+        asc(githubPullRequestSignals.id)
+      )
+      .limit(limit);
+    const claimed: ClaimedGitHubPullRequestSignal[] = [];
+    for (const candidate of candidates) {
+      const account = trackedGitHubAccountFrom(candidate.account);
+      if (account === null || !isActiveAccount(account, activeAccounts)) {
+        continue;
+      }
+      const leaseToken = randomUUID();
+      const [updated] = await transaction
+        .update(githubPullRequestSignals)
+        .set({
+          attemptCount: candidate.attemptCount + 1,
+          errorCode: null,
+          leaseToken,
+          leaseUntil: new Date(now.getTime() + DEFAULT_LEASE_MS),
+          state: "processing",
+        })
+        .where(
+          and(
+            eq(githubPullRequestSignals.id, candidate.id),
+            eq(githubPullRequestSignals.state, candidate.state),
+            or(
+              isNull(githubPullRequestSignals.leaseUntil),
+              lte(githubPullRequestSignals.leaseUntil, now)
+            )
+          )
+        )
+        .returning({ id: githubPullRequestSignals.id });
+      if (updated !== undefined) {
+        claimed.push({
+          account,
+          action: candidate.action,
+          attemptCount: candidate.attemptCount + 1,
+          id: candidate.id,
+          leaseToken,
+          number: candidate.number,
+          priorAttemptCount: candidate.attemptCount,
+          priorErrorCode: candidate.errorCode,
+          priorRetryAt: candidate.leaseUntil,
+          repository: candidate.repository,
+          repositoryId: candidate.repositoryId,
+        });
+      }
+    }
+    return claimed;
+  });
+};
+
+const pullRequestSignalLease = (signal: ClaimedGitHubPullRequestSignal) =>
+  and(
+    eq(githubPullRequestSignals.id, signal.id),
+    eq(githubPullRequestSignals.state, "processing"),
+    eq(githubPullRequestSignals.leaseToken, signal.leaseToken)
+  );
+
+export const completeGitHubPullRequestSignal = async (
+  signal: ClaimedGitHubPullRequestSignal,
+  now = new Date()
+) => {
+  await getDatabase()
+    .update(githubPullRequestSignals)
+    .set({
+      completedAt: now,
+      errorCode: null,
+      leaseToken: null,
+      leaseUntil: null,
+      state: "complete",
+    })
+    .where(pullRequestSignalLease(signal));
+};
+
+export const deferGitHubPullRequestSignal = async (
+  signal: ClaimedGitHubPullRequestSignal,
+  errorCode: string,
+  retryAt: Date | null,
+  now = new Date()
+) => {
+  await getDatabase()
+    .update(githubPullRequestSignals)
+    .set({
+      errorCode,
+      leaseToken: null,
+      leaseUntil: dueAt(signal.attemptCount, now, retryAt),
+      state: "pending",
+    })
+    .where(pullRequestSignalLease(signal));
+};
+
+export const releaseGitHubPullRequestSignal = async (
+  signal: ClaimedGitHubPullRequestSignal
+) => {
+  await getDatabase()
+    .update(githubPullRequestSignals)
+    .set({
+      attemptCount: signal.priorAttemptCount,
+      errorCode: signal.priorErrorCode,
+      leaseToken: null,
+      leaseUntil: signal.priorRetryAt,
+      state: "pending",
+    })
+    .where(pullRequestSignalLease(signal));
+};
+
+export const markGitHubPullRequestSignalUnavailable = async (
+  signal: ClaimedGitHubPullRequestSignal,
+  errorCode: string,
+  now = new Date()
+) => {
+  await getDatabase()
+    .update(githubPullRequestSignals)
+    .set({
+      completedAt: now,
+      errorCode,
+      leaseToken: null,
+      leaseUntil: null,
+      state: "unavailable",
+    })
+    .where(pullRequestSignalLease(signal));
 };
 
 const pullRequestState = (pullRequest: GitHubPullRequest) =>
@@ -842,6 +1397,7 @@ const persistPullRequestSnapshotInTransaction = async (
   pullRequest: GitHubPullRequest,
   refreshMembership: boolean,
   authoritative: boolean,
+  reconciliationLeaseUntil: Date | null,
   now: Date
 ): Promise<StoredPullRequestSnapshot | null> => {
   const [existing] = await transaction
@@ -853,9 +1409,13 @@ const persistPullRequestSnapshotInTransaction = async (
       headRepositoryId: githubPullRequests.headRepositoryId,
       headSha: githubPullRequests.headSha,
       lastReconciledAt: githubPullRequests.lastReconciledAt,
+      mergeSha: githubPullRequests.mergeSha,
+      mergeShaVerifiedAt: githubPullRequests.mergeShaVerifiedAt,
       nextReconcileAt: githubPullRequests.nextReconcileAt,
       nodeId: githubPullRequests.nodeId,
       providerUpdatedAt: githubPullRequests.providerUpdatedAt,
+      repositoryId: githubPullRequests.repositoryId,
+      state: githubPullRequests.state,
     })
     .from(githubPullRequests)
     .where(eq(githubPullRequests.nodeId, pullRequest.nodeId))
@@ -885,6 +1445,61 @@ const persistPullRequestSnapshotInTransaction = async (
     );
   }
   const state = pullRequestState(pullRequest);
+  const mergeShaResolved =
+    state === "merged" && pullRequest.mergeCommitSha !== undefined;
+  const resolvedMergeSha = mergeShaResolved
+    ? (pullRequest.mergeCommitSha ?? null)
+    : null;
+  const existingMergeShaResolved =
+    existing?.mergeShaVerifiedAt !== null &&
+    existing?.mergeShaVerifiedAt !== undefined;
+  const mergeSha =
+    state === "merged"
+      ? mergeShaResolved
+        ? resolvedMergeSha
+        : existingMergeShaResolved
+          ? (existing?.mergeSha ?? null)
+          : null
+      : null;
+  const mergeShaVerifiedAt =
+    state === "merged"
+      ? mergeShaResolved
+        ? now
+        : (existing?.mergeShaVerifiedAt ?? null)
+      : null;
+  const canonicalEvidenceChanged =
+    existing !== undefined &&
+    (existing.headSha !== pullRequest.headSha ||
+      (pullRequest.headRepository !== null &&
+        existing.headRepositoryId !== pullRequest.headRepository.id) ||
+      existing.repositoryId !== pullRequest.repository.id ||
+      existing.mergeSha !== mergeSha ||
+      (existing.mergeShaVerifiedAt === null) !==
+        (mergeShaVerifiedAt === null) ||
+      existing.state !== state);
+  const retryLifecycleReset =
+    existing !== undefined &&
+    (disposition === "newer" || canonicalEvidenceChanged);
+  const retryLifecycleUpdate = retryLifecycleReset
+    ? {
+        nextReconcileAt: reconciliationLeaseUntil ?? now,
+        reconcileAttempts: 0,
+        reconcileError: null,
+      }
+    : {};
+  if (canonicalEvidenceChanged) {
+    await invalidateGitHubPullRequestDerivedAliases(
+      transaction,
+      pullRequest.nodeId,
+      [
+        existing.repositoryId,
+        existing.headRepositoryId,
+        pullRequest.repository.id,
+        pullRequest.baseRepository.id,
+        pullRequest.headRepository?.id,
+      ]
+    );
+  }
   const mutable = {
     additions: pullRequest.additions,
     baseRefName: pullRequest.baseRef,
@@ -902,7 +1517,8 @@ const persistPullRequestSnapshotInTransaction = async (
     headSha: pullRequest.headSha,
     mergedAt:
       pullRequest.mergedAt === null ? null : new Date(pullRequest.mergedAt),
-    mergeSha: pullRequest.mergeCommitSha,
+    mergeSha,
+    mergeShaVerifiedAt,
     providerFileCapReached: false,
     providerUpdatedAt,
     state,
@@ -937,7 +1553,7 @@ const persistPullRequestSnapshotInTransaction = async (
   } else if (disposition === "newer") {
     await transaction
       .update(githubPullRequests)
-      .set(mutableUpdate)
+      .set({ ...mutableUpdate, ...retryLifecycleUpdate })
       .where(
         and(
           eq(githubPullRequests.nodeId, pullRequest.nodeId),
@@ -949,7 +1565,7 @@ const persistPullRequestSnapshotInTransaction = async (
       .update(githubPullRequests)
       .set(
         authoritative
-          ? mutableUpdate
+          ? { ...mutableUpdate, ...retryLifecycleUpdate }
           : {
               additions: pullRequest.additions ?? existing.additions,
               changedFiles: pullRequest.changedFiles ?? existing.changedFiles,
@@ -957,6 +1573,7 @@ const persistPullRequestSnapshotInTransaction = async (
               deletions: pullRequest.deletions ?? existing.deletions,
               headRepositoryId:
                 pullRequest.headRepository?.id ?? existing.headRepositoryId,
+              ...retryLifecycleUpdate,
             }
       )
       .where(
@@ -1088,24 +1705,26 @@ const persistPullRequestSnapshotInTransaction = async (
         )
       );
   }
-  if (pullRequest.mergeCommitSha !== null) {
+  if (typeof resolvedMergeSha === "string") {
     await transaction
       .update(githubCommits)
       .set({ canonicalizedAt: null })
       .where(
         and(
           eq(githubCommits.repositoryId, pullRequest.repository.id),
-          eq(githubCommits.sha, pullRequest.mergeCommitSha)
+          eq(githubCommits.sha, resolvedMergeSha)
         )
       );
   }
   return {
+    baseRepositoryId: pullRequest.repository.id,
     commitRepositoryId:
       pullRequest.headRepository?.id ??
       existing?.headRepositoryId ??
       pullRequest.repository.id,
     membershipRefreshRequired,
     pullRequestNodeId: pullRequest.nodeId,
+    retryLifecycleReset,
     versionId,
   };
 };
@@ -1113,7 +1732,10 @@ const persistPullRequestSnapshotInTransaction = async (
 export const persistGitHubPullRequestSnapshot = async (
   account: TrackedGitHubAccount,
   pullRequest: GitHubPullRequest,
-  options: { refreshMembership?: boolean } = {},
+  options: {
+    reconciliationLeaseUntil?: Date;
+    refreshMembership?: boolean;
+  } = {},
   now = new Date()
 ) =>
   await getDatabase().transaction(
@@ -1124,6 +1746,7 @@ export const persistGitHubPullRequestSnapshot = async (
         pullRequest,
         options.refreshMembership === true,
         true,
+        options.reconciliationLeaseUntil ?? null,
         now
       )
   );
@@ -1155,6 +1778,7 @@ export const completeGitHubPullRequestDiscovery = async (
         pullRequest,
         true,
         false,
+        null,
         now
       );
     }
@@ -1180,10 +1804,10 @@ export const completeGitHubPullRequestDiscovery = async (
 export const claimDueGitHubPullRequests = async (
   account: TrackedGitHubAccount,
   maximumAgeDays: number,
-  limit = 25,
+  limit = 4,
   now = new Date()
 ): Promise<readonly DueGitHubPullRequest[]> => {
-  if (!Number.isSafeInteger(limit) || limit < 1 || limit > 25) {
+  if (!Number.isSafeInteger(limit) || limit < 1 || limit > 8) {
     throw new RangeError("The GitHub pull request claim limit is invalid.");
   }
   const reconciliationCutoff = githubPrReconciliationCutoff(
@@ -1198,9 +1822,12 @@ export const claimDueGitHubPullRequests = async (
     const candidates = await transaction
       .select({
         account: githubPullRequests.account,
+        attemptCount: githubPullRequests.reconcileAttempts,
+        createdAt: githubPullRequests.createdAt,
         lastReconciledAt: githubPullRequests.lastReconciledAt,
         membershipComplete: githubPullRequestVersions.membershipComplete,
         nextReconcileAt: githubPullRequests.nextReconcileAt,
+        reconcileError: githubPullRequests.reconcileError,
         nodeId: githubPullRequests.nodeId,
         number: githubPullRequests.number,
         repository: githubRepositories.fullName,
@@ -1248,10 +1875,15 @@ export const claimDueGitHubPullRequests = async (
       const leaseUntil = new Date(now.getTime() + DEFAULT_LEASE_MS);
       const [updated] = await transaction
         .update(githubPullRequests)
-        .set({ nextReconcileAt: leaseUntil })
+        .set({
+          nextReconcileAt: leaseUntil,
+          reconcileAttempts: candidate.attemptCount + 1,
+          reconcileError: null,
+        })
         .where(
           and(
             eq(githubPullRequests.nodeId, candidate.nodeId),
+            eq(githubPullRequests.reconcileAttempts, candidate.attemptCount),
             eq(githubPullRequests.nextReconcileAt, candidate.nextReconcileAt)
           )
         )
@@ -1259,11 +1891,16 @@ export const claimDueGitHubPullRequests = async (
       if (updated !== undefined) {
         claimed.push({
           account: candidate.account as TrackedGitHubAccount,
+          attemptCount: candidate.attemptCount + 1,
+          createdAt: candidate.createdAt,
           lastReconciledAt: candidate.lastReconciledAt,
           leaseUntil,
           membershipComplete: candidate.membershipComplete ?? false,
           nodeId: candidate.nodeId,
           number: candidate.number,
+          priorAttemptCount: candidate.attemptCount,
+          priorErrorCode: candidate.reconcileError,
+          priorRetryAt: candidate.nextReconcileAt,
           repository: candidate.repository,
           repositoryId: candidate.repositoryId,
           versionObservedAt: candidate.versionObservedAt,
@@ -1296,6 +1933,11 @@ export const persistGitHubPullRequestMembership = async (
         .where(eq(githubPullRequestVersions.id, stored.versionId));
       return false;
     }
+    await invalidateGitHubPullRequestDerivedAliases(
+      transaction,
+      stored.pullRequestNodeId,
+      [stored.baseRepositoryId, stored.commitRepositoryId]
+    );
     await transaction
       .delete(githubPullRequestMemberships)
       .where(eq(githubPullRequestMemberships.versionId, stored.versionId));
@@ -1339,7 +1981,13 @@ export const completeGitHubPullRequestReconciliation = async (
       .update(githubPullRequests)
       .set({
         lastReconciledAt: now,
-        nextReconcileAt: nextGitHubPullRequestReconciliationAt(state, now),
+        nextReconcileAt: nextGitHubPullRequestReconciliationAt(
+          state,
+          now,
+          due.createdAt
+        ),
+        reconcileAttempts: 0,
+        reconcileError: null,
       })
       .where(
         and(
@@ -1379,12 +2027,34 @@ export const completeGitHubPullRequestReconciliation = async (
 
 export const deferGitHubPullRequestReconciliation = async (
   due: DueGitHubPullRequest,
+  errorCode: string,
   retryAt: Date | null,
   now = new Date()
 ) => {
   await getDatabase()
     .update(githubPullRequests)
-    .set({ nextReconcileAt: dueAt(now, retryAt) })
+    .set({
+      nextReconcileAt: dueAt(due.attemptCount, now, retryAt),
+      reconcileError: errorCode,
+    })
+    .where(
+      and(
+        eq(githubPullRequests.nodeId, due.nodeId),
+        eq(githubPullRequests.nextReconcileAt, due.leaseUntil)
+      )
+    );
+};
+
+export const releaseGitHubPullRequestReconciliation = async (
+  due: DueGitHubPullRequest
+) => {
+  await getDatabase()
+    .update(githubPullRequests)
+    .set({
+      nextReconcileAt: due.priorRetryAt,
+      reconcileAttempts: due.priorAttemptCount,
+      reconcileError: due.priorErrorCode,
+    })
     .where(
       and(
         eq(githubPullRequests.nodeId, due.nodeId),
@@ -1395,11 +2065,16 @@ export const deferGitHubPullRequestReconciliation = async (
 
 export const stopGitHubPullRequestReconciliation = async (
   due: DueGitHubPullRequest,
+  errorCode: string,
   now = new Date()
 ) => {
   await getDatabase()
     .update(githubPullRequests)
-    .set({ lastReconciledAt: now, nextReconcileAt: null })
+    .set({
+      lastReconciledAt: now,
+      nextReconcileAt: null,
+      reconcileError: errorCode,
+    })
     .where(
       and(
         eq(githubPullRequests.nodeId, due.nodeId),
@@ -1614,195 +2289,6 @@ const markGitHubCommitCanonicalized = async (
   await publishCompletedSummaryForCommit(transaction, repositoryId, sha, now);
 };
 
-const comparableCommitHeadline = (message: string | null) => {
-  const headline = message?.split("\n", 1)[0]?.trim();
-  if (headline === undefined || headline.length === 0) {
-    return null;
-  }
-  return headline.replace(/\s+\(#[1-9]\d*\)$/u, "");
-};
-
-interface AuthoredRewriteCandidate {
-  authoredAt: Date | null;
-  authorUserId: string | null;
-  committedAt: Date;
-  committerAt: Date | null;
-  firstObservedAt: Date;
-  fullMessage: string | null;
-  parentShas: readonly string[] | null;
-  publicId: string;
-  sha: string;
-}
-
-const authoredRewriteOrder = (commit: AuthoredRewriteCandidate) =>
-  (commit.committerAt ?? commit.committedAt).getTime();
-
-const compareAuthoredRewriteCandidates = (
-  left: AuthoredRewriteCandidate,
-  right: AuthoredRewriteCandidate
-) => {
-  const byCommitter = authoredRewriteOrder(left) - authoredRewriteOrder(right);
-  if (byCommitter !== 0) {
-    return byCommitter;
-  }
-  const byObservation =
-    left.firstObservedAt.getTime() - right.firstObservedAt.getTime();
-  if (byObservation !== 0) {
-    return byObservation;
-  }
-  if (left.sha === right.sha) {
-    return 0;
-  }
-  return left.sha < right.sha ? -1 : 1;
-};
-
-const canonicalizeAuthoredRewriteLineage = async (
-  transaction: DatabaseTransaction,
-  repositoryId: string,
-  candidate: AuthoredRewriteCandidate,
-  now: Date,
-  allowedMemberMergeSha: string | null = null
-) => {
-  if (
-    candidate.authorUserId === null ||
-    candidate.authoredAt === null ||
-    candidate.fullMessage === null ||
-    candidate.parentShas === null ||
-    candidate.parentShas.length > 1
-  ) {
-    return { aliases: 0, candidateAliased: false };
-  }
-  const lineage = await transaction
-    .select({
-      authoredAt: githubCommits.authoredAt,
-      authorUserId: githubCommits.authorUserId,
-      committedAt: githubCommits.committedAt,
-      committerAt: githubCommits.committerAt,
-      firstObservedAt: githubCommits.firstObservedAt,
-      fullMessage: githubCommits.fullMessage,
-      parentShas: githubCommits.parentShas,
-      publicId: githubPublicActivities.publicId,
-      sha: githubCommits.sha,
-    })
-    .from(githubCommits)
-    .innerJoin(githubPublicActivities, commitActivityIdentity)
-    .where(
-      and(
-        eq(githubCommits.repositoryId, repositoryId),
-        eq(githubCommits.authorUserId, candidate.authorUserId),
-        eq(githubCommits.authoredAt, candidate.authoredAt),
-        eq(githubCommits.fullMessage, candidate.fullMessage),
-        eq(githubCommits.enrichmentState, "complete"),
-        inArray(githubCommits.pullRequestDiscoveryState, [
-          "complete",
-          "unavailable",
-        ]),
-        isNonMergeCommit,
-        isNull(githubPublicActivities.canonicalPublicId),
-        isNull(githubPublicActivities.hiddenAt),
-        or(
-          allowedMemberMergeSha === null
-            ? undefined
-            : eq(githubCommits.sha, allowedMemberMergeSha),
-          sql<boolean>`NOT EXISTS (
-            SELECT 1
-            FROM ${githubPullRequests} AS rewrite_merge_pr
-            WHERE rewrite_merge_pr.repository_id = ${githubCommits.repositoryId}
-              AND rewrite_merge_pr.merge_sha = ${githubCommits.sha}
-              AND rewrite_merge_pr.state = 'merged'
-          )`
-        )
-      )
-    )
-    .orderBy(asc(githubCommits.sha))
-    .for("update");
-  if (lineage.length < 2) {
-    return { aliases: 0, candidateAliased: false };
-  }
-
-  const winner = lineage.toSorted(compareAuthoredRewriteCandidates).at(-1);
-  if (winner === undefined) {
-    throw new Error("The authored rewrite lineage has no canonical commit.");
-  }
-  const losers = lineage.filter(({ publicId }) => publicId !== winner.publicId);
-  const loserPublicIds = losers.map(({ publicId }) => publicId);
-
-  await transaction.execute(sql`
-    WITH RECURSIVE rewrite_alias_descendants AS (
-      SELECT alias_activity.public_id
-      FROM ${githubPublicActivities} AS alias_activity
-      WHERE alias_activity.canonical_public_id IN (
-        ${sql.join(
-          loserPublicIds.map((publicId) => sql`${publicId}`),
-          sql`, `
-        )}
-      )
-      UNION
-      SELECT child_activity.public_id
-      FROM ${githubPublicActivities} AS child_activity
-      INNER JOIN rewrite_alias_descendants AS parent_activity
-        ON child_activity.canonical_public_id = parent_activity.public_id
-    )
-    UPDATE ${githubPublicActivities} AS rewrite_alias
-    SET
-      alias_evidence = COALESCE(rewrite_alias.alias_evidence, '{}'::jsonb)
-        || jsonb_build_object(
-          'canonicalRetargetReason', 'same_authored_rewrite',
-          'canonicalRetargetedFrom', rewrite_alias.canonical_public_id
-        ),
-      canonical_public_id = ${winner.publicId}
-    WHERE rewrite_alias.public_id IN (
-      SELECT public_id FROM rewrite_alias_descendants
-    )
-      AND rewrite_alias.public_id <> ${winner.publicId}
-  `);
-
-  let aliases = 0;
-  for (const loser of losers) {
-    if (
-      await setCanonicalAlias(
-        transaction,
-        loser.publicId,
-        winner.publicId,
-        "same_authored_rewrite",
-        {
-          authoredAt: candidate.authoredAt.toISOString(),
-          authorUserId: candidate.authorUserId,
-          canonicalCommitterAt: (
-            winner.committerAt ?? winner.committedAt
-          ).toISOString(),
-          sourceSha: winner.sha,
-        },
-        now
-      )
-    ) {
-      aliases += 1;
-    }
-  }
-  await transaction
-    .update(githubCommits)
-    .set({ canonicalizedAt: now })
-    .where(
-      and(
-        eq(githubCommits.repositoryId, repositoryId),
-        inArray(
-          githubCommits.activityPublicId,
-          lineage.map(({ publicId }) => publicId)
-        )
-      )
-    );
-  await publishCompletedSummaryForCommit(
-    transaction,
-    repositoryId,
-    winner.sha,
-    now
-  );
-  return {
-    aliases,
-    candidateAliased: candidate.publicId !== winner.publicId,
-  };
-};
-
 export const canonicalizeGitHubCommitActivity = async (
   repositoryId: string,
   sha: string,
@@ -1815,10 +2301,7 @@ export const canonicalizeGitHubCommitActivity = async (
     );
     const [candidate] = await transaction
       .select({
-        authoredAt: githubCommits.authoredAt,
-        authorUserId: githubCommits.authorUserId,
         changeFingerprint: githubCommits.changeFingerprint,
-        committedAt: githubCommits.committedAt,
         committerAt: githubCommits.committerAt,
         fingerprintComplete: githubCommits.fingerprintComplete,
         firstObservedAt: githubCommits.firstObservedAt,
@@ -1853,6 +2336,7 @@ export const canonicalizeGitHubCommitActivity = async (
         and(
           eq(githubPullRequests.repositoryId, repositoryId),
           eq(githubPullRequests.mergeSha, sha),
+          isNotNull(githubPullRequests.mergeShaVerifiedAt),
           eq(githubPullRequests.state, "merged")
         )
       )
@@ -1867,20 +2351,6 @@ export const canonicalizeGitHubCommitActivity = async (
         sha
       );
       if (mergeEvidence.integrationIsMember) {
-        const rewrite = await canonicalizeAuthoredRewriteLineage(
-          transaction,
-          repositoryId,
-          { ...candidate, sha },
-          now,
-          sha
-        );
-        if (rewrite.aliases > 0) {
-          return {
-            aliased: rewrite.candidateAliased,
-            aliases: rewrite.aliases,
-            publicId: candidate.publicId,
-          };
-        }
         await markGitHubCommitCanonicalized(
           transaction,
           repositoryId,
@@ -1920,20 +2390,6 @@ export const canonicalizeGitHubCommitActivity = async (
       }
     }
 
-    const rewrite = await canonicalizeAuthoredRewriteLineage(
-      transaction,
-      repositoryId,
-      { ...candidate, sha },
-      now
-    );
-    if (rewrite.aliases > 0) {
-      return {
-        aliased: rewrite.candidateAliased,
-        aliases: rewrite.aliases,
-        publicId: candidate.publicId,
-      };
-    }
-
     if (
       !candidate.fingerprintComplete ||
       candidate.changeFingerprint === null
@@ -1943,13 +2399,9 @@ export const canonicalizeGitHubCommitActivity = async (
     }
     const copies = await transaction
       .select({
-        authoredAt: githubCommits.authoredAt,
-        authorUserId: githubCommits.authorUserId,
         canonicalPublicId: githubPublicActivities.canonicalPublicId,
         committerAt: githubCommits.committerAt,
         firstObservedAt: githubCommits.firstObservedAt,
-        fullMessage: githubCommits.fullMessage,
-        parentShas: githubCommits.parentShas,
         publicId: githubPublicActivities.publicId,
         sha: githubCommits.sha,
       })
@@ -1986,9 +2438,10 @@ export const canonicalizeGitHubCommitActivity = async (
         )
       )
       .orderBy(asc(githubCommits.firstObservedAt), asc(githubCommits.sha));
-    const cherryPickSource = /cherry picked from commit ([a-f0-9]{40})/iu.exec(
-      candidate.fullMessage ?? ""
-    )?.[1];
+    const cherryPickSource =
+      /^\(cherry picked from commit ([a-f0-9]{40})\)\r?$/imu.exec(
+        candidate.fullMessage ?? ""
+      )?.[1];
     const candidatePullRequests = await pullRequestMembershipsForCommit(
       transaction,
       repositoryId,
@@ -2006,24 +2459,6 @@ export const canonicalizeGitHubCommitActivity = async (
       const directMergeParent =
         (candidate.parentShas?.length ?? 0) > 1 &&
         candidate.parentShas?.includes(copy.sha) === true;
-      const sameAuthorSingleParent =
-        candidate.parentShas?.length === 1 &&
-        copy.parentShas?.length === 1 &&
-        candidate.authorUserId !== null &&
-        candidate.authorUserId === copy.authorUserId;
-      const sameAuthoredCommit =
-        sameAuthorSingleParent &&
-        candidate.authoredAt !== null &&
-        copy.authoredAt !== null &&
-        candidate.authoredAt.getTime() === copy.authoredAt.getTime() &&
-        candidate.fullMessage !== null &&
-        candidate.fullMessage === copy.fullMessage;
-      const candidateHeadline = comparableCommitHeadline(candidate.fullMessage);
-      const copyHeadline = comparableCommitHeadline(copy.fullMessage);
-      const sameHeadlineCommit =
-        sameAuthorSingleParent &&
-        candidateHeadline !== null &&
-        candidateHeadline === copyHeadline;
       const candidateOrder =
         candidate.committerAt?.getTime() ?? candidate.firstObservedAt.getTime();
       const copyOrder =
@@ -2059,8 +2494,6 @@ export const canonicalizeGitHubCommitActivity = async (
       if (
         !explicitCherryPick &&
         !directMergeParent &&
-        !sameAuthoredCommit &&
-        !sameHeadlineCommit &&
         sharedPullRequest === undefined
       ) {
         continue;
@@ -2069,11 +2502,7 @@ export const canonicalizeGitHubCommitActivity = async (
         ? "direct_parent_merge"
         : explicitCherryPick
           ? "cherry_pick"
-          : sameAuthoredCommit
-            ? "same_authored_exact_copy"
-            : sameHeadlineCommit
-              ? "same_author_headline_exact_copy"
-              : "pr_history_exact_copy";
+          : "pr_history_exact_copy";
       const aliased = await setCanonicalAlias(
         transaction,
         candidate.publicId,
@@ -2082,14 +2511,7 @@ export const canonicalizeGitHubCommitActivity = async (
         {
           fingerprint: candidate.changeFingerprint,
           fingerprintComplete: true,
-          authoredAt: sameAuthoredCommit
-            ? candidate.authoredAt?.toISOString()
-            : null,
           directMergeParent,
-          headline:
-            !sameAuthoredCommit && sameHeadlineCommit
-              ? candidateHeadline
-              : null,
           pullRequestNodeId: sharedPullRequest ?? null,
           sourceSha: copy.sha,
         },
@@ -2240,11 +2662,10 @@ export const claimGitHubSummaryAttempts = async (
     await transaction
       .update(githubSummaryAttempts)
       .set({
-        completedAt: now,
         errorCode: "lease_expired",
         leaseToken: null,
         leaseUntil: null,
-        state: "indeterminate",
+        state: "pending",
       })
       .where(
         and(
@@ -2255,8 +2676,12 @@ export const claimGitHubSummaryAttempts = async (
     const candidates = await transaction
       .select({
         activityPublicId: githubSummaryAttempts.activityPublicId,
+        attemptCount: githubSummaryAttempts.attemptCount,
+        attemptedAt: githubSummaryAttempts.attemptedAt,
         author: githubCommits.author,
         committedAt: githubCommits.committedAt,
+        errorCode: githubSummaryAttempts.errorCode,
+        leaseUntil: githubSummaryAttempts.leaseUntil,
         message: githubCommits.message,
         repository: githubCommits.repository,
         repositoryId: githubCommits.repositoryId,
@@ -2278,6 +2703,10 @@ export const claimGitHubSummaryAttempts = async (
       .where(
         and(
           eq(githubSummaryAttempts.state, "pending"),
+          or(
+            isNull(githubSummaryAttempts.leaseUntil),
+            lte(githubSummaryAttempts.leaseUntil, now)
+          ),
           eq(githubPublicActivities.kind, "commit"),
           isNull(githubPublicActivities.canonicalPublicId),
           isNull(githubPublicActivities.hiddenAt),
@@ -2302,6 +2731,7 @@ export const claimGitHubSummaryAttempts = async (
       const [updated] = await transaction
         .update(githubSummaryAttempts)
         .set({
+          attemptCount: candidate.attemptCount + 1,
           attemptedAt: now,
           errorCode: null,
           leaseToken,
@@ -2324,10 +2754,15 @@ export const claimGitHubSummaryAttempts = async (
       if (updated !== undefined) {
         claimed.push({
           activityPublicId: candidate.activityPublicId,
+          attemptCount: candidate.attemptCount + 1,
           author,
           committedAt: candidate.committedAt.toISOString(),
           leaseToken,
           message: candidate.message,
+          priorAttemptCount: candidate.attemptCount,
+          priorAttemptedAt: candidate.attemptedAt,
+          priorErrorCode: candidate.errorCode,
+          priorRetryAt: candidate.leaseUntil,
           repository: candidate.repository,
           repositoryId: candidate.repositoryId,
           revision: candidate.revision,
@@ -2421,19 +2856,19 @@ export const completeGitHubSummaryAttempt = async (
     return true;
   });
 
-export const failGitHubSummaryAttempt = async (
+export const deferGitHubSummaryAttempt = async (
   attempt: ClaimedGitHubSummary,
   errorCode: string,
+  retryAt: Date | null,
   now = new Date()
 ) => {
   await getDatabase()
     .update(githubSummaryAttempts)
     .set({
-      completedAt: now,
       errorCode,
       leaseToken: null,
-      leaseUntil: null,
-      state: "failed",
+      leaseUntil: dueAt(attempt.attemptCount, now, retryAt),
+      state: "pending",
     })
     .where(
       and(
@@ -2451,10 +2886,11 @@ export const releaseGitHubSummaryAttempt = async (
   await getDatabase()
     .update(githubSummaryAttempts)
     .set({
-      attemptedAt: null,
-      errorCode: null,
+      attemptCount: attempt.priorAttemptCount,
+      attemptedAt: attempt.priorAttemptedAt,
+      errorCode: attempt.priorErrorCode,
       leaseToken: null,
-      leaseUntil: null,
+      leaseUntil: attempt.priorRetryAt,
       state: "pending",
     })
     .where(

--- a/src/lib/github-activity-worker.ts
+++ b/src/lib/github-activity-worker.ts
@@ -1,4 +1,3 @@
-import { env } from "@/env";
 import {
   ActivityProcessingError,
   fetchGitHubActivityCommitSource,
@@ -7,9 +6,8 @@ import {
   fetchGitHubPullRequestSnapshot,
   fetchGitHubPushObservationSource,
   generateValidatedGitHubActivitySummary,
-  GITHUB_ACTIVITY_SUMMARY_MODEL,
+  GitHubGraphQlResponseError,
 } from "@/lib/github-activity-processor";
-import { PUBLIC_COMMIT_SUMMARY_RECIPE } from "@/lib/github-activity-public-summary";
 import {
   boundedWorkerLimit,
   exactGitHubDiffDigest,
@@ -21,29 +19,41 @@ import {
   claimDueGitHubPullRequests,
   claimGitHubCommitsForEnrichment,
   claimGitHubCommitsForPullRequestDiscovery,
+  claimGitHubPullRequestSignals,
   claimGitHubPushObservations,
   claimGitHubSummaryAttempts,
   completeGitHubCommitEnrichment,
   completeGitHubPullRequestDiscovery,
   completeGitHubPullRequestReconciliation,
+  completeGitHubPullRequestSignal,
   completeGitHubPushObservation,
   completeGitHubSummaryAttempt,
   deferGitHubCommitEnrichment,
   deferGitHubPullRequestDiscovery,
   deferGitHubPullRequestReconciliation,
+  deferGitHubPullRequestSignal,
   deferGitHubPushObservation,
   ensureMissingGitHubSummaryAttempts,
-  failGitHubSummaryAttempt,
+  deferGitHubSummaryAttempt,
   markGitHubCommitUnavailable,
   markGitHubPullRequestDiscoveryUnavailable,
+  markGitHubPullRequestSignalUnavailable,
   markGitHubPushObservationUnavailable,
   persistGitHubPullRequestMembership,
   persistGitHubPullRequestSnapshot,
+  releaseGitHubCommitEnrichment,
+  releaseGitHubPullRequestDiscovery,
+  releaseGitHubPullRequestReconciliation,
+  releaseGitHubPullRequestSignal,
+  releaseGitHubPushObservation,
   releaseGitHubSummaryAttempt,
   stopGitHubPullRequestReconciliation,
 } from "@/lib/github-activity-worker-store";
 import type { DueGitHubPullRequest } from "@/lib/github-activity-worker-store";
-import { GitHubResponseError } from "@/lib/github-api";
+import {
+  GitHubRequestDeadlineError,
+  GitHubResponseError,
+} from "@/lib/github-api";
 import { TRACKED_GITHUB_ACCOUNTS } from "@/lib/github-commits-core";
 import type { TrackedGitHubAccount } from "@/lib/github-commits-core";
 import {
@@ -52,7 +62,10 @@ import {
 } from "@/lib/github-commits-store";
 
 const DEFAULT_WORKER_MAXIMUM_DURATION_MS = 90_000;
-const PERMANENT_GITHUB_STATUSES = new Set([404, 410, 422]);
+// A 404 is visibility-dependent on GitHub and must remain recoverable after a
+// token or repository-permission change.
+const PERMANENT_GITHUB_STATUSES = new Set([410, 422]);
+const MINIMUM_TERMINAL_GITHUB_ATTEMPTS = 8;
 
 interface StageResult {
   claimed: number;
@@ -77,6 +90,7 @@ export interface GitHubActivityWorkerResult {
   observations: StageResult;
   pullRequests: StageResult;
   pullRequestDiscovery: StageResult;
+  pullRequestSignals: StageResult;
   summaries: StageResult;
 }
 
@@ -85,10 +99,15 @@ export interface GitHubActivityWorkerOptions {
   maximumDurationMs?: number;
   observationLimit?: number;
   pullRequestDiscoveryLimit?: number;
+  pullRequestLimit?: number;
+  pullRequestSignalLimit?: number;
   summaryLimit?: number;
 }
 
 const errorCode = (error: unknown) => {
+  if (error instanceof GitHubRequestDeadlineError) {
+    return "worker_deadline";
+  }
   if (error instanceof ActivityProcessingError) {
     return error.code;
   }
@@ -99,13 +118,18 @@ const errorCode = (error: unknown) => {
 };
 
 const retryAtFrom = (error: unknown) =>
-  error instanceof GitHubResponseError ? error.retryAt : null;
+  error instanceof GitHubResponseError ||
+  error instanceof GitHubGraphQlResponseError
+    ? error.retryAt
+    : null;
 
-const permanentlyUnavailable = (error: unknown) =>
-  (error instanceof GitHubResponseError &&
-    PERMANENT_GITHUB_STATUSES.has(error.status)) ||
+const permanentlyUnavailable = (error: unknown, attemptCount: number) =>
   (error instanceof ActivityProcessingError &&
-    ["provenance_changed", "source_invalid"].includes(error.code));
+    error.code === "provenance_changed") ||
+  (error instanceof GitHubResponseError &&
+    !error.retryable &&
+    PERMANENT_GITHUB_STATUSES.has(error.status) &&
+    attemptCount >= MINIMUM_TERMINAL_GITHUB_ATTEMPTS);
 
 const activeTrackedAccounts = async () => {
   const accounts: TrackedGitHubAccount[] = [];
@@ -127,6 +151,7 @@ type CommitSource = Awaited<ReturnType<typeof fetchGitHubActivityCommitSource>>;
 
 interface WorkerContext {
   activeAccounts: readonly TrackedGitHubAccount[];
+  deadlineAt: number;
   deadlineReached: () => boolean;
   sourceCache: Map<string, CommitSource>;
 }
@@ -146,21 +171,22 @@ const processObservations = async (
   result.claimed = claimed.length;
   for (const observation of claimed) {
     if (context.deadlineReached()) {
-      await deferGitHubPushObservation(
-        observation,
-        "worker_deadline",
-        new Date()
-      );
+      await releaseGitHubPushObservation(observation);
       result.deferred += 1;
       continue;
     }
     try {
-      const source = await fetchGitHubPushObservationSource(observation);
+      const source = await fetchGitHubPushObservationSource(observation, {
+        deadlineAt: context.deadlineAt,
+      });
       await completeGitHubPushObservation(observation, source);
       result.completed += 1;
     } catch (error) {
       const code = errorCode(error);
-      if (permanentlyUnavailable(error)) {
+      if (error instanceof GitHubRequestDeadlineError) {
+        await releaseGitHubPushObservation(observation);
+        result.deferred += 1;
+      } else if (permanentlyUnavailable(error, observation.attemptCount)) {
         await markGitHubPushObservationUnavailable(observation, code);
         result.unavailable += 1;
       } else {
@@ -187,12 +213,14 @@ const processCommits = async (
   result.claimed = claimed.length;
   for (const commit of claimed) {
     if (context.deadlineReached()) {
-      await deferGitHubCommitEnrichment(commit, "worker_deadline", new Date());
+      await releaseGitHubCommitEnrichment(commit);
       result.deferred += 1;
       continue;
     }
     try {
-      const source = await fetchGitHubActivityCommitSource(commit);
+      const source = await fetchGitHubActivityCommitSource(commit, {
+        deadlineAt: context.deadlineAt,
+      });
       const hydrated = await completeGitHubCommitEnrichment(
         commit,
         source,
@@ -206,7 +234,10 @@ const processCommits = async (
       }
     } catch (error) {
       const code = errorCode(error);
-      if (permanentlyUnavailable(error)) {
+      if (error instanceof GitHubRequestDeadlineError) {
+        await releaseGitHubCommitEnrichment(commit);
+        result.deferred += 1;
+      } else if (permanentlyUnavailable(error, commit.attemptCount)) {
         await markGitHubCommitUnavailable(commit, code);
         result.unavailable += 1;
       } else {
@@ -233,16 +264,14 @@ const processPullRequestDiscovery = async (
   result.claimed = claimed.length;
   for (const commit of claimed) {
     if (context.deadlineReached()) {
-      await deferGitHubPullRequestDiscovery(
-        commit,
-        "worker_deadline",
-        new Date()
-      );
+      await releaseGitHubPullRequestDiscovery(commit);
       result.deferred += 1;
       continue;
     }
     try {
-      const pullRequests = await fetchGitHubAssociatedPullRequests(commit);
+      const pullRequests = await fetchGitHubAssociatedPullRequests(commit, {
+        deadlineAt: context.deadlineAt,
+      });
       if (await completeGitHubPullRequestDiscovery(commit, pullRequests)) {
         result.completed += 1;
       } else {
@@ -250,7 +279,10 @@ const processPullRequestDiscovery = async (
       }
     } catch (error) {
       const code = errorCode(error);
-      if (permanentlyUnavailable(error)) {
+      if (error instanceof GitHubRequestDeadlineError) {
+        await releaseGitHubPullRequestDiscovery(commit);
+        result.deferred += 1;
+      } else if (permanentlyUnavailable(error, commit.attemptCount)) {
         await markGitHubPullRequestDiscoveryUnavailable(commit, code);
         result.unavailable += 1;
       } else {
@@ -260,6 +292,53 @@ const processPullRequestDiscovery = async (
     }
   }
   result.failed += result.deferred + result.unavailable;
+};
+
+const processPullRequestSignals = async (
+  context: WorkerContext,
+  limit: number,
+  result: StageResult
+) => {
+  if (context.deadlineReached()) {
+    return;
+  }
+  const claimed = await claimGitHubPullRequestSignals(
+    limit,
+    context.activeAccounts
+  );
+  result.claimed = claimed.length;
+  for (const signal of claimed) {
+    if (context.deadlineReached()) {
+      await releaseGitHubPullRequestSignal(signal);
+      result.deferred += 1;
+      continue;
+    }
+    try {
+      const snapshot = await fetchGitHubPullRequestSnapshot(signal, {
+        deadlineAt: context.deadlineAt,
+      });
+      await persistGitHubPullRequestSnapshot(
+        signal.account,
+        snapshot.pullRequest,
+        { refreshMembership: true }
+      );
+      await completeGitHubPullRequestSignal(signal);
+      result.completed += 1;
+    } catch (error) {
+      const code = errorCode(error);
+      if (error instanceof GitHubRequestDeadlineError) {
+        await releaseGitHubPullRequestSignal(signal);
+        result.deferred += 1;
+      } else if (permanentlyUnavailable(error, signal.attemptCount)) {
+        await markGitHubPullRequestSignalUnavailable(signal, code);
+        result.unavailable += 1;
+      } else {
+        await deferGitHubPullRequestSignal(signal, code, retryAtFrom(error));
+        result.deferred += 1;
+      }
+    }
+  }
+  result.failed = result.deferred + result.unavailable;
 };
 
 const reconcilePullRequest = async (
@@ -272,11 +351,16 @@ const reconcilePullRequest = async (
     repository: due.repository,
     repositoryId: due.repositoryId,
   };
-  const snapshot = await fetchGitHubPullRequestSnapshot(reference);
+  const snapshot = await fetchGitHubPullRequestSnapshot(reference, {
+    deadlineAt: context.deadlineAt,
+  });
   const stored = await persistGitHubPullRequestSnapshot(
     due.account,
     snapshot.pullRequest,
-    { refreshMembership: observedSinceLastReconciliation(due) }
+    {
+      reconciliationLeaseUntil: due.leaseUntil,
+      refreshMembership: observedSinceLastReconciliation(due),
+    }
   );
   if (stored === null) {
     throw new ActivityProcessingError(
@@ -284,10 +368,22 @@ const reconcilePullRequest = async (
       "A newer GitHub pull request observation is already stored."
     );
   }
+  if (stored.retryLifecycleReset) {
+    due.attemptCount = 1;
+    due.priorAttemptCount = 0;
+    due.priorErrorCode = null;
+  }
   if (stored.membershipRefreshRequired) {
     const membership = await fetchGitHubPullRequestMembership(
       reference,
-      snapshot.expectedCommitCount
+      snapshot.expectedCommitCount,
+      {
+        commitRepository:
+          snapshot.pullRequest.headRepository ??
+          snapshot.pullRequest.baseRepository,
+        deadlineAt: context.deadlineAt,
+        expectedHeadSha: snapshot.pullRequest.headSha,
+      }
     );
     const complete = await persistGitHubPullRequestMembership(
       stored,
@@ -302,40 +398,69 @@ const reconcilePullRequest = async (
       );
     }
   }
-  await completeGitHubPullRequestReconciliation(due, snapshot.pullRequest);
+  if (
+    !(await completeGitHubPullRequestReconciliation(due, snapshot.pullRequest))
+  ) {
+    throw new ActivityProcessingError(
+      "claim_stale",
+      "The GitHub pull request reconciliation claim is no longer current."
+    );
+  }
 };
 
 const processPullRequests = async (
   context: WorkerContext,
+  limit: number,
   result: StageResult
 ) => {
-  for (const account of context.activeAccounts) {
-    if (context.deadlineReached()) {
-      break;
-    }
-    const duePullRequests = await claimDueGitHubPullRequests(
-      account,
-      GITHUB_PR_RECONCILIATION_MAX_AGE_DAYS,
-      25
-    );
-    result.claimed += duePullRequests.length;
-    for (const due of duePullRequests) {
-      if (context.deadlineReached()) {
-        await deferGitHubPullRequestReconciliation(due, new Date());
-        result.deferred += 1;
-        continue;
+  const duePullRequests: DueGitHubPullRequest[] = [];
+  let claimedInRound = true;
+  while (
+    duePullRequests.length < limit &&
+    claimedInRound &&
+    !context.deadlineReached()
+  ) {
+    claimedInRound = false;
+    for (const account of context.activeAccounts) {
+      if (duePullRequests.length >= limit || context.deadlineReached()) {
+        break;
       }
-      try {
-        await reconcilePullRequest(context, due);
-        result.completed += 1;
-      } catch (error) {
-        if (permanentlyUnavailable(error)) {
-          await stopGitHubPullRequestReconciliation(due);
-          result.unavailable += 1;
-        } else {
-          await deferGitHubPullRequestReconciliation(due, retryAtFrom(error));
-          result.deferred += 1;
-        }
+      const [due] = await claimDueGitHubPullRequests(
+        account,
+        GITHUB_PR_RECONCILIATION_MAX_AGE_DAYS,
+        1
+      );
+      if (due !== undefined) {
+        duePullRequests.push(due);
+        claimedInRound = true;
+      }
+    }
+  }
+  result.claimed = duePullRequests.length;
+  for (const due of duePullRequests) {
+    if (context.deadlineReached()) {
+      await releaseGitHubPullRequestReconciliation(due);
+      result.deferred += 1;
+      continue;
+    }
+    try {
+      await reconcilePullRequest(context, due);
+      result.completed += 1;
+    } catch (error) {
+      const code = errorCode(error);
+      if (error instanceof GitHubRequestDeadlineError) {
+        await releaseGitHubPullRequestReconciliation(due);
+        result.deferred += 1;
+      } else if (permanentlyUnavailable(error, due.attemptCount)) {
+        await stopGitHubPullRequestReconciliation(due, code);
+        result.unavailable += 1;
+      } else {
+        await deferGitHubPullRequestReconciliation(
+          due,
+          code,
+          retryAtFrom(error)
+        );
+        result.deferred += 1;
       }
     }
   }
@@ -347,10 +472,7 @@ const processSummaries = async (
   limit: number,
   result: StageResult
 ) => {
-  if (
-    context.deadlineReached() ||
-    (env.OPENAI_API_KEY?.trim().length ?? 0) === 0
-  ) {
+  if (context.deadlineReached()) {
     return;
   }
   const claimed = await claimGitHubSummaryAttempts(
@@ -368,18 +490,22 @@ const processSummaries = async (
       const cacheKey = `${attempt.repositoryId}:${attempt.sha}`;
       const source =
         context.sourceCache.get(cacheKey) ??
-        (await fetchGitHubActivityCommitSource(attempt));
+        (await fetchGitHubActivityCommitSource(attempt, {
+          deadlineAt: context.deadlineAt,
+        }));
       if (context.deadlineReached()) {
         await releaseGitHubSummaryAttempt(attempt);
         result.deferred += 1;
         continue;
       }
-      const generated = await generateValidatedGitHubActivitySummary(source);
+      const generated = await generateValidatedGitHubActivitySummary(source, {
+        deadlineAt: context.deadlineAt,
+      });
       const completed = await completeGitHubSummaryAttempt(attempt, {
         headline: generated.summary.headline,
         inputHash: generated.inputHash,
-        model: GITHUB_ACTIVITY_SUMMARY_MODEL,
-        recipe: PUBLIC_COMMIT_SUMMARY_RECIPE,
+        model: generated.model,
+        recipe: generated.recipe,
         short: generated.summary.short,
       });
       if (completed) {
@@ -388,11 +514,17 @@ const processSummaries = async (
         result.failed += 1;
       }
     } catch (error) {
-      await failGitHubSummaryAttempt(attempt, errorCode(error));
-      result.failed += 1;
+      await (error instanceof GitHubRequestDeadlineError
+        ? releaseGitHubSummaryAttempt(attempt)
+        : deferGitHubSummaryAttempt(
+            attempt,
+            errorCode(error),
+            retryAtFrom(error)
+          ));
+      result.deferred += 1;
     }
   }
-  result.failed += result.deferred;
+  result.failed = result.deferred + result.unavailable;
 };
 
 export const runGitHubActivityWorker = async (
@@ -402,6 +534,10 @@ export const runGitHubActivityWorker = async (
   const observationLimit = boundedWorkerLimit(options.observationLimit);
   const pullRequestDiscoveryLimit = boundedWorkerLimit(
     options.pullRequestDiscoveryLimit
+  );
+  const pullRequestLimit = boundedWorkerLimit(options.pullRequestLimit);
+  const pullRequestSignalLimit = boundedWorkerLimit(
+    options.pullRequestSignalLimit
   );
   const summaryLimit = boundedWorkerLimit(options.summaryLimit);
   const maximumDurationMs =
@@ -421,21 +557,28 @@ export const runGitHubActivityWorker = async (
   const commits = emptyStageResult();
   const pullRequests = emptyStageResult();
   const pullRequestDiscovery = emptyStageResult();
+  const pullRequestSignals = emptyStageResult();
   const summaries = emptyStageResult();
   const context: WorkerContext = {
     activeAccounts: await activeTrackedAccounts(),
+    deadlineAt: startedAt + maximumDurationMs,
     deadlineReached,
     sourceCache: new Map(),
   };
 
   await processObservations(context, observationLimit, observations);
   await processCommits(context, commitLimit, commits);
+  await processPullRequestSignals(
+    context,
+    pullRequestSignalLimit,
+    pullRequestSignals
+  );
   await processPullRequestDiscovery(
     context,
     pullRequestDiscoveryLimit,
     pullRequestDiscovery
   );
-  await processPullRequests(context, pullRequests);
+  await processPullRequests(context, pullRequestLimit, pullRequests);
   const aliases = context.deadlineReached()
     ? 0
     : await canonicalizePendingGitHubActivities(8);
@@ -451,6 +594,7 @@ export const runGitHubActivityWorker = async (
     observations,
     pullRequests,
     pullRequestDiscovery,
+    pullRequestSignals,
     summaries,
   };
 };

--- a/src/lib/github-api.ts
+++ b/src/lib/github-api.ts
@@ -7,6 +7,9 @@ const GITHUB_API_VERSION = "2026-03-10";
 const REQUEST_ATTEMPTS = 3;
 const REQUEST_TIMEOUT_MS = 15_000;
 const MAXIMUM_INLINE_RETRY_DELAY_MS = 2000;
+const MAXIMUM_GITHUB_ERROR_BODY_BYTES = 16 * 1024;
+const SECONDARY_RATE_LIMIT_RETRY_MS = 60_000;
+const MAXIMUM_DATE_MILLISECONDS = 8_640_000_000_000_000;
 
 export class GitHubResponseError extends Error {
   readonly retryable: boolean;
@@ -25,12 +28,23 @@ export class GitHubResponseError extends Error {
   }
 }
 
+// oxlint-disable-next-line eslint/max-classes-per-file -- Callers distinguish deadline exhaustion from provider failures.
+export class GitHubRequestDeadlineError extends Error {
+  constructor() {
+    super("The GitHub request deadline was reached.");
+    this.name = "GitHubRequestDeadlineError";
+  }
+}
+
 const retryAtFrom = (headers: Headers, now = Date.now()) => {
   const retryAfter = headers.get("retry-after")?.trim();
   if (retryAfter !== undefined && retryAfter !== "") {
     if (/^\d+$/.test(retryAfter)) {
       const timestamp = now + Number(retryAfter) * 1000;
-      if (Number.isFinite(timestamp) && timestamp <= 8_640_000_000_000_000) {
+      if (
+        Number.isFinite(timestamp) &&
+        timestamp <= MAXIMUM_DATE_MILLISECONDS
+      ) {
         return new Date(timestamp);
       }
     }
@@ -41,20 +55,97 @@ const retryAtFrom = (headers: Headers, now = Date.now()) => {
   }
 
   const reset = headers.get("x-ratelimit-reset")?.trim();
-  if (reset !== undefined && /^\d+$/.test(reset)) {
+  if (
+    headers.get("x-ratelimit-remaining") === "0" &&
+    reset !== undefined &&
+    /^\d+$/.test(reset)
+  ) {
     const timestamp = Number(reset) * 1000;
-    if (Number.isFinite(timestamp) && timestamp <= 8_640_000_000_000_000) {
+    if (Number.isFinite(timestamp) && timestamp <= MAXIMUM_DATE_MILLISECONDS) {
       return new Date(timestamp);
     }
   }
   return null;
 };
 
-const isRateLimited = (response: Response) =>
+const readBoundedResponseText = async (response: Response) => {
+  const { body } = response.clone();
+  if (body === null) {
+    return null;
+  }
+  const reader = body.getReader();
+  const chunks: Uint8Array[] = [];
+  let totalBytes = 0;
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) {
+        break;
+      }
+      totalBytes += value.byteLength;
+      if (totalBytes > MAXIMUM_GITHUB_ERROR_BODY_BYTES) {
+        await reader.cancel();
+        return null;
+      }
+      chunks.push(value);
+    }
+  } catch {
+    return null;
+  }
+  const bytes = new Uint8Array(totalBytes);
+  let offset = 0;
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  try {
+    return new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+  } catch {
+    return null;
+  }
+};
+
+const hasSecondaryRateLimitEvidence = async (response: Response) => {
+  const text = await readBoundedResponseText(response);
+  if (text === null) {
+    return false;
+  }
+  let payload: unknown;
+  try {
+    payload = JSON.parse(text) as unknown;
+  } catch {
+    return false;
+  }
+  if (
+    typeof payload !== "object" ||
+    payload === null ||
+    Array.isArray(payload)
+  ) {
+    return false;
+  }
+  const record = payload as Record<string, unknown>;
+  const message =
+    typeof record.message === "string" ? record.message.toLowerCase() : "";
+  const documentationUrl =
+    typeof record.documentation_url === "string"
+      ? record.documentation_url.toLowerCase()
+      : "";
+  return (
+    message.includes("secondary rate limit") ||
+    message.includes("abuse detection") ||
+    message.includes("rate limit exceeded") ||
+    documentationUrl.includes("rate-limits-for-the-rest-api") ||
+    documentationUrl.includes("secondary-rate-limits") ||
+    documentationUrl.includes("abuse-rate-limits")
+  );
+};
+
+const isRateLimited = async (response: Response) =>
   response.status === 429 ||
   (response.status === 403 &&
     (response.headers.has("retry-after") ||
-      response.headers.get("x-ratelimit-remaining") === "0"));
+      response.headers.get("x-ratelimit-remaining") === "0" ||
+      (await hasSecondaryRateLimitEvidence(response))));
 
 const readDefaultGitHubToken = () => {
   const token = env.GITHUB_TOKEN?.trim() ?? env.GITHUB_F0RR0_TOKEN?.trim();
@@ -65,9 +156,55 @@ export const githubApiUrl = (path: string) => new URL(path, GITHUB_API_ORIGIN);
 
 interface GitHubFetchOptions {
   body?: string;
+  deadlineAt?: number;
+  ifNoneMatch?: string | null;
   method?: "GET" | "POST";
   token?: string | null;
 }
+
+const isSafeHttpHeaderValue = (value: string) => {
+  if (value.length === 0 || value.length > 1024) {
+    return false;
+  }
+  for (const character of value) {
+    const code = character.codePointAt(0) ?? 0;
+    if (code <= 31 || code === 127) {
+      return false;
+    }
+  }
+  return true;
+};
+
+export const githubResponseEtagFrom = (response: Response) => {
+  const etag = response.headers.get("etag")?.trim() ?? null;
+  return etag !== null && isSafeHttpHeaderValue(etag) ? etag : null;
+};
+
+export const githubNextPollAtFrom = (
+  response: Response,
+  receivedAt = Date.now()
+) => {
+  const value = response.headers.get("x-poll-interval")?.trim();
+  if (
+    value === undefined ||
+    !/^\d+$/.test(value) ||
+    !Number.isFinite(receivedAt) ||
+    receivedAt < 0
+  ) {
+    throw new TypeError("GitHub returned an invalid event poll interval.");
+  }
+  const seconds = Number(value);
+  const timestamp = receivedAt + seconds * 1000;
+  if (
+    !Number.isSafeInteger(seconds) ||
+    seconds < 1 ||
+    !Number.isFinite(timestamp) ||
+    timestamp > MAXIMUM_DATE_MILLISECONDS
+  ) {
+    throw new TypeError("GitHub returned an invalid event poll interval.");
+  }
+  return new Date(timestamp);
+};
 
 const checkedGitHubRequest = (url: URL, options: GitHubFetchOptions) => {
   if (url.origin !== GITHUB_API_ORIGIN) {
@@ -81,9 +218,43 @@ const checkedGitHubRequest = (url: URL, options: GitHubFetchOptions) => {
   ) {
     throw new Error("The GitHub request method and body are invalid.");
   }
+  if (
+    (options.ifNoneMatch !== undefined &&
+      options.ifNoneMatch !== null &&
+      (method !== "GET" || !isSafeHttpHeaderValue(options.ifNoneMatch))) ||
+    (options.deadlineAt !== undefined &&
+      (!Number.isFinite(options.deadlineAt) || options.deadlineAt < 0))
+  ) {
+    throw new Error("The GitHub conditional request options are invalid.");
+  }
   return method;
 };
 
+const requestTimeoutFrom = (deadlineAt: number | undefined) => {
+  if (deadlineAt === undefined) {
+    return REQUEST_TIMEOUT_MS;
+  }
+  const remaining = Math.floor(deadlineAt - Date.now());
+  if (remaining <= 0) {
+    throw new GitHubRequestDeadlineError();
+  }
+  return Math.max(1, Math.min(REQUEST_TIMEOUT_MS, remaining));
+};
+
+const waitForRetry = async (
+  milliseconds: number,
+  deadlineAt: number | undefined
+) => {
+  if (
+    deadlineAt !== undefined &&
+    Date.now() + Math.max(0, milliseconds) >= deadlineAt
+  ) {
+    throw new GitHubRequestDeadlineError();
+  }
+  await delay(Math.max(0, milliseconds));
+};
+
+// oxlint-disable-next-line eslint/complexity -- Retry, deadline, conditional, and rate-limit branches fail independently.
 export const fetchGitHub = async (
   url: URL,
   options: GitHubFetchOptions = {}
@@ -101,27 +272,43 @@ export const fetchGitHub = async (
         headers: {
           Accept: "application/vnd.github+json",
           ...(token === null ? {} : { Authorization: `Bearer ${token}` }),
+          ...(options.ifNoneMatch === undefined || options.ifNoneMatch === null
+            ? {}
+            : { "If-None-Match": options.ifNoneMatch }),
           ...(method === "POST" ? { "Content-Type": "application/json" } : {}),
           "User-Agent": "f0rr0.dev",
           "X-GitHub-Api-Version": GITHUB_API_VERSION,
         },
         method,
-        signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+        signal: AbortSignal.timeout(requestTimeoutFrom(options.deadlineAt)),
       });
     } catch (error) {
+      if (
+        options.deadlineAt !== undefined &&
+        Date.now() >= options.deadlineAt
+      ) {
+        throw new GitHubRequestDeadlineError();
+      }
       if (attempt === REQUEST_ATTEMPTS - 1) {
         throw error;
       }
-      await delay(250 * 2 ** attempt);
+      await waitForRetry(250 * 2 ** attempt, options.deadlineAt);
       continue;
     }
 
-    if (response.ok) {
+    if (
+      response.ok ||
+      (response.status === 304 &&
+        options.ifNoneMatch !== undefined &&
+        options.ifNoneMatch !== null)
+    ) {
       return response;
     }
-    if (isRateLimited(response)) {
+    if (await isRateLimited(response)) {
+      const retryAt = retryAtFrom(response.headers);
       throw new GitHubResponseError(response.status, {
-        retryAt: retryAtFrom(response.headers),
+        retryAt:
+          retryAt ?? new Date(Date.now() + SECONDARY_RATE_LIMIT_RETRY_MS),
         retryable: true,
       });
     }
@@ -143,7 +330,7 @@ export const fetchGitHub = async (
         retryable: true,
       });
     }
-    await delay(Math.max(0, retryDelay));
+    await waitForRetry(Math.max(0, retryDelay), options.deadlineAt);
   }
 
   throw new Error("GitHub request retry budget exhausted.");

--- a/src/lib/github-backfill-core.ts
+++ b/src/lib/github-backfill-core.ts
@@ -4,19 +4,79 @@ import {
   trackedGitHubAccountFrom,
 } from "@/lib/github-commits-core";
 import type { TrackedGitHubAccount } from "@/lib/github-commits-core";
-import type { GitHubBackfillWindow } from "@/lib/github-commits-store";
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 const DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
-const MAXIMUM_BACKFILL_DAYS = 366;
-const WINDOW_DAYS = 31;
 const MINIMUM_GITHUB_DATE = Date.UTC(1970, 0, 1);
-const MAXIMUM_GITHUB_DATE = Date.UTC(2099, 11, 13);
+const MAXIMUM_GITHUB_DATE = Date.UTC(2099, 11, 31);
+
+export const GITHUB_BACKFILL_WORKER_BATCH_SIZE = 8;
+
+interface GitHubBackfillWorkerStageCounts {
+  claimed: number;
+  completed: number;
+  deferred: number;
+  failed: number;
+  unavailable: number;
+}
+
+interface GitHubBackfillWorkerPassCounts {
+  aliases: number;
+  commits: GitHubBackfillWorkerStageCounts;
+  observations: GitHubBackfillWorkerStageCounts;
+  pullRequestDiscovery: GitHubBackfillWorkerStageCounts;
+  pullRequests: GitHubBackfillWorkerStageCounts;
+  pullRequestSignals: GitHubBackfillWorkerStageCounts;
+  summaries: GitHubBackfillWorkerStageCounts;
+}
+
+export interface GitHubBackfillProcessingCounts {
+  aliases: number;
+  claimed: number;
+  deferred: number;
+  failed: number;
+  processed: number;
+  unavailable: number;
+}
 
 type JsonObject = Record<string, unknown>;
 
 const isObject = (value: unknown): value is JsonObject =>
   typeof value === "object" && value !== null && !Array.isArray(value);
+
+export const githubBackfillProcessingCountsFrom = (
+  result: GitHubBackfillWorkerPassCounts
+): GitHubBackfillProcessingCounts => {
+  const counts: GitHubBackfillProcessingCounts = {
+    aliases: result.aliases,
+    claimed: 0,
+    deferred: 0,
+    failed: 0,
+    processed: 0,
+    unavailable: 0,
+  };
+  const stages = [
+    result.observations,
+    result.commits,
+    result.pullRequestDiscovery,
+    result.pullRequestSignals,
+    result.pullRequests,
+    result.summaries,
+  ];
+  for (const stage of stages) {
+    counts.claimed += stage.claimed;
+    counts.deferred += stage.deferred;
+    counts.processed += stage.completed;
+    counts.unavailable += stage.unavailable;
+    // Worker stages include deferred and unavailable items in `failed`.
+    // Report those outcomes once so the final counts remain disjoint.
+    counts.failed += Math.max(
+      0,
+      stage.failed - stage.deferred - stage.unavailable
+    );
+  }
+  return counts;
+};
 
 const utcDayFrom = (value: unknown) => {
   if (typeof value !== "string" || !DATE_PATTERN.test(value)) {
@@ -33,8 +93,9 @@ export interface GitHubBackfillRequest {
   accounts: readonly TrackedGitHubAccount[];
   endDate: string;
   repositoryId: string | null;
+  sinceAt: Date;
   startDate: string;
-  windows: readonly GitHubBackfillWindow[];
+  untilAt: Date;
 }
 
 interface NormalizedGitHubBackfillInput {
@@ -84,36 +145,16 @@ const normalizedGitHubBackfillInputFrom = (
 };
 
 const githubBackfillRequestFor = (
-  input: Pick<NormalizedGitHubBackfillInput, "accounts" | "repositoryId"> & {
-    endDay: Date;
-    startAt: Date;
-  }
+  input: NormalizedGitHubBackfillInput
 ): GitHubBackfillRequest => {
   const { accounts, endDay, repositoryId, startAt } = input;
-
-  const windows: GitHubBackfillWindow[] = [];
-  const rangeEndExclusive = endDay.getTime() + DAY_MS;
-  for (
-    let cursor = startAt.getTime();
-    cursor < rangeEndExclusive;
-    cursor += WINDOW_DAYS * DAY_MS
-  ) {
-    const windowEndExclusive = Math.min(
-      cursor + WINDOW_DAYS * DAY_MS,
-      rangeEndExclusive
-    );
-    windows.push({
-      sinceAt: new Date(cursor),
-      untilAt: new Date(windowEndExclusive - 1),
-    });
-  }
-
   return {
     accounts,
     endDate: endDay.toISOString().slice(0, 10),
     repositoryId,
+    sinceAt: startAt,
     startDate: startAt.toISOString().slice(0, 10),
-    windows,
+    untilAt: new Date(endDay.getTime() + DAY_MS - 1),
   };
 };
 
@@ -125,68 +166,5 @@ export const githubBackfillRequestFrom = (
   if (input === null) {
     return null;
   }
-  const dayCount =
-    (input.endDay.getTime() - input.startAt.getTime()) / DAY_MS + 1;
-  return dayCount > MAXIMUM_BACKFILL_DAYS
-    ? null
-    : githubBackfillRequestFor(input);
-};
-
-export const githubBackfillRequestSeriesFrom = (
-  value: unknown,
-  now = new Date()
-): readonly GitHubBackfillRequest[] | null => {
-  const input = normalizedGitHubBackfillInputFrom(value, now);
-  if (input === null) {
-    return null;
-  }
-  const requests: GitHubBackfillRequest[] = [];
-  const finalEnd = input.endDay.getTime();
-  for (
-    let start = input.startAt.getTime();
-    start <= finalEnd;
-    start += MAXIMUM_BACKFILL_DAYS * DAY_MS
-  ) {
-    requests.push(
-      githubBackfillRequestFor({
-        accounts: input.accounts,
-        endDay: new Date(
-          Math.min(start + (MAXIMUM_BACKFILL_DAYS - 1) * DAY_MS, finalEnd)
-        ),
-        repositoryId: input.repositoryId,
-        startAt: new Date(start),
-      })
-    );
-  }
-  return requests;
-};
-
-export const splitGitHubBackfillRequest = (
-  request: GitHubBackfillRequest
-): readonly [GitHubBackfillRequest, GitHubBackfillRequest] | null => {
-  const startAt = utcDayFrom(request.startDate);
-  const endDay = utcDayFrom(request.endDate);
-  if (startAt === null || endDay === null) {
-    return null;
-  }
-  const dayCount = (endDay.getTime() - startAt.getTime()) / DAY_MS + 1;
-  if (!Number.isSafeInteger(dayCount) || dayCount <= 1) {
-    return null;
-  }
-  const leftDayCount = Math.floor(dayCount / 2);
-  const rightStartAt = new Date(startAt.getTime() + leftDayCount * DAY_MS);
-  return [
-    githubBackfillRequestFor({
-      accounts: request.accounts,
-      endDay: new Date(rightStartAt.getTime() - DAY_MS),
-      repositoryId: request.repositoryId,
-      startAt,
-    }),
-    githubBackfillRequestFor({
-      accounts: request.accounts,
-      endDay,
-      repositoryId: request.repositoryId,
-      startAt: rightStartAt,
-    }),
-  ];
+  return githubBackfillRequestFor(input);
 };

--- a/src/lib/github-commits-core.ts
+++ b/src/lib/github-commits-core.ts
@@ -81,7 +81,13 @@ export interface GitHubPullRequest {
   headRepository: GitHubRepositoryFacts | null;
   headSha: string;
   id: string;
-  mergeCommitSha: string | null;
+  /**
+   * GitHub's observed integration-commit candidate.
+   * `undefined` means the versioned REST representation omitted the field;
+   * `null` means no candidate exists. Durable merge identity must be verified
+   * from GraphQL `PullRequest.mergeCommit` before it is treated as authoritative.
+   */
+  mergeCommitSha: string | null | undefined;
   merged: boolean;
   mergedAt: string | null;
   nodeId: string;
@@ -199,6 +205,9 @@ export const commitShaFrom = (value: unknown) => {
 };
 
 const optionalCommitSha = (value: unknown) => {
+  if (value === undefined) {
+    return { valid: true, value: undefined } as const;
+  }
   if (value === null) {
     return { valid: true, value: null } as const;
   }
@@ -421,10 +430,10 @@ export const commitFromGitHub = (
       ? (normalizedText(value.commit.message.split(/\r?\n/, 1)[0], 240) ?? "")
       : null;
   const committedAt = normalizedDate(
-    (isObject(value.commit.author) ? value.commit.author.date : undefined) ??
-      (isObject(value.commit.committer)
-        ? value.commit.committer.date
-        : undefined)
+    (isObject(value.commit.committer)
+      ? value.commit.committer.date
+      : undefined) ??
+      (isObject(value.commit.author) ? value.commit.author.date : undefined)
   );
   if (sha === null || message === null || committedAt === null) {
     throw new TypeError("GitHub returned an invalid commit response.");
@@ -626,7 +635,6 @@ export const pullRequestFromGitHub = (
   const deletions = optionalNonNegativeInteger(value.deletions);
   const branches = pullRequestBranchesFrom(value, repository);
   const stateFacts = pullRequestStateFrom(value, closedAt, mergedAt);
-  const mergeCommitSha = optionalCommitSha(value.merge_commit_sha);
   const required = requiredPullRequestScalarsFrom({
     body,
     createdAt,
@@ -640,6 +648,12 @@ export const pullRequestFromGitHub = (
   if (branches === null || stateFacts === null || required === null) {
     return null;
   }
+  // Before a pull request is merged, GitHub's legacy REST field identifies a
+  // synthetic test merge commit. It is not stable integration evidence and
+  // must never enter durable merge identity state.
+  const mergeCommitSha = stateFacts.merged
+    ? optionalCommitSha(value.merge_commit_sha)
+    : ({ valid: true, value: null } as const);
   const expectedUrl = `https://github.com/${repository.fullName}/pull/${required.number}`;
 
   if (

--- a/src/lib/github-commits-store.ts
+++ b/src/lib/github-commits-store.ts
@@ -1,7 +1,8 @@
-import { createHash } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 
 import {
   and,
+  asc,
   eq,
   gt,
   inArray,
@@ -9,7 +10,6 @@ import {
   lt,
   lte,
   ne,
-  notInArray,
   or,
   sql,
 } from "drizzle-orm";
@@ -17,9 +17,11 @@ import {
 import { getDatabase } from "@/db/client";
 import {
   githubAccountCheckpoints,
+  githubCommits,
   githubIssues,
   githubPublicActivities,
   githubPullRequests,
+  githubPullRequestSignals,
   githubPullRequestVersions,
   githubPushObservationCommits,
   githubPushObservations,
@@ -27,8 +29,10 @@ import {
   githubRepositoryRefs,
   githubWebhookDeliveries,
 } from "@/db/schema";
+import { invalidateGitHubPullRequestDerivedAliases } from "@/lib/github-activity-alias-store";
 import { trackedGitHubAccountFrom } from "@/lib/github-commits-core";
 import type {
+  GitHubCommit,
   GitHubEvent,
   GitHubIssue,
   GitHubPullRequest,
@@ -47,9 +51,28 @@ export class CheckpointConflictError extends Error {
 }
 
 export interface GitHubAccountCheckpoint {
+  eventsEtag: string | null;
+  eventsLastAttemptedAt: Date | null;
+  eventsLastSucceededAt: Date | null;
+  eventsNextPollAt: Date | null;
   latestEventId: string | null;
   paused: boolean;
   refBackfillSinceAt: Date;
+}
+
+export interface GitHubEventPollStart {
+  checkpoint: GitHubAccountCheckpoint;
+  shouldPoll: boolean;
+}
+
+export type GitHubRepositoryRefKind = GitHubRepositoryRefSnapshot["kind"];
+
+export interface GitHubRefReconciliationLease {
+  cursorRepositoryId: string | null;
+  kind: GitHubRepositoryRefKind;
+  leaseToken: string;
+  nextPage: number | null;
+  scanStartedAt: Date | null;
 }
 
 export interface GitHubIntakeResult {
@@ -77,17 +100,6 @@ export interface GitHubRepositoryRefIntakeResult {
   refs: number;
 }
 
-export interface GitHubBackfillWindow {
-  sinceAt: Date;
-  untilAt: Date;
-}
-
-export interface GitHubRepositoryBackfillIntakeResult {
-  duplicates: number;
-  observations: number;
-  refs: number;
-}
-
 type DatabaseTransaction = Parameters<
   Parameters<ReturnType<typeof getDatabase>["transaction"]>[0]
 >[0];
@@ -101,6 +113,10 @@ export const readGitHubAccountCheckpoint = async (
 ): Promise<GitHubAccountCheckpoint | null> => {
   const [checkpoint] = await getDatabase()
     .select({
+      eventsEtag: githubAccountCheckpoints.eventsEtag,
+      eventsLastAttemptedAt: githubAccountCheckpoints.eventsLastAttemptedAt,
+      eventsLastSucceededAt: githubAccountCheckpoints.eventsLastSucceededAt,
+      eventsNextPollAt: githubAccountCheckpoints.eventsNextPollAt,
       latestEventId: githubAccountCheckpoints.latestEventId,
       paused: githubAccountCheckpoints.paused,
       refBackfillSinceAt: githubAccountCheckpoints.refBackfillSinceAt,
@@ -110,6 +126,60 @@ export const readGitHubAccountCheckpoint = async (
     .limit(1);
   return checkpoint ?? null;
 };
+
+export const beginGitHubEventPoll = async (
+  account: TrackedGitHubAccount,
+  attemptedAt = new Date()
+): Promise<GitHubEventPollStart> =>
+  await getDatabase().transaction(async (transaction) => {
+    await transaction
+      .insert(githubAccountCheckpoints)
+      .values({ account })
+      .onConflictDoNothing({ target: githubAccountCheckpoints.account });
+    const minimumPreviousAttemptAt = new Date(attemptedAt.getTime() - 60_000);
+    const selection = {
+      eventsEtag: githubAccountCheckpoints.eventsEtag,
+      eventsLastAttemptedAt: githubAccountCheckpoints.eventsLastAttemptedAt,
+      eventsLastSucceededAt: githubAccountCheckpoints.eventsLastSucceededAt,
+      eventsNextPollAt: githubAccountCheckpoints.eventsNextPollAt,
+      latestEventId: githubAccountCheckpoints.latestEventId,
+      paused: githubAccountCheckpoints.paused,
+      refBackfillSinceAt: githubAccountCheckpoints.refBackfillSinceAt,
+    } as const;
+    const [started] = await transaction
+      .update(githubAccountCheckpoints)
+      .set({ eventsLastAttemptedAt: attemptedAt })
+      .where(
+        and(
+          eq(githubAccountCheckpoints.account, account),
+          eq(githubAccountCheckpoints.paused, false),
+          or(
+            isNull(githubAccountCheckpoints.eventsNextPollAt),
+            lte(githubAccountCheckpoints.eventsNextPollAt, attemptedAt)
+          ),
+          or(
+            isNull(githubAccountCheckpoints.eventsLastAttemptedAt),
+            lte(
+              githubAccountCheckpoints.eventsLastAttemptedAt,
+              minimumPreviousAttemptAt
+            )
+          )
+        )
+      )
+      .returning(selection);
+    if (started !== undefined) {
+      return { checkpoint: started, shouldPoll: true };
+    }
+    const [checkpoint] = await transaction
+      .select(selection)
+      .from(githubAccountCheckpoints)
+      .where(eq(githubAccountCheckpoints.account, account))
+      .limit(1);
+    if (checkpoint === undefined) {
+      throw new Error("The GitHub account checkpoint could not be created.");
+    }
+    return { checkpoint, shouldPoll: false };
+  });
 
 const upsertRepository = async (
   transaction: DatabaseTransaction,
@@ -198,14 +268,149 @@ interface PushObservationInput {
   sourceId: string;
 }
 
+// oxlint-disable-next-line eslint/max-classes-per-file -- Durable intake exposes distinct optimistic-lock and evidence errors.
+export class GitHubPushObservationEvidenceConflictError extends Error {
+  constructor() {
+    super("Conflicting GitHub push evidence was observed.");
+    this.name = "GitHubPushObservationEvidenceConflictError";
+  }
+}
+
+const pushObservationIdentityKey = (input: {
+  afterSha: string;
+  beforeSha: string;
+  refName: string;
+  repositoryId: string;
+}) =>
+  JSON.stringify([
+    input.repositoryId,
+    input.refName,
+    input.beforeSha,
+    input.afterSha,
+  ]);
+
+const pushInputIdentityKey = (input: PushObservationInput) =>
+  pushObservationIdentityKey({
+    afterSha: input.push.head,
+    beforeSha: input.push.before,
+    refName: input.push.ref,
+    repositoryId: input.push.repository.id,
+  });
+
+const pushSourceIdentityKey = (input: { source: string; sourceId: string }) =>
+  JSON.stringify([input.source, input.sourceId]);
+
+const isOrderedSubsequence = (
+  candidate: readonly string[],
+  complete: readonly string[]
+) => {
+  let offset = 0;
+  for (const sha of candidate) {
+    const index = complete.indexOf(sha, offset);
+    if (index === -1) {
+      return false;
+    }
+    offset = index + 1;
+  }
+  return true;
+};
+
 const PUSH_COMMIT_INSERT_BATCH = 1000;
 
+export interface GitHubCommitReferenceIntakeResult {
+  duplicates: number;
+  inserted: number;
+}
+
+/** Inserts independently discovered commit references for normal worker enrichment. */
+export const persistGitHubCommitReferences = async (input: {
+  commits: readonly GitHubCommit[];
+  observedAt?: Date;
+}): Promise<GitHubCommitReferenceIntakeResult> => {
+  const observedAt = input.observedAt ?? new Date();
+  if (Number.isNaN(observedAt.getTime())) {
+    throw new RangeError("The GitHub commit observation time is invalid.");
+  }
+  const commits = new Map<string, GitHubCommit>();
+  for (const commit of input.commits) {
+    const committedAt = new Date(commit.committedAt);
+    if (Number.isNaN(committedAt.getTime())) {
+      throw new TypeError("A GitHub commit reference has an invalid date.");
+    }
+    const identity = `${commit.repositoryId}:${commit.sha}`;
+    const existing = commits.get(identity);
+    if (
+      existing !== undefined &&
+      (existing.author !== commit.author ||
+        existing.committedAt !== commit.committedAt ||
+        existing.message !== commit.message ||
+        existing.repository !== commit.repository)
+    ) {
+      throw new TypeError("GitHub returned conflicting commit references.");
+    }
+    commits.set(identity, commit);
+  }
+  if (commits.size === 0) {
+    return { duplicates: 0, inserted: 0 };
+  }
+
+  return await getDatabase().transaction(async (transaction) => {
+    const repositories = new Map<string, GitHubRepository>();
+    for (const commit of commits.values()) {
+      repositories.set(commit.repositoryId, {
+        fullName: commit.repository,
+        id: commit.repositoryId,
+      });
+    }
+    for (const repository of repositories.values()) {
+      await upsertRepository(transaction, repository, observedAt);
+    }
+
+    let inserted = 0;
+    const values = [...commits.values()];
+    for (
+      let offset = 0;
+      offset < values.length;
+      offset += PUSH_COMMIT_INSERT_BATCH
+    ) {
+      const rows = await transaction
+        .insert(githubCommits)
+        .values(
+          values
+            .slice(offset, offset + PUSH_COMMIT_INSERT_BATCH)
+            .map((commit) => ({
+              author: commit.author,
+              committedAt: new Date(commit.committedAt),
+              firstObservedAt: observedAt,
+              message: commit.message,
+              repository: commit.repository,
+              repositoryId: commit.repositoryId,
+              sha: commit.sha,
+            }))
+        )
+        .onConflictDoNothing({
+          target: [githubCommits.repositoryId, githubCommits.sha],
+        })
+        .returning({ sha: githubCommits.sha });
+      inserted += rows.length;
+    }
+    return { duplicates: input.commits.length - inserted, inserted };
+  });
+};
+
+// oxlint-disable-next-line eslint/complexity -- Conflict promotion validates each independent evidence invariant before mutation.
 const insertPushObservations = async (
   transaction: DatabaseTransaction,
   inputs: readonly PushObservationInput[]
 ) => {
   if (inputs.length === 0) {
     return { duplicates: 0, knownCommits: 0, pushes: 0 };
+  }
+  if (
+    new Set(inputs.map(pushInputIdentityKey)).size !== inputs.length ||
+    new Set(inputs.map(pushSourceIdentityKey)).size !== inputs.length
+  ) {
+    throw new GitHubPushObservationEvidenceConflictError();
   }
 
   const repositories = new Map<string, GitHubRepository>();
@@ -259,13 +464,16 @@ const insertPushObservations = async (
     .onConflictDoNothing()
     .returning({
       id: githubPushObservations.id,
+      source: githubPushObservations.source,
       sourceId: githubPushObservations.sourceId,
     });
-  const inputsBySourceId = new Map(
-    inputs.map((input) => [input.sourceId, input])
+  const inputsBySource = new Map(
+    inputs.map((input) => [pushSourceIdentityKey(input), input])
   );
-  const commitRows = inserted.flatMap(({ id, sourceId }) => {
-    const input = inputsBySourceId.get(sourceId);
+  const commitRows = inserted.flatMap(({ id, source, sourceId }) => {
+    const input = inputsBySource.get(
+      pushSourceIdentityKey({ source, sourceId })
+    );
     if (input === undefined) {
       throw new Error("A persisted GitHub push observation lost its source.");
     }
@@ -276,6 +484,160 @@ const insertPushObservations = async (
       sha,
     }));
   });
+  const insertedSources = new Set(inserted.map(pushSourceIdentityKey));
+  const duplicateInputs = inputs.filter(
+    (input) => !insertedSources.has(pushSourceIdentityKey(input))
+  );
+  let promoted = 0;
+  let promotedCommitCount = 0;
+  if (duplicateInputs.length > 0) {
+    const conflicts = await transaction
+      .select({
+        afterSha: githubPushObservations.afterSha,
+        beforeSha: githubPushObservations.beforeSha,
+        expectedCommitCount: githubPushObservations.expectedCommitCount,
+        id: githubPushObservations.id,
+        providerCreatedAt: githubPushObservations.providerCreatedAt,
+        refName: githubPushObservations.refName,
+        repositoryId: githubPushObservations.repositoryId,
+        source: githubPushObservations.source,
+        sourceId: githubPushObservations.sourceId,
+      })
+      .from(githubPushObservations)
+      .where(
+        or(
+          ...duplicateInputs.flatMap((input) => [
+            and(
+              eq(githubPushObservations.source, input.source),
+              eq(githubPushObservations.sourceId, input.sourceId)
+            ),
+            and(
+              eq(githubPushObservations.repositoryId, input.push.repository.id),
+              eq(githubPushObservations.refName, input.push.ref),
+              eq(githubPushObservations.beforeSha, input.push.before),
+              eq(githubPushObservations.afterSha, input.push.head),
+              ne(githubPushObservations.source, "backfill")
+            ),
+          ])
+        )
+      )
+      .for("update");
+    const conflictIds = conflicts.map(({ id }) => id);
+    const storedCommitRows =
+      conflictIds.length === 0
+        ? []
+        : await transaction
+            .select({
+              observationId: githubPushObservationCommits.observationId,
+              position: githubPushObservationCommits.position,
+              repositoryId: githubPushObservationCommits.repositoryId,
+              sha: githubPushObservationCommits.sha,
+            })
+            .from(githubPushObservationCommits)
+            .where(
+              inArray(githubPushObservationCommits.observationId, conflictIds)
+            )
+            .orderBy(
+              asc(githubPushObservationCommits.observationId),
+              asc(githubPushObservationCommits.position)
+            );
+    const commitsByObservation = new Map<string, string[]>();
+    const conflictsById = new Map(
+      conflicts.map((conflict) => [conflict.id, conflict])
+    );
+    for (const row of storedCommitRows) {
+      const commits = commitsByObservation.get(row.observationId) ?? [];
+      if (
+        row.position !== commits.length ||
+        conflictsById.get(row.observationId)?.repositoryId !== row.repositoryId
+      ) {
+        throw new GitHubPushObservationEvidenceConflictError();
+      }
+      commits.push(row.sha);
+      commitsByObservation.set(row.observationId, commits);
+    }
+    const byPush = new Map(
+      conflicts.map((conflict) => [
+        pushObservationIdentityKey(conflict),
+        conflict,
+      ])
+    );
+    const bySource = new Map(
+      conflicts.map((conflict) => [pushSourceIdentityKey(conflict), conflict])
+    );
+
+    for (const input of duplicateInputs) {
+      const sourceConflict = bySource.get(pushSourceIdentityKey(input));
+      const pushConflict = byPush.get(pushInputIdentityKey(input));
+      if (
+        (sourceConflict !== undefined &&
+          pushConflict !== undefined &&
+          sourceConflict.id !== pushConflict.id) ||
+        (sourceConflict !== undefined &&
+          pushObservationIdentityKey(sourceConflict) !==
+            pushInputIdentityKey(input))
+      ) {
+        throw new GitHubPushObservationEvidenceConflictError();
+      }
+      const conflict = pushConflict ?? sourceConflict;
+      if (conflict === undefined) {
+        throw new GitHubPushObservationEvidenceConflictError();
+      }
+      const exact =
+        input.push.size !== null &&
+        input.push.commitShas.length === input.push.size;
+      const storedCommits = commitsByObservation.get(conflict.id) ?? [];
+      if (
+        (input.push.size !== null &&
+          conflict.expectedCommitCount !== null &&
+          input.push.size !== conflict.expectedCommitCount) ||
+        (exact &&
+          !isOrderedSubsequence(storedCommits, input.push.commitShas)) ||
+        (!exact &&
+          storedCommits.length > 0 &&
+          input.push.commitShas.length > 0 &&
+          !isOrderedSubsequence(storedCommits, input.push.commitShas) &&
+          !isOrderedSubsequence(input.push.commitShas, storedCommits))
+      ) {
+        throw new GitHubPushObservationEvidenceConflictError();
+      }
+      if (conflict.source !== "refs" || !exact) {
+        continue;
+      }
+
+      const complete = input.push.size === 0;
+      await transaction
+        .update(githubPushObservations)
+        .set({
+          account: input.push.pushedBy,
+          attemptCount: 0,
+          completedAt: complete ? input.observedAt : null,
+          errorCode: null,
+          expectedCommitCount: input.push.size,
+          leaseToken: null,
+          leaseUntil: null,
+          providerCreatedAt:
+            input.providerCreatedAt ?? conflict.providerCreatedAt,
+          state: complete ? "complete" : "pending",
+        })
+        .where(eq(githubPushObservations.id, conflict.id));
+      await transaction
+        .delete(githubPushObservationCommits)
+        .where(eq(githubPushObservationCommits.observationId, conflict.id));
+      if (input.push.commitShas.length > 0) {
+        await transaction.insert(githubPushObservationCommits).values(
+          input.push.commitShas.map((sha, position) => ({
+            observationId: conflict.id,
+            position,
+            repositoryId: input.push.repository.id,
+            sha,
+          }))
+        );
+      }
+      promoted += 1;
+      promotedCommitCount += input.push.commitShas.length;
+    }
+  }
   for (
     let offset = 0;
     offset < commitRows.length;
@@ -286,14 +648,13 @@ const insertPushObservations = async (
       .values(commitRows.slice(offset, offset + PUSH_COMMIT_INSERT_BATCH));
   }
   return {
-    duplicates: inputs.length - inserted.length,
-    knownCommits: commitRows.length,
-    pushes: inserted.length,
+    duplicates: inputs.length - inserted.length - promoted,
+    knownCommits: commitRows.length + promotedCommitCount,
+    pushes: inserted.length + promoted,
   };
 };
 
 const ZERO_SHA = "0".repeat(40);
-const BACKFILL_OBSERVATION_INSERT_BATCH = 250;
 
 const refObservationSourceId = (input: {
   afterSha: string;
@@ -309,157 +670,239 @@ const refObservationSourceId = (input: {
     )
     .digest("hex")}`;
 
-const backfillObservationSourceId = (input: {
-  afterSha: string;
-  repositoryId: string;
-  sinceAt: Date;
-  untilAt: Date;
-}) =>
-  `backfill:${createHash("sha256")
-    .update(
-      [
-        input.repositoryId,
-        input.afterSha,
-        input.sinceAt.toISOString(),
-        input.untilAt.toISOString(),
-      ].join("\0")
-    )
-    .digest("hex")}`;
+// oxlint-disable-next-line eslint/max-classes-per-file -- Lease loss is recoverable and must remain distinguishable by callers.
+export class GitHubRefReconciliationLeaseLostError extends Error {
+  constructor() {
+    super("The GitHub ref reconciliation lease was lost.");
+    this.name = "GitHubRefReconciliationLeaseLostError";
+  }
+}
 
-export const persistGitHubRepositoryBackfill = async (input: {
+const refCheckpointColumns = (kind: GitHubRepositoryRefKind) =>
+  kind === "head"
+    ? {
+        cursor: githubAccountCheckpoints.headRefCursorRepositoryId,
+        cycleStartedAt: githubAccountCheckpoints.headRefCycleStartedAt,
+        lastAttemptedAt: githubAccountCheckpoints.headRefLastAttemptedAt,
+        lastSucceededAt: githubAccountCheckpoints.headRefLastSucceededAt,
+        leaseToken: githubAccountCheckpoints.headRefLeaseToken,
+        leaseUntil: githubAccountCheckpoints.headRefLeaseUntil,
+        nextPage: githubAccountCheckpoints.headRefNextPage,
+        scanStartedAt: githubAccountCheckpoints.headRefScanStartedAt,
+      }
+    : {
+        cursor: githubAccountCheckpoints.tagRefCursorRepositoryId,
+        cycleStartedAt: githubAccountCheckpoints.tagRefCycleStartedAt,
+        lastAttemptedAt: githubAccountCheckpoints.tagRefLastAttemptedAt,
+        lastSucceededAt: githubAccountCheckpoints.tagRefLastSucceededAt,
+        leaseToken: githubAccountCheckpoints.tagRefLeaseToken,
+        leaseUntil: githubAccountCheckpoints.tagRefLeaseUntil,
+        nextPage: githubAccountCheckpoints.tagRefNextPage,
+        scanStartedAt: githubAccountCheckpoints.tagRefScanStartedAt,
+      };
+
+const refLeaseValues = (
+  kind: GitHubRepositoryRefKind,
+  input: { leaseToken: string | null; leaseUntil: Date | null }
+) =>
+  kind === "head"
+    ? {
+        headRefLeaseToken: input.leaseToken,
+        headRefLeaseUntil: input.leaseUntil,
+      }
+    : {
+        tagRefLeaseToken: input.leaseToken,
+        tagRefLeaseUntil: input.leaseUntil,
+      };
+
+export const acquireGitHubRefReconciliationLease = async (input: {
   account: TrackedGitHubAccount;
-  observedAt: Date;
-  refs: readonly GitHubRepositoryRefSnapshot[];
-  repository: GitHubRepositoryFacts;
-  windows: readonly GitHubBackfillWindow[];
-}): Promise<GitHubRepositoryBackfillIntakeResult> => {
+  kind: GitHubRepositoryRefKind;
+  leaseDurationMs: number;
+  now?: Date;
+}): Promise<GitHubRefReconciliationLease | null> => {
   if (
-    input.windows.length === 0 ||
-    input.windows.some(
-      ({ sinceAt, untilAt }) =>
-        Number.isNaN(sinceAt.getTime()) ||
-        Number.isNaN(untilAt.getTime()) ||
-        sinceAt > untilAt
-    )
+    !Number.isSafeInteger(input.leaseDurationMs) ||
+    input.leaseDurationMs < 1000 ||
+    input.leaseDurationMs > 300_000
   ) {
-    throw new RangeError("The GitHub backfill windows are invalid.");
+    throw new RangeError("The GitHub ref lease duration is invalid.");
   }
-  const windowIdentities = input.windows.map(({ sinceAt, untilAt }) =>
-    [sinceAt.toISOString(), untilAt.toISOString()].join("\0")
-  );
-  if (new Set(windowIdentities).size !== windowIdentities.length) {
-    throw new RangeError("The GitHub backfill windows are duplicated.");
-  }
-
-  const refsByHead = new Map<string, GitHubRepositoryRefSnapshot>();
-  for (const ref of input.refs) {
-    const existing = refsByHead.get(ref.headSha);
-    if (existing === undefined || ref.refName < existing.refName) {
-      refsByHead.set(ref.headSha, ref);
-    }
-  }
-  const refs = [...refsByHead.values()].toSorted((left, right) =>
-    left.refName < right.refName ? -1 : left.refName > right.refName ? 1 : 0
-  );
-  const rows = refs.flatMap((ref) =>
-    input.windows.map(({ sinceAt, untilAt }) => ({
-      account: input.account,
-      afterSha: ref.headSha,
-      beforeSha: ZERO_SHA,
-      expectedCommitCount: null,
-      historySinceAt: sinceAt,
-      historyUntilAt: untilAt,
-      observedAt: input.observedAt,
-      providerCreatedAt: null,
-      refName: ref.refName,
-      repositoryId: input.repository.id,
-      repositoryNameSnapshot: input.repository.fullName,
-      source: "backfill" as const,
-      sourceId: backfillObservationSourceId({
-        afterSha: ref.headSha,
-        repositoryId: input.repository.id,
-        sinceAt,
-        untilAt,
-      }),
-      state: "pending" as const,
-    }))
-  );
-
+  const now = input.now ?? new Date();
+  const leaseUntil = new Date(now.getTime() + input.leaseDurationMs);
+  const leaseToken = randomUUID();
+  const columns = refCheckpointColumns(input.kind);
   return await getDatabase().transaction(async (transaction) => {
     await transaction
       .insert(githubAccountCheckpoints)
       .values({ account: input.account })
       .onConflictDoNothing({ target: githubAccountCheckpoints.account });
-    await upsertRepository(transaction, input.repository, input.observedAt);
-
-    let queued = 0;
-    for (
-      let offset = 0;
-      offset < rows.length;
-      offset += BACKFILL_OBSERVATION_INSERT_BATCH
-    ) {
-      const persisted = await transaction
-        .insert(githubPushObservations)
-        .values(rows.slice(offset, offset + BACKFILL_OBSERVATION_INSERT_BATCH))
-        .onConflictDoUpdate({
-          set: {
-            completedAt: null,
-            errorCode: null,
-            leaseToken: null,
-            leaseUntil: null,
-            observedAt: input.observedAt,
-            state: "pending",
-          },
-          setWhere: and(
-            eq(githubPushObservations.source, "backfill"),
-            inArray(githubPushObservations.state, ["deferred", "unavailable"])
-          ),
-          target: [
-            githubPushObservations.source,
-            githubPushObservations.sourceId,
-          ],
-        })
-        .returning({ id: githubPushObservations.id });
-      queued += persisted.length;
+    const attemptedValues =
+      input.kind === "head"
+        ? {
+            headRefCycleStartedAt: sql`coalesce(${columns.cycleStartedAt}, ${sql.param(now, columns.cycleStartedAt)})`,
+            headRefLastAttemptedAt: now,
+          }
+        : {
+            tagRefCycleStartedAt: sql`coalesce(${columns.cycleStartedAt}, ${sql.param(now, columns.cycleStartedAt)})`,
+            tagRefLastAttemptedAt: now,
+          };
+    const [leased] = await transaction
+      .update(githubAccountCheckpoints)
+      .set({
+        ...attemptedValues,
+        ...refLeaseValues(input.kind, { leaseToken, leaseUntil }),
+      })
+      .where(
+        and(
+          eq(githubAccountCheckpoints.account, input.account),
+          eq(githubAccountCheckpoints.paused, false),
+          or(isNull(columns.leaseUntil), lte(columns.leaseUntil, now))
+        )
+      )
+      .returning({
+        cursorRepositoryId: columns.cursor,
+        nextPage: columns.nextPage,
+        scanStartedAt: columns.scanStartedAt,
+      });
+    if (leased === undefined) {
+      return null;
     }
-
-    return {
-      duplicates: rows.length - queued,
-      observations: queued,
-      refs: refs.length,
-    };
+    if ((leased.nextPage === null) !== (leased.scanStartedAt === null)) {
+      throw new Error("The GitHub ref scan checkpoint is inconsistent.");
+    }
+    return { ...leased, kind: input.kind, leaseToken };
   });
 };
 
-export const persistGitHubRepositoryRefs = async (input: {
+const updateLeasedRefCheckpoint = async (
+  transaction: DatabaseTransaction,
+  input: {
+    account: TrackedGitHubAccount;
+    cursorRepositoryId: string;
+    kind: GitHubRepositoryRefKind;
+    leaseToken: string;
+    nextPage: number | null;
+    scanStartedAt: Date | null;
+  }
+) => {
+  const columns = refCheckpointColumns(input.kind);
+  const progressValues =
+    input.kind === "head"
+      ? {
+          headRefCursorRepositoryId: input.cursorRepositoryId,
+          headRefNextPage: input.nextPage,
+          headRefScanStartedAt: input.scanStartedAt,
+        }
+      : {
+          tagRefCursorRepositoryId: input.cursorRepositoryId,
+          tagRefNextPage: input.nextPage,
+          tagRefScanStartedAt: input.scanStartedAt,
+        };
+  const updated = await transaction
+    .update(githubAccountCheckpoints)
+    .set(progressValues)
+    .where(
+      and(
+        eq(githubAccountCheckpoints.account, input.account),
+        eq(columns.leaseToken, input.leaseToken)
+      )
+    )
+    .returning({ account: githubAccountCheckpoints.account });
+  if (updated.length !== 1) {
+    throw new GitHubRefReconciliationLeaseLostError();
+  }
+};
+
+const refKindRepositoryValues = (
+  kind: GitHubRepositoryRefKind,
+  reconciledAt: Date
+) =>
+  kind === "head"
+    ? { headsLastReconciledAt: reconciledAt }
+    : { tagsLastReconciledAt: reconciledAt };
+
+const refKindRepositoryColumn = (kind: GitHubRepositoryRefKind) =>
+  kind === "head"
+    ? githubRepositories.headsLastReconciledAt
+    : githubRepositories.tagsLastReconciledAt;
+
+export const persistGitHubRepositoryRefPage = async (input: {
   account: TrackedGitHubAccount;
+  complete: boolean;
+  kind: GitHubRepositoryRefKind;
+  leaseToken: string;
+  nextPage: number | null;
   observedAt: Date;
   refs: readonly GitHubRepositoryRefSnapshot[];
   repository: GitHubRepositoryFacts;
-}): Promise<GitHubRepositoryRefIntakeResult> =>
-  await getDatabase().transaction(async (transaction) => {
+  scanStartedAt: Date;
+}): Promise<GitHubRepositoryRefIntakeResult> => {
+  if (
+    input.refs.some((ref) => ref.kind !== input.kind) ||
+    input.complete !== (input.nextPage === null) ||
+    (!input.complete && input.nextPage !== null && input.nextPage < 2)
+  ) {
+    throw new RangeError("The GitHub reference page state is invalid.");
+  }
+  const refNames = input.refs.map((ref) => ref.refName);
+  if (new Set(refNames).size !== refNames.length) {
+    throw new TypeError("The GitHub reference page contains duplicates.");
+  }
+
+  return await getDatabase().transaction(async (transaction) => {
     await upsertRepository(transaction, input.repository, input.observedAt);
-    const existing = await transaction
+    const [repositoryState] = await transaction
       .select({
-        active: githubRepositoryRefs.active,
-        headSha: githubRepositoryRefs.headSha,
-        lastObservedAt: githubRepositoryRefs.lastObservedAt,
-        refName: githubRepositoryRefs.refName,
+        lastReconciledAt: refKindRepositoryColumn(input.kind),
       })
-      .from(githubRepositoryRefs)
-      .where(eq(githubRepositoryRefs.repositoryId, input.repository.id));
+      .from(githubRepositories)
+      .where(eq(githubRepositories.id, input.repository.id))
+      .limit(1);
+    if (repositoryState === undefined) {
+      throw new Error("The GitHub repository checkpoint could not be read.");
+    }
+    const establishingBaseline = repositoryState.lastReconciledAt === null;
+    const existing =
+      refNames.length === 0
+        ? []
+        : await transaction
+            .select({
+              active: githubRepositoryRefs.active,
+              headSha: githubRepositoryRefs.headSha,
+              lastObservedAt: githubRepositoryRefs.lastObservedAt,
+              refName: githubRepositoryRefs.refName,
+            })
+            .from(githubRepositoryRefs)
+            .where(
+              and(
+                eq(githubRepositoryRefs.repositoryId, input.repository.id),
+                inArray(githubRepositoryRefs.refName, refNames)
+              )
+            );
+    const incomingHeads = [...new Set(input.refs.map((ref) => ref.headSha))];
+    const knownHeads =
+      incomingHeads.length === 0
+        ? []
+        : await transaction
+            .select({ headSha: githubRepositoryRefs.headSha })
+            .from(githubRepositoryRefs)
+            .where(
+              and(
+                eq(githubRepositoryRefs.repositoryId, input.repository.id),
+                eq(githubRepositoryRefs.active, true),
+                inArray(githubRepositoryRefs.headSha, incomingHeads)
+              )
+            );
     const existingByName = new Map(existing.map((ref) => [ref.refName, ref]));
-    const knownActiveHeads = new Set(
-      existing.filter((ref) => ref.active).map((ref) => ref.headSha)
-    );
+    const knownActiveHeads = new Set(knownHeads.map((ref) => ref.headSha));
     const observedRanges = new Set<string>();
     const observations: PushObservationInput[] = [];
-
     for (const ref of input.refs) {
       const previous = existingByName.get(ref.refName);
       if (
         previous !== undefined &&
-        (previous.lastObservedAt > input.observedAt ||
+        (previous.lastObservedAt > input.scanStartedAt ||
           (previous.active && previous.headSha === ref.headSha))
       ) {
         knownActiveHeads.add(ref.headSha);
@@ -467,20 +910,23 @@ export const persistGitHubRepositoryRefs = async (input: {
       }
       const beforeSha = previous?.active === true ? previous.headSha : ZERO_SHA;
       const range = `${beforeSha}:${ref.headSha}`;
-      if (!knownActiveHeads.has(ref.headSha) && !observedRanges.has(range)) {
-        const push: GitHubPush = {
-          before: beforeSha,
-          commitShas: [],
-          head: ref.headSha,
-          pushedBy: input.account,
-          ref: ref.refName,
-          repository: input.repository,
-          size: null,
-        };
+      if (
+        !establishingBaseline &&
+        !knownActiveHeads.has(ref.headSha) &&
+        !observedRanges.has(range)
+      ) {
         observations.push({
           observedAt: input.observedAt,
           providerCreatedAt: null,
-          push,
+          push: {
+            before: beforeSha,
+            commitShas: [],
+            head: ref.headSha,
+            pushedBy: input.account,
+            ref: ref.refName,
+            repository: input.repository,
+            size: null,
+          },
           source: "refs",
           sourceId: refObservationSourceId({
             afterSha: ref.headSha,
@@ -501,10 +947,10 @@ export const persistGitHubRepositoryRefs = async (input: {
         .values(
           input.refs.map((ref) => ({
             active: true,
-            firstObservedAt: input.observedAt,
+            firstObservedAt: input.scanStartedAt,
             headSha: ref.headSha,
             kind: ref.kind,
-            lastObservedAt: input.observedAt,
+            lastObservedAt: input.scanStartedAt,
             refName: ref.refName,
             repositoryId: input.repository.id,
           }))
@@ -514,37 +960,138 @@ export const persistGitHubRepositoryRefs = async (input: {
             active: true,
             headSha: sql`excluded.head_sha`,
             kind: sql`excluded.kind`,
-            lastObservedAt: input.observedAt,
+            lastObservedAt: input.scanStartedAt,
           },
-          setWhere: lte(githubRepositoryRefs.lastObservedAt, input.observedAt),
+          setWhere: lte(
+            githubRepositoryRefs.lastObservedAt,
+            input.scanStartedAt
+          ),
           target: [
             githubRepositoryRefs.repositoryId,
             githubRepositoryRefs.refName,
           ],
         });
     }
-
-    const currentRefNames = input.refs.map((ref) => ref.refName);
-    await transaction
-      .update(githubRepositoryRefs)
-      .set({ active: false, lastObservedAt: input.observedAt })
-      .where(
-        and(
-          eq(githubRepositoryRefs.repositoryId, input.repository.id),
-          eq(githubRepositoryRefs.active, true),
-          lte(githubRepositoryRefs.lastObservedAt, input.observedAt),
-          ...(currentRefNames.length === 0
-            ? []
-            : [notInArray(githubRepositoryRefs.refName, currentRefNames)])
-        )
-      );
-
+    if (input.complete) {
+      await transaction
+        .update(githubRepositoryRefs)
+        .set({ active: false, lastObservedAt: input.scanStartedAt })
+        .where(
+          and(
+            eq(githubRepositoryRefs.repositoryId, input.repository.id),
+            eq(githubRepositoryRefs.kind, input.kind),
+            eq(githubRepositoryRefs.active, true),
+            lt(githubRepositoryRefs.lastObservedAt, input.scanStartedAt)
+          )
+        );
+    }
+    if (input.complete) {
+      await transaction
+        .update(githubRepositories)
+        .set(refKindRepositoryValues(input.kind, input.observedAt))
+        .where(eq(githubRepositories.id, input.repository.id));
+    }
+    await updateLeasedRefCheckpoint(transaction, {
+      account: input.account,
+      cursorRepositoryId: input.repository.id,
+      kind: input.kind,
+      leaseToken: input.leaseToken,
+      nextPage: input.nextPage,
+      scanStartedAt: input.complete ? null : input.scanStartedAt,
+    });
     return {
       knownCommits: persisted.knownCommits,
       pushes: persisted.pushes,
       refs: input.refs.length,
     };
   });
+};
+
+export const skipGitHubRefRepository = async (input: {
+  account: TrackedGitHubAccount;
+  kind: GitHubRepositoryRefKind;
+  leaseToken: string;
+  repositoryId: string;
+}) => {
+  await getDatabase().transaction(async (transaction) => {
+    await updateLeasedRefCheckpoint(transaction, {
+      account: input.account,
+      cursorRepositoryId: input.repositoryId,
+      kind: input.kind,
+      leaseToken: input.leaseToken,
+      nextPage: null,
+      scanStartedAt: null,
+    });
+  });
+};
+
+export const finishGitHubRefReconciliationLease = async (input: {
+  account: TrackedGitHubAccount;
+  complete: boolean;
+  kind: GitHubRepositoryRefKind;
+  leaseToken: string;
+  now?: Date;
+}) => {
+  const now = input.now ?? new Date();
+  const columns = refCheckpointColumns(input.kind);
+  const completionValues =
+    input.kind === "head"
+      ? {
+          ...(input.complete
+            ? {
+                headRefCursorRepositoryId: null,
+                headRefCycleStartedAt: null,
+                headRefNextPage: null,
+                headRefScanStartedAt: null,
+              }
+            : {}),
+          headRefLastSucceededAt: now,
+        }
+      : {
+          ...(input.complete
+            ? {
+                tagRefCursorRepositoryId: null,
+                tagRefCycleStartedAt: null,
+                tagRefNextPage: null,
+                tagRefScanStartedAt: null,
+              }
+            : {}),
+          tagRefLastSucceededAt: now,
+        };
+  const updated = await getDatabase()
+    .update(githubAccountCheckpoints)
+    .set({
+      ...completionValues,
+      ...refLeaseValues(input.kind, { leaseToken: null, leaseUntil: null }),
+    })
+    .where(
+      and(
+        eq(githubAccountCheckpoints.account, input.account),
+        eq(columns.leaseToken, input.leaseToken)
+      )
+    )
+    .returning({ account: githubAccountCheckpoints.account });
+  if (updated.length !== 1) {
+    throw new GitHubRefReconciliationLeaseLostError();
+  }
+};
+
+export const releaseGitHubRefReconciliationLease = async (input: {
+  account: TrackedGitHubAccount;
+  kind: GitHubRepositoryRefKind;
+  leaseToken: string;
+}) => {
+  const columns = refCheckpointColumns(input.kind);
+  await getDatabase()
+    .update(githubAccountCheckpoints)
+    .set(refLeaseValues(input.kind, { leaseToken: null, leaseUntil: null }))
+    .where(
+      and(
+        eq(githubAccountCheckpoints.account, input.account),
+        eq(columns.leaseToken, input.leaseToken)
+      )
+    );
+};
 
 const insertPushObservation = async (
   transaction: DatabaseTransaction,
@@ -619,6 +1166,74 @@ const markWebhookDeliveryAccepted = async (
 const pullRequestState = (pullRequest: GitHubPullRequest) =>
   pullRequest.merged ? ("merged" as const) : pullRequest.state;
 
+const pullRequestTerminalTimestamp = (
+  pullRequest: GitHubPullRequest,
+  state: "closed" | "merged" | "open"
+) => {
+  if (state === "merged") {
+    return pullRequest.mergedAt;
+  }
+  return state === "closed" ? pullRequest.closedAt : null;
+};
+
+const pullRequestAliasEvidenceChanged = (
+  existing: Readonly<{
+    headRepositoryId: string | null;
+    headSha: string | null;
+    providerUpdatedAt: Date;
+    repositoryId: string;
+    state: string;
+  }>,
+  pullRequest: GitHubPullRequest,
+  providerUpdatedAt: Date,
+  state: "closed" | "merged" | "open"
+) =>
+  providerUpdatedAt >= existing.providerUpdatedAt &&
+  (pullRequest.headSha !== existing.headSha ||
+    (pullRequest.headRepository !== null &&
+      pullRequest.headRepository.id !== existing.headRepositoryId) ||
+    pullRequest.repository.id !== existing.repositoryId ||
+    state !== existing.state);
+
+const invalidateChangedPullRequestAliases = async (
+  transaction: DatabaseTransaction,
+  existing:
+    | Readonly<{
+        headRepositoryId: string | null;
+        headSha: string | null;
+        providerUpdatedAt: Date;
+        repositoryId: string;
+        state: string;
+      }>
+    | undefined,
+  pullRequest: GitHubPullRequest,
+  providerUpdatedAt: Date,
+  state: "closed" | "merged" | "open"
+) => {
+  if (
+    existing === undefined ||
+    !pullRequestAliasEvidenceChanged(
+      existing,
+      pullRequest,
+      providerUpdatedAt,
+      state
+    )
+  ) {
+    return;
+  }
+  await invalidateGitHubPullRequestDerivedAliases(
+    transaction,
+    pullRequest.nodeId,
+    [
+      existing.repositoryId,
+      existing.headRepositoryId,
+      pullRequest.repository.id,
+      pullRequest.baseRepository.id,
+      pullRequest.headRepository?.id,
+    ]
+  );
+};
+
 const upsertPullRequest = async (
   transaction: DatabaseTransaction,
   account: TrackedGitHubAccount,
@@ -632,12 +1247,25 @@ const upsertPullRequest = async (
 
   const providerUpdatedAt = new Date(pullRequest.providerUpdatedAt);
   const state = pullRequestState(pullRequest);
-  const terminalTimestamp =
-    state === "merged"
-      ? pullRequest.mergedAt
-      : state === "closed"
-        ? pullRequest.closedAt
-        : null;
+  const [existing] = await transaction
+    .select({
+      headRepositoryId: githubPullRequests.headRepositoryId,
+      headSha: githubPullRequests.headSha,
+      providerUpdatedAt: githubPullRequests.providerUpdatedAt,
+      repositoryId: githubPullRequests.repositoryId,
+      state: githubPullRequests.state,
+    })
+    .from(githubPullRequests)
+    .where(eq(githubPullRequests.nodeId, pullRequest.nodeId))
+    .for("update");
+  await invalidateChangedPullRequestAliases(
+    transaction,
+    existing,
+    pullRequest,
+    providerUpdatedAt,
+    state
+  );
+  const terminalTimestamp = pullRequestTerminalTimestamp(pullRequest, state);
   if (state !== "open" && terminalTimestamp === null) {
     throw new Error("A terminal GitHub pull request has no terminal time.");
   }
@@ -660,7 +1288,10 @@ const upsertPullRequest = async (
     headSha: pullRequest.headSha,
     mergedAt:
       pullRequest.mergedAt === null ? null : new Date(pullRequest.mergedAt),
-    mergeSha: pullRequest.mergeCommitSha,
+    // REST and webhook PR representations are state signals only. GitHub's
+    // GraphQL PullRequest.mergeCommit is the sole merge-SHA authority.
+    mergeSha: null,
+    mergeShaVerifiedAt: null,
     nextReconcileAt: observedAt,
     providerUpdatedAt,
     state,
@@ -690,6 +1321,14 @@ const upsertPullRequest = async (
         commitCount: sql`coalesce(excluded.commit_count, ${githubPullRequests.commitCount})`,
         deletions: sql`coalesce(excluded.deletions, ${githubPullRequests.deletions})`,
         headRepositoryId: sql`coalesce(excluded.head_repository_id, ${githubPullRequests.headRepositoryId})`,
+        mergeSha:
+          state === "merged"
+            ? sql`CASE WHEN ${githubPullRequests.mergeShaVerifiedAt} IS NOT NULL THEN ${githubPullRequests.mergeSha} ELSE NULL END`
+            : null,
+        mergeShaVerifiedAt:
+          state === "merged" ? githubPullRequests.mergeShaVerifiedAt : null,
+        reconcileAttempts: 0,
+        reconcileError: null,
       },
       setWhere: lt(githubPullRequests.providerUpdatedAt, providerUpdatedAt),
       target: githubPullRequests.nodeId,
@@ -709,8 +1348,15 @@ const upsertPullRequest = async (
         .set({
           closedAt: mutableValues.closedAt,
           mergedAt: mutableValues.mergedAt,
-          mergeSha: mutableValues.mergeSha,
+          mergeSha:
+            state === "merged"
+              ? sql`CASE WHEN ${githubPullRequests.mergeShaVerifiedAt} IS NOT NULL THEN ${githubPullRequests.mergeSha} ELSE NULL END`
+              : null,
+          mergeShaVerifiedAt:
+            state === "merged" ? githubPullRequests.mergeShaVerifiedAt : null,
           nextReconcileAt: observedAt,
+          reconcileAttempts: 0,
+          reconcileError: null,
           state,
           terminalAt,
         })
@@ -803,8 +1449,10 @@ const signalKnownPullRequestReconciliation = async (
 ) => {
   const [known] = await transaction
     .select({
+      headRepositoryId: githubPullRequests.headRepositoryId,
       nodeId: githubPullRequests.nodeId,
       providerUpdatedAt: githubPullRequests.providerUpdatedAt,
+      repositoryId: githubPullRequests.repositoryId,
       state: githubPullRequests.state,
     })
     .from(githubPullRequests)
@@ -826,10 +1474,22 @@ const signalKnownPullRequestReconciliation = async (
   const promoteToProvisionalClosed =
     TERMINAL_PULL_REQUEST_EVENT_ACTIONS.has(signal.action) &&
     known.state === "open";
+  const retryEvidenceImproved =
+    occurredAt > known.providerUpdatedAt ||
+    TERMINAL_PULL_REQUEST_EVENT_ACTIONS.has(signal.action);
+  if (promoteToProvisionalClosed) {
+    await invalidateGitHubPullRequestDerivedAliases(transaction, known.nodeId, [
+      known.repositoryId,
+      known.headRepositoryId,
+    ]);
+  }
   await transaction
     .update(githubPullRequests)
     .set({
       nextReconcileAt: observedAt,
+      ...(retryEvidenceImproved
+        ? { reconcileAttempts: 0, reconcileError: null }
+        : {}),
       ...(promoteToProvisionalClosed
         ? {
             closedAt: occurredAt,
@@ -845,6 +1505,36 @@ const signalKnownPullRequestReconciliation = async (
       )
     );
   return true;
+};
+
+const persistPullRequestSignal = async (
+  transaction: DatabaseTransaction,
+  input: {
+    account: TrackedGitHubAccount;
+    eventId: string;
+    observedAt: Date;
+    occurredAt: Date;
+    signal: GitHubPullRequestEventSignal;
+  }
+) => {
+  await transaction
+    .insert(githubPullRequestSignals)
+    .values({
+      account: input.account,
+      action: input.signal.action,
+      eventId: input.eventId,
+      number: input.signal.number,
+      observedAt: input.observedAt,
+      occurredAt: input.occurredAt,
+      repositoryId: input.signal.repository.id,
+      repositoryNameSnapshot: input.signal.repository.fullName,
+    })
+    .onConflictDoNothing({
+      target: [
+        githubPullRequestSignals.account,
+        githubPullRequestSignals.eventId,
+      ],
+    });
 };
 
 const lockWebhookAccount = async (
@@ -1048,6 +1738,8 @@ const updateCheckpoint = async (
   transaction: DatabaseTransaction,
   input: {
     account: TrackedGitHubAccount;
+    eventsEtag?: string | null;
+    eventsNextPollAt?: Date | null;
     expectedCheckpoint: GitHubAccountCheckpoint | null;
     gap: {
       expectedEventId: string;
@@ -1071,6 +1763,10 @@ const updateCheckpoint = async (
       .insert(githubAccountCheckpoints)
       .values({
         account: input.account,
+        eventsEtag: input.eventsEtag ?? null,
+        eventsLastAttemptedAt: now,
+        eventsLastSucceededAt: now,
+        eventsNextPollAt: input.eventsNextPollAt ?? null,
         latestEventId: input.latestEventId,
         ...gapValues,
       })
@@ -1089,13 +1785,31 @@ const updateCheckpoint = async (
           githubAccountCheckpoints.latestEventId,
           input.expectedCheckpoint.latestEventId
         );
+  const pollAttemptCondition =
+    input.expectedCheckpoint.eventsLastAttemptedAt === null
+      ? isNull(githubAccountCheckpoints.eventsLastAttemptedAt)
+      : eq(
+          githubAccountCheckpoints.eventsLastAttemptedAt,
+          input.expectedCheckpoint.eventsLastAttemptedAt
+        );
   const updated = await transaction
     .update(githubAccountCheckpoints)
-    .set({ latestEventId: input.latestEventId, ...gapValues })
+    .set({
+      eventsEtag: input.eventsEtag ?? null,
+      eventsLastAttemptedAt:
+        input.expectedCheckpoint.eventsLastAttemptedAt ?? now,
+      eventsLastSucceededAt: now,
+      ...(input.eventsNextPollAt === undefined
+        ? {}
+        : { eventsNextPollAt: input.eventsNextPollAt }),
+      latestEventId: input.latestEventId,
+      ...gapValues,
+    })
     .where(
       and(
         eq(githubAccountCheckpoints.account, input.account),
         checkpointCondition,
+        pollAttemptCondition,
         eq(githubAccountCheckpoints.paused, input.expectedCheckpoint.paused)
       )
     )
@@ -1108,6 +1822,8 @@ const updateCheckpoint = async (
 export const persistAccountIntake = async (input: {
   account: TrackedGitHubAccount;
   events: readonly GitHubEvent[];
+  eventsEtag?: string | null;
+  eventsNextPollAt?: Date | null;
   expectedCheckpoint: GitHubAccountCheckpoint | null;
   gap: {
     expectedEventId: string;
@@ -1185,17 +1901,26 @@ export const persistAccountIntake = async (input: {
           result.pullRequests += 1;
         }
       }
-      if (
-        event.pullRequestSignal !== undefined &&
-        (await signalKnownPullRequestReconciliation(
+      if (event.pullRequestSignal !== undefined) {
+        const occurredAt = new Date(event.occurredAt);
+        const known = await signalKnownPullRequestReconciliation(
           transaction,
           input.account,
           event.pullRequestSignal,
-          new Date(event.occurredAt),
+          occurredAt,
           now
-        ))
-      ) {
-        result.pullRequests += 1;
+        );
+        if (known) {
+          result.pullRequests += 1;
+        } else {
+          await persistPullRequestSignal(transaction, {
+            account: input.account,
+            eventId: event.id,
+            observedAt: now,
+            occurredAt,
+            signal: event.pullRequestSignal,
+          });
+        }
       }
     }
 

--- a/src/lib/github-commits.ts
+++ b/src/lib/github-commits.ts
@@ -1,7 +1,12 @@
 import { DatabaseConfigurationError, isDatabaseConfigured } from "@/db/client";
 import { env } from "@/env";
-import { fetchGitHub, githubApiUrl, nextGitHubPage } from "@/lib/github-api";
-import type { GitHubBackfillRequest } from "@/lib/github-backfill-core";
+import {
+  fetchGitHub,
+  githubApiUrl,
+  githubNextPollAtFrom,
+  githubResponseEtagFrom,
+  nextGitHubPage,
+} from "@/lib/github-api";
 import {
   authenticatedGitHubAccountFrom,
   githubEventFrom,
@@ -13,15 +18,13 @@ import type {
 } from "@/lib/github-commits-core";
 import {
   CheckpointConflictError,
+  beginGitHubEventPoll,
   isGitHubAccountPaused,
   persistAccountIntake,
   readGitHubAccountCheckpoint,
 } from "@/lib/github-commits-store";
-import {
-  hydrateSparseGitHubPullRequestEvents,
-  queueAccessibleGitHubHistoryBackfill,
-  reconcileAccessibleGitHubRepositoryRefs,
-} from "@/lib/github-reconciliation";
+import type { GitHubRepositoryRefKind } from "@/lib/github-commits-store";
+import { reconcileGitHubRepositoryRefBatch } from "@/lib/github-ref-reconciliation-batch";
 
 const ACCOUNT_TOKEN_VARIABLES = {
   f0rr0: "GITHUB_F0RR0_TOKEN",
@@ -34,20 +37,21 @@ const GITHUB_PAGE_SIZE = 100;
 export interface GitHubAccountSyncResult {
   account: TrackedGitHubAccount;
   checkpointChanged: boolean;
+  deferred: boolean;
   events: number;
   gapRecorded: boolean;
   issues: number;
   knownCommits: number;
+  notModified: boolean;
   paused: boolean;
   pullRequests: number;
   pushes: number;
-  refs: number;
-  repositories: number;
 }
 
 export interface GitHubSyncResult {
   accounts: number;
   checkpoints: number;
+  deferred: number;
   events: number;
   failedAccounts: readonly {
     account: TrackedGitHubAccount;
@@ -56,22 +60,36 @@ export interface GitHubSyncResult {
   gaps: number;
   issues: number;
   knownCommits: number;
+  notModified: number;
   paused: number;
   pullRequests: number;
+  pushes: number;
+}
+
+export interface GitHubAccountRefReconciliationResult {
+  account: TrackedGitHubAccount;
+  complete: boolean;
+  kind: GitHubRepositoryRefKind;
+  knownCommits: number;
+  pages: number;
+  paused: boolean;
   pushes: number;
   refs: number;
   repositories: number;
 }
 
-export interface GitHubBackfillResult {
+export interface GitHubRefReconciliationResult {
   accounts: number;
-  duplicates: number;
+  complete: boolean;
   failedAccounts: readonly {
     account: TrackedGitHubAccount;
     error: string;
   }[];
-  observations: number;
+  knownCommits: number;
+  kind: GitHubRepositoryRefKind;
+  pages: number;
   paused: number;
+  pushes: number;
   refs: number;
   repositories: number;
 }
@@ -92,16 +110,28 @@ const tokenFor = (account: TrackedGitHubAccount) => {
   return token;
 };
 
-const fetchJson = async (url: URL, token: string) => {
-  const response = await fetchGitHub(url, { token });
+interface GitHubCronRequestOptions {
+  deadlineAt?: number;
+}
+
+const fetchJson = async (
+  url: URL,
+  token: string,
+  options: GitHubCronRequestOptions = {}
+) => {
+  const response = await fetchGitHub(url, {
+    deadlineAt: options.deadlineAt,
+    token,
+  });
   return { payload: (await response.json()) as unknown, response };
 };
 
-const assertTokenIdentity = async (
+export const assertGitHubTokenIdentity = async (
   account: TrackedGitHubAccount,
-  token: string
+  token: string,
+  options: GitHubCronRequestOptions = {}
 ) => {
-  const { payload } = await fetchJson(githubApiUrl("/user"), token);
+  const { payload } = await fetchJson(githubApiUrl("/user"), token, options);
   if (authenticatedGitHubAccountFrom(payload) !== account) {
     throw new Error(
       `${ACCOUNT_TOKEN_VARIABLES[account]} is not authenticated as ${account}.`
@@ -110,18 +140,24 @@ const assertTokenIdentity = async (
 };
 
 interface CollectedGitHubEvents {
+  etag: string | null;
   events: readonly GitHubEvent[];
   gap: {
     expectedEventId: string;
     oldestAvailableEventId: string;
   } | null;
   latestEventId: string | null;
+  nextPollAt: Date;
+  notModified: boolean;
 }
 
+// oxlint-disable-next-line eslint/complexity -- Bounded pagination, checkpoint gaps, 304 handling, and provider poll timing fail independently.
 export const collectGitHubEvents = async (
   account: TrackedGitHubAccount,
   token: string,
-  checkpoint: string | null
+  checkpoint: string | null,
+  etag: string | null = null,
+  options: GitHubCronRequestOptions = {}
 ): Promise<CollectedGitHubEvents> => {
   let url: URL | null = githubApiUrl(
     `/users/${encodeURIComponent(account)}/events`
@@ -131,10 +167,36 @@ export const collectGitHubEvents = async (
   let checkpointFound = checkpoint === null;
   let latestEventId: string | null = null;
   let oldestAvailableEventId: string | null = null;
+  let responseEtag: string | null = null;
+  let nextPollAt: Date | null = null;
   const events: GitHubEvent[] = [];
 
   for (let page = 0; url !== null && page < EVENT_PAGES; page += 1) {
-    const { payload, response } = await fetchJson(url, token);
+    const response = await fetchGitHub(url, {
+      deadlineAt: options.deadlineAt,
+      ifNoneMatch: page === 0 ? etag : null,
+      token,
+    });
+    if (page === 0) {
+      nextPollAt = githubNextPollAtFrom(response);
+    }
+    if (response.status === 304) {
+      if (nextPollAt === null) {
+        throw new Error("GitHub returned no event poll interval.");
+      }
+      return {
+        etag,
+        events: [],
+        gap: null,
+        latestEventId: checkpoint,
+        nextPollAt,
+        notModified: true,
+      };
+    }
+    const payload = (await response.json()) as unknown;
+    if (page === 0) {
+      responseEtag = githubResponseEtagFrom(response);
+    }
     if (!Array.isArray(payload)) {
       throw new TypeError("GitHub returned an invalid event response.");
     }
@@ -169,74 +231,92 @@ export const collectGitHubEvents = async (
           oldestAvailableEventId,
         }
       : null;
+  if (nextPollAt === null) {
+    throw new Error("GitHub returned no event poll interval.");
+  }
   return {
+    etag: responseEtag,
     events,
     gap,
     latestEventId: latestEventId ?? checkpoint,
+    nextPollAt,
+    notModified: false,
   };
 };
 
 export const syncGitHubAccount = async (
-  account: TrackedGitHubAccount
+  account: TrackedGitHubAccount,
+  options: GitHubCronRequestOptions = {}
 ): Promise<GitHubAccountSyncResult> => {
   let token: string | null = null;
 
   for (let attempt = 0; attempt < CHECKPOINT_ATTEMPTS; attempt += 1) {
-    const checkpoint = await readGitHubAccountCheckpoint(account);
+    const started = await beginGitHubEventPoll(account);
+    const { checkpoint } = started;
     if (isGitHubAccountPaused(checkpoint)) {
       return {
         account,
         checkpointChanged: false,
+        deferred: false,
         events: 0,
         gapRecorded: false,
         issues: 0,
         knownCommits: 0,
+        notModified: false,
         paused: true,
         pullRequests: 0,
         pushes: 0,
-        refs: 0,
-        repositories: 0,
+      };
+    }
+    if (!started.shouldPoll) {
+      return {
+        account,
+        checkpointChanged: false,
+        deferred: true,
+        events: 0,
+        gapRecorded: false,
+        issues: 0,
+        knownCommits: 0,
+        notModified: false,
+        paused: false,
+        pullRequests: 0,
+        pushes: 0,
       };
     }
     if (token === null) {
       token = tokenFor(account);
-      await assertTokenIdentity(account, token);
+      await assertGitHubTokenIdentity(account, token, options);
     }
     const collected = await collectGitHubEvents(
       account,
       token,
-      checkpoint?.latestEventId ?? null
+      checkpoint.latestEventId,
+      checkpoint.eventsEtag,
+      options
     );
-    const events = await hydrateSparseGitHubPullRequestEvents(
-      collected.events,
-      token
-    );
-
     try {
       const persisted = await persistAccountIntake({
         account,
-        events,
+        events: collected.events,
+        eventsEtag: collected.etag,
+        eventsNextPollAt: collected.nextPollAt,
         expectedCheckpoint: checkpoint,
         gap: collected.gap,
         latestEventId: collected.latestEventId,
       });
-      const refs = await reconcileAccessibleGitHubRepositoryRefs(
-        account,
-        token
-      );
       return {
         account,
         checkpointChanged:
           collected.latestEventId !== (checkpoint?.latestEventId ?? null),
+        deferred: false,
         events: collected.events.length,
         gapRecorded: collected.gap !== null,
         issues: persisted.issues,
-        knownCommits: persisted.knownCommits + refs.knownCommits,
+        knownCommits: persisted.knownCommits,
+        notModified: collected.notModified,
         paused: false,
         pullRequests: persisted.pullRequests,
-        pushes: persisted.pushes + refs.pushes,
-        refs: refs.refs,
-        repositories: refs.repositories,
+        pushes: persisted.pushes,
       };
     } catch (error) {
       if (
@@ -251,7 +331,9 @@ export const syncGitHubAccount = async (
   throw new Error("GitHub checkpoint retry budget exhausted.");
 };
 
-export const syncGitHubAccounts = async (): Promise<GitHubSyncResult> => {
+export const syncGitHubAccounts = async (
+  options: GitHubCronRequestOptions = {}
+): Promise<GitHubSyncResult> => {
   if (!isDatabaseConfigured()) {
     throw new DatabaseConfigurationError();
   }
@@ -259,7 +341,7 @@ export const syncGitHubAccounts = async (): Promise<GitHubSyncResult> => {
   const settled = await Promise.allSettled(
     TRACKED_GITHUB_ACCOUNTS.map(async (account) => ({
       account,
-      result: await syncGitHubAccount(account),
+      result: await syncGitHubAccount(account, options),
     }))
   );
   const results = settled.flatMap((outcome) =>
@@ -283,6 +365,7 @@ export const syncGitHubAccounts = async (): Promise<GitHubSyncResult> => {
   return {
     accounts: results.length,
     checkpoints: results.filter((result) => result.checkpointChanged).length,
+    deferred: results.filter((result) => result.deferred).length,
     events: results.reduce((total, result) => total + result.events, 0),
     failedAccounts,
     gaps: results.filter((result) => result.gapRecorded).length,
@@ -291,74 +374,98 @@ export const syncGitHubAccounts = async (): Promise<GitHubSyncResult> => {
       (total, result) => total + result.knownCommits,
       0
     ),
+    notModified: results.filter((result) => result.notModified).length,
     paused: results.filter((result) => result.paused).length,
     pullRequests: results.reduce(
       (total, result) => total + result.pullRequests,
       0
     ),
     pushes: results.reduce((total, result) => total + result.pushes, 0),
-    refs: results.reduce((total, result) => total + result.refs, 0),
-    repositories: results.reduce(
-      (total, result) => total + result.repositories,
-      0
-    ),
   };
 };
 
-export const queueGitHubBackfill = async (
-  request: GitHubBackfillRequest
-): Promise<GitHubBackfillResult> => {
+export const reconcileGitHubAccountRefs = async (
+  account: TrackedGitHubAccount,
+  options: {
+    deadlineAt: number;
+    kind: GitHubRepositoryRefKind;
+    repositoryLimit: number;
+  }
+): Promise<GitHubAccountRefReconciliationResult> => {
+  const checkpoint = await readGitHubAccountCheckpoint(account);
+  if (isGitHubAccountPaused(checkpoint)) {
+    return {
+      account,
+      complete: true,
+      kind: options.kind,
+      knownCommits: 0,
+      pages: 0,
+      paused: true,
+      pushes: 0,
+      refs: 0,
+      repositories: 0,
+    };
+  }
+  const token = tokenFor(account);
+  await assertGitHubTokenIdentity(account, token, options);
+  return {
+    account,
+    kind: options.kind,
+    paused: false,
+    ...(await reconcileGitHubRepositoryRefBatch({
+      account,
+      deadlineAt: options.deadlineAt,
+      kind: options.kind,
+      repositoryLimit: options.repositoryLimit,
+      token,
+    })),
+  };
+};
+
+export const reconcileGitHubRefs = async (options: {
+  deadlineAt: number;
+  kind: GitHubRepositoryRefKind;
+  repositoryLimit: number;
+}): Promise<GitHubRefReconciliationResult> => {
   if (!isDatabaseConfigured()) {
     throw new DatabaseConfigurationError();
   }
   const settled = await Promise.allSettled(
-    request.accounts.map(async (account) => {
-      const checkpoint = await readGitHubAccountCheckpoint(account);
-      if (isGitHubAccountPaused(checkpoint)) {
-        return { account, paused: true as const, result: null };
-      }
-      const token = tokenFor(account);
-      await assertTokenIdentity(account, token);
-      return {
-        account,
-        paused: false as const,
-        result: await queueAccessibleGitHubHistoryBackfill({
-          account,
-          repositoryId: request.repositoryId,
-          token,
-          windows: request.windows,
-        }),
-      };
-    })
+    TRACKED_GITHUB_ACCOUNTS.map(async (account) => ({
+      account,
+      result: await reconcileGitHubAccountRefs(account, options),
+    }))
   );
-  const succeeded = settled.flatMap((outcome) =>
-    outcome.status === "fulfilled" ? [outcome.value] : []
+  const results = settled.flatMap((outcome) =>
+    outcome.status === "fulfilled" ? [outcome.value.result] : []
   );
-  const failedAccounts = settled.flatMap((outcome, index) =>
-    outcome.status === "fulfilled"
-      ? []
-      : [
-          {
-            account: request.accounts[index],
-            error:
-              outcome.reason instanceof Error
-                ? outcome.reason.name.slice(0, 80)
-                : "UnknownError",
-          },
-        ]
-  );
-  const results = succeeded.flatMap(({ result }) =>
-    result === null ? [] : [result]
-  );
+  const failedAccounts = settled.flatMap((outcome, index) => {
+    if (outcome.status === "fulfilled") {
+      return [];
+    }
+    return [
+      {
+        account: TRACKED_GITHUB_ACCOUNTS[index],
+        error:
+          outcome.reason instanceof Error
+            ? outcome.reason.name.slice(0, 80)
+            : "UnknownError",
+      },
+    ];
+  });
   return {
     accounts: results.length,
-    duplicates: results.reduce((total, result) => total + result.duplicates, 0),
+    complete:
+      failedAccounts.length === 0 && results.every((result) => result.complete),
     failedAccounts,
-    observations: results.reduce(
-      (total, result) => total + result.observations,
+    knownCommits: results.reduce(
+      (total, result) => total + result.knownCommits,
       0
     ),
-    paused: succeeded.filter(({ paused }) => paused).length,
+    kind: options.kind,
+    pages: results.reduce((total, result) => total + result.pages, 0),
+    paused: results.filter((result) => result.paused).length,
+    pushes: results.reduce((total, result) => total + result.pushes, 0),
     refs: results.reduce((total, result) => total + result.refs, 0),
     repositories: results.reduce(
       (total, result) => total + result.repositories,

--- a/src/lib/github-cron-config.ts
+++ b/src/lib/github-cron-config.ts
@@ -1,0 +1,41 @@
+export const GITHUB_EVENTS_CRON_JOB = {
+  name: "github-events-every-five-minutes",
+  schedule: "*/5 * * * *",
+} as const;
+
+export const GITHUB_WORKER_CRON_JOB = {
+  name: "github-activity-worker-every-five-minutes",
+  schedule: "2-57/5 * * * *",
+} as const;
+
+export const GITHUB_HEAD_REFS_CRON_JOB = {
+  name: "github-head-refs-every-fifteen-minutes",
+  schedule: "4,19,34,49 * * * *",
+} as const;
+
+export const GITHUB_TAG_REFS_CRON_JOB = {
+  name: "github-tag-refs-every-fifteen-minutes",
+  schedule: "9,24,39,54 * * * *",
+} as const;
+
+export const GITHUB_REF_REPOSITORY_BATCH_SIZE = 8;
+export const MAXIMUM_GITHUB_REF_REPOSITORY_BATCH_SIZE = 8;
+export const GITHUB_CRON_EXECUTION_DURATION_MS = 90_000;
+
+export const githubRefRepositoryLimitFrom = (value: string | null) => {
+  if (value === null) {
+    return GITHUB_REF_REPOSITORY_BATCH_SIZE;
+  }
+  return /^[1-8]$/.test(value) ? Number(value) : null;
+};
+
+export const githubRefKindFrom = (value: string | null) => {
+  if (value === null || value === "head") {
+    return "head" as const;
+  }
+  return value === "tag" ? ("tag" as const) : null;
+};
+
+export const githubCronStatusFromFailedAccounts = (
+  failedAccounts: readonly unknown[]
+): 200 | 503 => (failedAccounts.length === 0 ? 200 : 503);

--- a/src/lib/github-direct-backfill.ts
+++ b/src/lib/github-direct-backfill.ts
@@ -1,0 +1,384 @@
+import { setTimeout as delay } from "node:timers/promises";
+
+import {
+  fetchGitHub,
+  GitHubRequestDeadlineError,
+  GitHubResponseError,
+  githubApiUrl,
+  nextGitHubPage,
+} from "@/lib/github-api";
+import {
+  commitShaFrom,
+  trackedGitHubAccountFrom,
+} from "@/lib/github-commits-core";
+import type {
+  GitHubCommit,
+  GitHubRepositoryFacts,
+  TrackedGitHubAccount,
+} from "@/lib/github-commits-core";
+import { persistGitHubCommitReferences } from "@/lib/github-commits-store";
+import type { GitHubRepositoryRefSnapshot } from "@/lib/github-commits-store";
+import {
+  collectAccessibleGitHubRepositories,
+  collectGitHubRepositoryRefs,
+} from "@/lib/github-reconciliation";
+
+const DEADLINE_MARGIN_MS = 30_000;
+const GITHUB_PAGE_SIZE = 100;
+const PERSISTENCE_BATCH_SIZE = 1000;
+const RATE_LIMIT_RESET_PADDING_MS = 1000;
+
+type JsonObject = Record<string, unknown>;
+
+const isObject = (value: unknown): value is JsonObject =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const repositoryApiPath = (repository: string, suffix: string) => {
+  const [owner, name, ...rest] = repository.split("/");
+  if (owner === undefined || name === undefined || rest.length > 0) {
+    throw new TypeError("GitHub returned an invalid repository name.");
+  }
+  return `/repos/${encodeURIComponent(owner)}/${encodeURIComponent(name)}${suffix}`;
+};
+
+const deadlineReached = (deadlineAt: number) =>
+  Date.now() + DEADLINE_MARGIN_MS >= deadlineAt;
+
+const withRateLimitWait = async <Value>(
+  operation: () => Promise<Value>,
+  input: {
+    deadlineAt: number;
+    onRateLimitWait?: (retryAt: Date) => void;
+  }
+) => {
+  while (true) {
+    try {
+      return await operation();
+    } catch (error) {
+      if (
+        !(error instanceof GitHubResponseError) ||
+        !error.retryable ||
+        error.retryAt === null
+      ) {
+        throw error;
+      }
+      const waitMilliseconds = Math.max(
+        0,
+        error.retryAt.getTime() - Date.now() + RATE_LIMIT_RESET_PADDING_MS
+      );
+      if (
+        Date.now() + waitMilliseconds + DEADLINE_MARGIN_MS >=
+        input.deadlineAt
+      ) {
+        throw error;
+      }
+      input.onRateLimitWait?.(error.retryAt);
+      await delay(waitMilliseconds);
+    }
+  }
+};
+
+const commitReferenceFrom = (
+  value: unknown,
+  account: TrackedGitHubAccount,
+  repository: GitHubRepositoryFacts
+) => {
+  if (!isObject(value) || !isObject(value.commit)) {
+    throw new TypeError("GitHub returned an invalid commit page.");
+  }
+  const sha = commitShaFrom(value.sha);
+  const returnedAuthor = isObject(value.author)
+    ? trackedGitHubAccountFrom(value.author.login)
+    : null;
+  if (
+    sha === null ||
+    (value.author !== null && returnedAuthor !== account) ||
+    !isObject(value.commit.committer) ||
+    typeof value.commit.committer.date !== "string" ||
+    typeof value.commit.message !== "string"
+  ) {
+    throw new TypeError("GitHub returned an invalid filtered commit.");
+  }
+  const committedAt = new Date(value.commit.committer.date);
+  if (Number.isNaN(committedAt.getTime())) {
+    throw new TypeError("GitHub returned an invalid commit timestamp.");
+  }
+  const message = (value.commit.message.split(/\r?\n/, 1)[0] ?? "")
+    .replaceAll(/\s+/g, " ")
+    .trim()
+    .slice(0, 240);
+  return {
+    author: account,
+    committedAt: committedAt.toISOString(),
+    message,
+    repository: repository.fullName,
+    repositoryId: repository.id,
+    sha,
+    url: `https://github.com/${repository.fullName}/commit/${sha}`,
+  } satisfies GitHubCommit;
+};
+
+const validateNextCommitPage = (
+  next: URL,
+  currentPage: number,
+  input: {
+    account: TrackedGitHubAccount;
+    headSha: string;
+    repository: GitHubRepositoryFacts;
+    sinceAt: Date;
+    untilAt: Date;
+  }
+) => {
+  const expectedPath = repositoryApiPath(input.repository.fullName, "/commits");
+  if (
+    next.pathname !== expectedPath ||
+    next.searchParams.get("author") !== input.account ||
+    next.searchParams.get("page") !== String(currentPage + 1) ||
+    next.searchParams.get("per_page") !== String(GITHUB_PAGE_SIZE) ||
+    next.searchParams.get("sha") !== input.headSha ||
+    next.searchParams.get("since") !== input.sinceAt.toISOString() ||
+    next.searchParams.get("until") !== input.untilAt.toISOString()
+  ) {
+    throw new TypeError("GitHub returned invalid commit pagination.");
+  }
+};
+
+export const collectGitHubCommitsFromHead = async (input: {
+  account: TrackedGitHubAccount;
+  deadlineAt: number;
+  headSha: string;
+  onRateLimitWait?: (retryAt: Date) => void;
+  repository: GitHubRepositoryFacts;
+  sinceAt: Date;
+  token: string;
+  untilAt: Date;
+}) => {
+  let page = 1;
+  let url: URL | null = githubApiUrl(
+    repositoryApiPath(input.repository.fullName, "/commits")
+  );
+  url.searchParams.set("author", input.account);
+  url.searchParams.set("page", String(page));
+  url.searchParams.set("per_page", String(GITHUB_PAGE_SIZE));
+  url.searchParams.set("sha", input.headSha);
+  url.searchParams.set("since", input.sinceAt.toISOString());
+  url.searchParams.set("until", input.untilAt.toISOString());
+  const commits: GitHubCommit[] = [];
+  const seenPages = new Set<string>();
+  let pages = 0;
+
+  while (url !== null) {
+    if (deadlineReached(input.deadlineAt)) {
+      throw new GitHubRequestDeadlineError();
+    }
+    if (seenPages.has(url.href)) {
+      throw new TypeError("GitHub returned cyclic commit pagination.");
+    }
+    seenPages.add(url.href);
+    const requestUrl = url;
+    const response = await withRateLimitWait(
+      async () =>
+        await fetchGitHub(requestUrl, {
+          deadlineAt: input.deadlineAt,
+          token: input.token,
+        }),
+      input
+    );
+    const payload = (await response.json()) as unknown;
+    if (!Array.isArray(payload)) {
+      throw new TypeError("GitHub returned an invalid commit page.");
+    }
+    for (const value of payload) {
+      const commit = commitReferenceFrom(
+        value,
+        input.account,
+        input.repository
+      );
+      const committedAt = new Date(commit.committedAt).getTime();
+      if (
+        committedAt >= input.sinceAt.getTime() &&
+        committedAt <= input.untilAt.getTime()
+      ) {
+        commits.push(commit);
+      }
+    }
+    pages += 1;
+    const next = nextGitHubPage(response);
+    if (next !== null) {
+      validateNextCommitPage(next, page, input);
+      page += 1;
+    }
+    url = next;
+  }
+  return { commits, pages };
+};
+
+export const distinctGitHubCurrentRefHeads = (
+  refs: readonly GitHubRepositoryRefSnapshot[]
+) => {
+  const distinct = new Map<string, string>();
+  for (const ref of refs.toSorted((left, right) => {
+    if (left.kind !== right.kind) {
+      return left.kind === "head" ? -1 : 1;
+    }
+    return left.refName < right.refName
+      ? -1
+      : left.refName > right.refName
+        ? 1
+        : 0;
+  })) {
+    if (!distinct.has(ref.headSha)) {
+      distinct.set(ref.headSha, ref.refName);
+    }
+  }
+  return [...distinct].map(([headSha, refName]) => ({ headSha, refName }));
+};
+
+export type GitHubDirectBackfillStopReason =
+  | "complete"
+  | "deadline"
+  | "provider_retry";
+
+export interface GitHubDirectBackfillResult {
+  complete: boolean;
+  duplicateCommits: number;
+  duplicateReachability: number;
+  heads: number;
+  insertedCommits: number;
+  pages: number;
+  refs: number;
+  repositories: number;
+  retryAt: Date | null;
+  stopReason: GitHubDirectBackfillStopReason;
+  uniqueCommits: number;
+}
+
+const emptyResult = (): GitHubDirectBackfillResult => ({
+  complete: true,
+  duplicateCommits: 0,
+  duplicateReachability: 0,
+  heads: 0,
+  insertedCommits: 0,
+  pages: 0,
+  refs: 0,
+  repositories: 0,
+  retryAt: null,
+  stopReason: "complete",
+  uniqueCommits: 0,
+});
+
+const stoppedResult = (result: GitHubDirectBackfillResult, error: unknown) => {
+  if (error instanceof GitHubRequestDeadlineError) {
+    return { ...result, complete: false, stopReason: "deadline" as const };
+  }
+  if (error instanceof GitHubResponseError && error.retryable) {
+    return {
+      ...result,
+      complete: false,
+      retryAt: error.retryAt,
+      stopReason: "provider_retry" as const,
+    };
+  }
+  throw error;
+};
+
+/**
+ * Discovers tracked commits directly from every distinct current ref head.
+ * Refs are inventoried once for the whole requested window; heads precede tags
+ * and all traversal is deterministic so an idempotent rerun repeats safely.
+ */
+export const backfillGitHubCommitsFromCurrentRefs = async (input: {
+  account: TrackedGitHubAccount;
+  deadlineAt: number;
+  onRateLimitWait?: (retryAt: Date) => void;
+  repositoryId: string | null;
+  sinceAt: Date;
+  token: string;
+  untilAt: Date;
+}): Promise<GitHubDirectBackfillResult> => {
+  if (
+    Number.isNaN(input.sinceAt.getTime()) ||
+    Number.isNaN(input.untilAt.getTime()) ||
+    input.sinceAt > input.untilAt
+  ) {
+    throw new RangeError("The GitHub direct backfill window is invalid.");
+  }
+  const result = emptyResult();
+  const buffered: GitHubCommit[] = [];
+  const seenCommits = new Set<string>();
+  const flush = async () => {
+    if (buffered.length === 0) {
+      return;
+    }
+    const persisted = await persistGitHubCommitReferences({
+      commits: buffered.splice(0),
+    });
+    result.insertedCommits += persisted.inserted;
+    result.duplicateCommits += persisted.duplicates;
+  };
+
+  try {
+    const repositories = await withRateLimitWait(
+      async () =>
+        await collectAccessibleGitHubRepositories(
+          input.token,
+          input.repositoryId,
+          { deadlineAt: input.deadlineAt }
+        ),
+      input
+    );
+    for (const repository of repositories) {
+      if (deadlineReached(input.deadlineAt)) {
+        throw new GitHubRequestDeadlineError();
+      }
+      const refs = await withRateLimitWait(
+        async () =>
+          await collectGitHubRepositoryRefs(repository, input.token, {
+            deadlineAt: input.deadlineAt,
+          }),
+        input
+      );
+      if (refs === null) {
+        await flush();
+        return {
+          ...result,
+          complete: false,
+          stopReason: "provider_retry",
+        };
+      }
+      result.repositories += 1;
+      result.refs += refs.length;
+      const distinctHeads = distinctGitHubCurrentRefHeads(refs);
+      for (const { headSha } of distinctHeads) {
+        if (deadlineReached(input.deadlineAt)) {
+          throw new GitHubRequestDeadlineError();
+        }
+        const page = await collectGitHubCommitsFromHead({
+          ...input,
+          headSha,
+          repository,
+        });
+        result.heads += 1;
+        result.pages += page.pages;
+        for (const commit of page.commits) {
+          const identity = `${commit.repositoryId}:${commit.sha}`;
+          if (seenCommits.has(identity)) {
+            result.duplicateReachability += 1;
+            continue;
+          }
+          seenCommits.add(identity);
+          buffered.push(commit);
+          result.uniqueCommits += 1;
+          if (buffered.length >= PERSISTENCE_BATCH_SIZE) {
+            await flush();
+          }
+        }
+      }
+    }
+    await flush();
+    return result;
+  } catch (error) {
+    await flush();
+    return stoppedResult(result, error);
+  }
+};

--- a/src/lib/github-pull-request-backfill.ts
+++ b/src/lib/github-pull-request-backfill.ts
@@ -1,0 +1,991 @@
+import { setTimeout as delay } from "node:timers/promises";
+
+import {
+  ActivityProcessingError,
+  fetchGitHubPullRequestMembershipWithToken,
+  fetchGitHubPullRequestRestSnapshotWithToken,
+  GitHubGraphQlResponseError,
+  githubGraphQlPayloadFrom,
+  resolveGitHubPullRequestMergeCommits,
+} from "@/lib/github-activity-processor";
+import type {
+  GitHubActivityPullRequestMembershipSource,
+  GitHubActivityPullRequestReference,
+  GitHubActivityPullRequestSnapshot,
+} from "@/lib/github-activity-processor";
+import {
+  persistGitHubPullRequestMembership,
+  persistGitHubPullRequestSnapshot,
+} from "@/lib/github-activity-worker-store";
+import type { StoredPullRequestSnapshot } from "@/lib/github-activity-worker-store";
+import {
+  fetchGitHub,
+  GitHubRequestDeadlineError,
+  GitHubResponseError,
+  githubApiUrl,
+  nextGitHubPage,
+} from "@/lib/github-api";
+import type {
+  GitHubCommit,
+  GitHubPullRequest,
+  GitHubRepositoryFacts,
+  TrackedGitHubAccount,
+} from "@/lib/github-commits-core";
+import {
+  repositoryFullNameFrom,
+  repositoryIdFrom,
+} from "@/lib/github-commits-core";
+import { persistGitHubCommitReferences } from "@/lib/github-commits-store";
+import { collectAccessibleGitHubRepositories } from "@/lib/github-reconciliation";
+
+const GITHUB_PAGE_SIZE = 100;
+const PULL_REQUEST_PROCESSING_BATCH_SIZE = 10;
+const DEADLINE_MARGIN_MS = 30_000;
+const RATE_LIMIT_RESET_PADDING_MS = 1000;
+const AUTHORED_PULL_REQUEST_PAGE_SIZE = 100;
+
+const AUTHORED_PULL_REQUESTS_QUERY = `query AuthoredPullRequests($login: String!, $cursor: String, $pageSize: Int!) {
+  user(login: $login) {
+    login
+    pullRequests(
+      first: $pageSize
+      after: $cursor
+      orderBy: { field: CREATED_AT, direction: DESC }
+    ) {
+      totalCount
+      nodes {
+        id
+        number
+        updatedAt
+        url
+        author { login }
+        repository { databaseId nameWithOwner }
+      }
+      pageInfo { hasNextPage endCursor }
+    }
+  }
+}`;
+
+const repositoryApiPath = (repository: string, suffix: string) => {
+  const [owner, name, ...rest] = repository.split("/");
+  if (owner === undefined || name === undefined || rest.length > 0) {
+    throw new TypeError("GitHub returned an invalid repository name.");
+  }
+  return `/repos/${encodeURIComponent(owner)}/${encodeURIComponent(name)}${suffix}`;
+};
+
+type JsonObject = Record<string, unknown>;
+
+const isObject = (value: unknown): value is JsonObject =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const nonNegativeIntegerFrom = (value: unknown) =>
+  typeof value === "number" && Number.isSafeInteger(value) && value >= 0
+    ? value
+    : null;
+
+const positiveIntegerFrom = (value: unknown) => {
+  const integer = nonNegativeIntegerFrom(value);
+  return integer !== null && integer > 0 ? integer : null;
+};
+
+const deadlineReached = (deadlineAt: number) =>
+  Date.now() + DEADLINE_MARGIN_MS >= deadlineAt;
+
+const providerRetryFrom = (error: unknown) => {
+  if (
+    error instanceof GitHubResponseError &&
+    (error.retryable || error.status === 404)
+  ) {
+    return { retryAt: error.retryAt };
+  }
+  if (error instanceof GitHubGraphQlResponseError && error.retryable) {
+    return { retryAt: error.retryAt };
+  }
+  return null;
+};
+
+const withProviderRetryWait = async <Value>(
+  operation: () => Promise<Value>,
+  input: {
+    deadlineAt: number;
+    onRateLimitWait?: (retryAt: Date) => void;
+  }
+) => {
+  while (true) {
+    try {
+      return await operation();
+    } catch (error) {
+      const retry = providerRetryFrom(error);
+      if (retry?.retryAt === null || retry === null) {
+        throw error;
+      }
+      const waitMilliseconds = Math.max(
+        0,
+        retry.retryAt.getTime() - Date.now() + RATE_LIMIT_RESET_PADDING_MS
+      );
+      if (
+        Date.now() + waitMilliseconds + DEADLINE_MARGIN_MS >=
+        input.deadlineAt
+      ) {
+        throw error;
+      }
+      input.onRateLimitWait?.(retry.retryAt);
+      await delay(waitMilliseconds);
+    }
+  }
+};
+
+export interface GitHubPullRequestBackfillCandidate extends GitHubActivityPullRequestReference {
+  nodeId: string;
+  providerUpdatedAt: string;
+}
+
+export interface GitHubPullRequestBackfillCandidateCollection {
+  complete: boolean;
+  pullRequests: readonly GitHubPullRequestBackfillCandidate[];
+}
+
+export interface GitHubAuthoredPullRequestBackfillCandidateCollection {
+  pages: number;
+  pullRequests: readonly GitHubPullRequestBackfillCandidate[];
+  totalCount: number;
+}
+
+const authoredPullRequestCandidateFrom = (
+  value: unknown,
+  account: TrackedGitHubAccount
+) => {
+  if (
+    !isObject(value) ||
+    !isObject(value.author) ||
+    !isObject(value.repository)
+  ) {
+    throw new TypeError("GitHub returned an invalid authored pull request.");
+  }
+  const repositoryId = repositoryIdFrom(value.repository.databaseId);
+  const repository = repositoryFullNameFrom(value.repository.nameWithOwner);
+  const number = positiveIntegerFrom(value.number);
+  const nodeId =
+    typeof value.id === "string" &&
+    value.id.length > 0 &&
+    value.id.length <= 100 &&
+    !/\s/u.test(value.id)
+      ? value.id
+      : null;
+  const providerUpdatedAt =
+    typeof value.updatedAt === "string"
+      ? new Date(value.updatedAt)
+      : new Date(Number.NaN);
+  if (
+    typeof value.author.login !== "string" ||
+    value.author.login.toLowerCase() !== account ||
+    repositoryId === null ||
+    repository === null ||
+    number === null ||
+    nodeId === null ||
+    Number.isNaN(providerUpdatedAt.getTime()) ||
+    value.url !== `https://github.com/${repository}/pull/${String(number)}`
+  ) {
+    throw new TypeError("GitHub returned an invalid authored pull request.");
+  }
+  return {
+    account,
+    nodeId,
+    number,
+    providerUpdatedAt: providerUpdatedAt.toISOString(),
+    repository,
+    repositoryId,
+  } satisfies GitHubPullRequestBackfillCandidate;
+};
+
+const samePullRequestIdentity = (
+  left: GitHubPullRequestBackfillCandidate,
+  right: GitHubPullRequestBackfillCandidate
+) =>
+  left.account === right.account &&
+  left.nodeId === right.nodeId &&
+  left.number === right.number &&
+  left.repository === right.repository &&
+  left.repositoryId === right.repositoryId;
+
+export const mergeGitHubPullRequestBackfillCandidates = (
+  candidates: Map<string, GitHubPullRequestBackfillCandidate>,
+  incoming: readonly GitHubPullRequestBackfillCandidate[]
+) => {
+  for (const candidate of incoming) {
+    const existing = candidates.get(candidate.nodeId);
+    if (
+      existing !== undefined &&
+      !samePullRequestIdentity(existing, candidate)
+    ) {
+      throw new TypeError("GitHub returned conflicting pull requests.");
+    }
+    if (
+      existing === undefined ||
+      candidate.providerUpdatedAt > existing.providerUpdatedAt
+    ) {
+      candidates.set(candidate.nodeId, candidate);
+    }
+  }
+  return candidates;
+};
+
+/**
+ * Independently enumerates PRs authored by the tracked account. Unlike
+ * `/user/repos`, this connection includes PRs whose base is an unrelated
+ * public repository. The cursor is intentionally unbounded; total and unique
+ * progress checks make a mutable or incomplete connection fail closed.
+ */
+// oxlint-disable eslint/complexity -- Every page, identity, count, progress, and cursor invariant fails closed independently.
+export const collectGitHubAuthoredPullRequestBackfillCandidates =
+  async (input: {
+    account: TrackedGitHubAccount;
+    deadlineAt: number;
+    token: string;
+  }): Promise<GitHubAuthoredPullRequestBackfillCandidateCollection> => {
+    const candidates = new Map<string, GitHubPullRequestBackfillCandidate>();
+    const visitedCursors = new Set<string>();
+    let cursor: string | null = null;
+    let expectedTotal: number | null = null;
+    let pages = 0;
+    let observedNodes = 0;
+
+    while (true) {
+      if (deadlineReached(input.deadlineAt)) {
+        throw new GitHubRequestDeadlineError();
+      }
+      const response = await fetchGitHub(githubApiUrl("/graphql"), {
+        body: JSON.stringify({
+          query: AUTHORED_PULL_REQUESTS_QUERY,
+          variables: {
+            cursor,
+            login: input.account,
+            pageSize: AUTHORED_PULL_REQUEST_PAGE_SIZE,
+          },
+        }),
+        deadlineAt: input.deadlineAt,
+        method: "POST",
+        token: input.token,
+      });
+      const payload = await githubGraphQlPayloadFrom(response);
+      const user = isObject(payload.data) ? payload.data.user : null;
+      const connection = isObject(user) ? user.pullRequests : null;
+      const totalCount = isObject(connection)
+        ? nonNegativeIntegerFrom(connection.totalCount)
+        : null;
+      const nodes = isObject(connection) ? connection.nodes : null;
+      const pageInfo = isObject(connection) ? connection.pageInfo : null;
+      if (
+        !isObject(user) ||
+        typeof user.login !== "string" ||
+        user.login.toLowerCase() !== input.account ||
+        !Array.isArray(nodes) ||
+        nodes.length > AUTHORED_PULL_REQUEST_PAGE_SIZE ||
+        !isObject(pageInfo) ||
+        typeof pageInfo.hasNextPage !== "boolean" ||
+        totalCount === null ||
+        (expectedTotal !== null && totalCount !== expectedTotal) ||
+        observedNodes + nodes.length > totalCount
+      ) {
+        throw new TypeError(
+          "GitHub returned an invalid authored pull request connection."
+        );
+      }
+      expectedTotal ??= totalCount;
+      const previousSize = candidates.size;
+      const pageCandidates = nodes.map((node) =>
+        authoredPullRequestCandidateFrom(node, input.account)
+      );
+      mergeGitHubPullRequestBackfillCandidates(candidates, pageCandidates);
+      observedNodes += nodes.length;
+      pages += 1;
+
+      if (!pageInfo.hasNextPage) {
+        if (
+          observedNodes !== expectedTotal ||
+          candidates.size !== expectedTotal
+        ) {
+          throw new TypeError(
+            "GitHub returned incomplete authored pull request pagination."
+          );
+        }
+        return {
+          pages,
+          pullRequests: [...candidates.values()],
+          totalCount: expectedTotal,
+        };
+      }
+
+      const nextCursor = pageInfo.endCursor;
+      if (
+        nodes.length === 0 ||
+        candidates.size === previousSize ||
+        typeof nextCursor !== "string" ||
+        nextCursor.length === 0 ||
+        nextCursor.length > 2048 ||
+        visitedCursors.has(nextCursor)
+      ) {
+        throw new TypeError(
+          "GitHub returned invalid authored pull request pagination."
+        );
+      }
+      visitedCursors.add(nextCursor);
+      cursor = nextCursor;
+    }
+  };
+// oxlint-enable eslint/complexity
+
+const pullRequestCandidateFromListValue = (
+  value: unknown,
+  input: {
+    account: TrackedGitHubAccount;
+    repository: GitHubRepositoryFacts;
+  }
+) => {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return null;
+  }
+  const root = value as Record<string, unknown>;
+  const {
+    html_url: htmlUrl,
+    node_id: nodeId,
+    number,
+    updated_at: providerUpdatedAt,
+  } = root;
+  const updatedAt =
+    typeof providerUpdatedAt === "string"
+      ? new Date(providerUpdatedAt)
+      : new Date(Number.NaN);
+  if (
+    !Number.isSafeInteger(number) ||
+    Number(number) < 1 ||
+    typeof nodeId !== "string" ||
+    nodeId.length === 0 ||
+    nodeId.length > 100 ||
+    Number.isNaN(updatedAt.getTime()) ||
+    htmlUrl !==
+      `https://github.com/${input.repository.fullName}/pull/${String(number)}`
+  ) {
+    return null;
+  }
+  return {
+    account: input.account,
+    nodeId,
+    number: Number(number),
+    providerUpdatedAt: updatedAt.toISOString(),
+    repository: input.repository.fullName,
+    repositoryId: input.repository.id,
+  } satisfies GitHubPullRequestBackfillCandidate;
+};
+
+const validateNextPullRequestPage = (
+  next: URL,
+  currentPage: number,
+  repository: GitHubRepositoryFacts
+) => {
+  if (
+    next.pathname !== repositoryApiPath(repository.fullName, "/pulls") ||
+    next.searchParams.get("direction") !== "desc" ||
+    next.searchParams.get("page") !== String(currentPage + 1) ||
+    next.searchParams.get("per_page") !== String(GITHUB_PAGE_SIZE) ||
+    next.searchParams.get("sort") !== "updated" ||
+    next.searchParams.get("state") !== "all"
+  ) {
+    throw new TypeError("GitHub returned invalid pull request pagination.");
+  }
+};
+
+/** Enumerates every PR because Git commit timestamps can be arbitrary. */
+export const collectGitHubPullRequestBackfillCandidates = async (input: {
+  account: TrackedGitHubAccount;
+  deadlineAt: number;
+  onRateLimitWait?: (retryAt: Date) => void;
+  repository: GitHubRepositoryFacts;
+  token: string;
+}): Promise<GitHubPullRequestBackfillCandidateCollection> => {
+  let url: URL | null = githubApiUrl(
+    repositoryApiPath(input.repository.fullName, "/pulls")
+  );
+  url.searchParams.set("direction", "desc");
+  url.searchParams.set("page", "1");
+  url.searchParams.set("per_page", String(GITHUB_PAGE_SIZE));
+  url.searchParams.set("sort", "updated");
+  url.searchParams.set("state", "all");
+  const pullRequests = new Map<string, GitHubPullRequestBackfillCandidate>();
+  const visited = new Set<string>();
+  let previousUpdatedAt = Number.POSITIVE_INFINITY;
+  let page = 1;
+
+  while (url !== null) {
+    if (deadlineReached(input.deadlineAt)) {
+      return { complete: false, pullRequests: [...pullRequests.values()] };
+    }
+    if (visited.has(url.href)) {
+      throw new TypeError("GitHub returned cyclic pull request pagination.");
+    }
+    visited.add(url.href);
+    const requestUrl = url;
+    const response = await withProviderRetryWait(
+      async () =>
+        await fetchGitHub(requestUrl, {
+          deadlineAt: input.deadlineAt,
+          token: input.token,
+        }),
+      input
+    );
+    const payload = (await response.json()) as unknown;
+    if (!Array.isArray(payload)) {
+      throw new TypeError("GitHub returned an invalid pull request page.");
+    }
+
+    for (const value of payload) {
+      const candidate = pullRequestCandidateFromListValue(value, input);
+      if (candidate === null) {
+        throw new TypeError("GitHub returned an invalid pull request page.");
+      }
+      const updatedAt = new Date(candidate.providerUpdatedAt).getTime();
+      if (updatedAt > previousUpdatedAt) {
+        throw new TypeError(
+          "GitHub returned pull requests outside descending updated order."
+        );
+      }
+      previousUpdatedAt = updatedAt;
+      const existing = pullRequests.get(candidate.nodeId);
+      if (
+        existing !== undefined &&
+        (existing.number !== candidate.number ||
+          existing.repositoryId !== candidate.repositoryId)
+      ) {
+        throw new TypeError("GitHub returned conflicting pull requests.");
+      }
+      pullRequests.set(candidate.nodeId, candidate);
+    }
+    const next = nextGitHubPage(response);
+    if (next !== null) {
+      validateNextPullRequestPage(next, page, input.repository);
+      page += 1;
+    }
+    url = next;
+  }
+  return { complete: true, pullRequests: [...pullRequests.values()] };
+};
+
+export type GitHubPullRequestBackfillStopReason =
+  | "complete"
+  | "deadline"
+  | "provider_retry";
+
+export interface GitHubPullRequestBackfillResult {
+  authoredPullRequestPages: number;
+  authoredPullRequests: number;
+  commits: number;
+  complete: boolean;
+  duplicateCommits: number;
+  memberships: number;
+  pullRequests: number;
+  repositories: number;
+  retryAt: Date | null;
+  scannedPullRequests: number;
+  skippedPullRequests: number;
+  stopReason: GitHubPullRequestBackfillStopReason;
+}
+
+interface PreparedPullRequest {
+  commits: readonly GitHubCommit[];
+  membership: GitHubActivityPullRequestMembershipSource;
+  snapshot: GitHubActivityPullRequestSnapshot;
+}
+
+const emptyResult = (): GitHubPullRequestBackfillResult => ({
+  authoredPullRequestPages: 0,
+  authoredPullRequests: 0,
+  commits: 0,
+  complete: true,
+  duplicateCommits: 0,
+  memberships: 0,
+  pullRequests: 0,
+  repositories: 0,
+  retryAt: null,
+  scannedPullRequests: 0,
+  skippedPullRequests: 0,
+  stopReason: "complete",
+});
+
+const isDeadlineError = (error: unknown) =>
+  error instanceof GitHubRequestDeadlineError;
+
+const withinInclusiveWindow = (
+  commit: GitHubCommit,
+  sinceAt: Date,
+  untilAt: Date
+) => {
+  const committedAt = new Date(commit.committedAt).getTime();
+  return committedAt >= sinceAt.getTime() && committedAt <= untilAt.getTime();
+};
+
+export const githubPullRequestBelongsInBackfillWindow = (input: {
+  account: TrackedGitHubAccount;
+  commits: readonly GitHubCommit[];
+  pullRequest: Pick<GitHubPullRequest, "authorAccount" | "mergedAt">;
+  sinceAt: Date;
+  untilAt: Date;
+}) => {
+  const mergedAt =
+    input.pullRequest.mergedAt === null
+      ? null
+      : new Date(input.pullRequest.mergedAt);
+  return (
+    input.commits.some(
+      (commit) =>
+        commit.author === input.account &&
+        withinInclusiveWindow(commit, input.sinceAt, input.untilAt)
+    ) ||
+    (input.pullRequest.authorAccount === input.account &&
+      mergedAt !== null &&
+      mergedAt >= input.sinceAt &&
+      mergedAt <= input.untilAt)
+  );
+};
+
+const withResolvedMergeCommits = async (
+  prepared: readonly PreparedPullRequest[],
+  token: string,
+  deadlineAt: number
+) => {
+  const merged = prepared.filter(({ snapshot }) => snapshot.pullRequest.merged);
+  const resolutions = await resolveGitHubPullRequestMergeCommits(
+    merged.map(({ snapshot }) => snapshot.pullRequest.nodeId),
+    token,
+    { deadlineAt }
+  );
+  const mergeCommitShas = new Map(
+    resolutions.map(({ mergeCommitSha, nodeId }) => [nodeId, mergeCommitSha])
+  );
+  return prepared.map((item) => {
+    if (!item.snapshot.pullRequest.merged) {
+      return item;
+    }
+    const mergeCommitSha = mergeCommitShas.get(
+      item.snapshot.pullRequest.nodeId
+    );
+    if (!mergeCommitShas.has(item.snapshot.pullRequest.nodeId)) {
+      throw new GitHubGraphQlResponseError("unresolved_merge_commit", {
+        retryable: true,
+      });
+    }
+    return {
+      ...item,
+      snapshot: {
+        ...item.snapshot,
+        pullRequest: { ...item.snapshot.pullRequest, mergeCommitSha },
+      },
+    };
+  });
+};
+
+export const persistGitHubPullRequestBackfillMembership = async (input: {
+  commitShas: readonly string[];
+  headSha: string;
+  membershipComplete: boolean;
+  persist?: typeof persistGitHubPullRequestMembership;
+  stored: StoredPullRequestSnapshot;
+}) => {
+  if (!input.stored.membershipRefreshRequired) {
+    return { complete: true, refreshed: false } as const;
+  }
+  const persist = input.persist ?? persistGitHubPullRequestMembership;
+  return {
+    complete: await persist(
+      input.stored,
+      input.headSha,
+      input.commitShas,
+      input.membershipComplete
+    ),
+    refreshed: true,
+  } as const;
+};
+
+const persistPreparedPullRequests = async (
+  prepared: readonly PreparedPullRequest[],
+  account: TrackedGitHubAccount,
+  result: GitHubPullRequestBackfillResult
+) => {
+  for (const item of prepared) {
+    const stored = await persistGitHubPullRequestSnapshot(
+      account,
+      item.snapshot.pullRequest,
+      { refreshMembership: true }
+    );
+    if (stored === null) {
+      result.skippedPullRequests += 1;
+      continue;
+    }
+    const commits = await persistGitHubCommitReferences({
+      commits: item.commits,
+    });
+    const membership = await persistGitHubPullRequestBackfillMembership({
+      commitShas: item.membership.commitShas,
+      headSha: item.snapshot.pullRequest.headSha,
+      membershipComplete: item.membership.membershipComplete,
+      stored,
+    });
+    if (!membership.complete) {
+      throw new ActivityProcessingError(
+        "source_incomplete",
+        "GitHub pull request membership was not persisted completely."
+      );
+    }
+    result.commits += commits.inserted;
+    result.duplicateCommits += commits.duplicates;
+    if (membership.refreshed) {
+      result.memberships += 1;
+    }
+    result.pullRequests += 1;
+  }
+};
+
+const preparePullRequest = async (input: {
+  account: TrackedGitHubAccount;
+  candidate: GitHubPullRequestBackfillCandidate;
+  deadlineAt: number;
+  sinceAt: Date;
+  token: string;
+  untilAt: Date;
+}): Promise<PreparedPullRequest | null> => {
+  const snapshot = await fetchGitHubPullRequestRestSnapshotWithToken(
+    input.candidate,
+    input.token,
+    { deadlineAt: input.deadlineAt }
+  );
+  const commitRepository =
+    snapshot.pullRequest.headRepository ?? snapshot.pullRequest.baseRepository;
+  const membership = await fetchGitHubPullRequestMembershipWithToken(
+    input.candidate,
+    snapshot.expectedCommitCount,
+    input.token,
+    {
+      commitRepository,
+      deadlineAt: input.deadlineAt,
+      expectedHeadSha: snapshot.pullRequest.headSha,
+    }
+  );
+  if (!membership.membershipComplete) {
+    throw new ActivityProcessingError(
+      "source_incomplete",
+      "GitHub returned incomplete pull request membership."
+    );
+  }
+  const commits = membership.commits.filter(
+    (commit) =>
+      commit.author === input.account &&
+      withinInclusiveWindow(commit, input.sinceAt, input.untilAt)
+  );
+  return githubPullRequestBelongsInBackfillWindow({
+    account: input.account,
+    commits,
+    pullRequest: snapshot.pullRequest,
+    sinceAt: input.sinceAt,
+    untilAt: input.untilAt,
+  })
+    ? { commits, membership, snapshot }
+    : null;
+};
+
+const stop = (
+  result: GitHubPullRequestBackfillResult,
+  reason: Exclude<GitHubPullRequestBackfillStopReason, "complete">,
+  retryAt: Date | null = null
+) => ({
+  ...result,
+  complete: false,
+  retryAt,
+  stopReason: reason,
+});
+
+interface PullRequestProcessingInterruption {
+  reason: "deadline" | "provider_retry";
+  retryAt: Date | null;
+}
+
+const comparePullRequestCandidates = (
+  left: GitHubPullRequestBackfillCandidate,
+  right: GitHubPullRequestBackfillCandidate
+) => {
+  const leftRepositoryId = BigInt(left.repositoryId);
+  const rightRepositoryId = BigInt(right.repositoryId);
+  if (leftRepositoryId !== rightRepositoryId) {
+    return leftRepositoryId < rightRepositoryId ? -1 : 1;
+  }
+  if (left.number !== right.number) {
+    return left.number - right.number;
+  }
+  return left.nodeId < right.nodeId ? -1 : left.nodeId > right.nodeId ? 1 : 0;
+};
+
+const processPullRequestCandidates = async (
+  candidates: readonly GitHubPullRequestBackfillCandidate[],
+  input: {
+    account: TrackedGitHubAccount;
+    deadlineAt: number;
+    onRateLimitWait?: (retryAt: Date) => void;
+    sinceAt: Date;
+    token: string;
+    untilAt: Date;
+  },
+  result: GitHubPullRequestBackfillResult
+): Promise<PullRequestProcessingInterruption | null> => {
+  for (
+    let offset = 0;
+    offset < candidates.length;
+    offset += PULL_REQUEST_PROCESSING_BATCH_SIZE
+  ) {
+    const prepared: PreparedPullRequest[] = [];
+    let interrupted: PullRequestProcessingInterruption | null = null;
+    for (const candidate of candidates.slice(
+      offset,
+      offset + PULL_REQUEST_PROCESSING_BATCH_SIZE
+    )) {
+      if (deadlineReached(input.deadlineAt)) {
+        interrupted = { reason: "deadline", retryAt: null };
+        break;
+      }
+      result.scannedPullRequests += 1;
+      try {
+        const value = await withProviderRetryWait(
+          async () =>
+            await preparePullRequest({
+              account: input.account,
+              candidate,
+              deadlineAt: input.deadlineAt,
+              sinceAt: input.sinceAt,
+              token: input.token,
+              untilAt: input.untilAt,
+            }),
+          input
+        );
+        if (value === null) {
+          result.skippedPullRequests += 1;
+        } else {
+          prepared.push(value);
+        }
+      } catch (error) {
+        if (isDeadlineError(error)) {
+          interrupted = { reason: "deadline", retryAt: null };
+          break;
+        }
+        const retry = providerRetryFrom(error);
+        if (retry !== null) {
+          interrupted = {
+            reason: "provider_retry",
+            retryAt: retry.retryAt,
+          };
+          break;
+        }
+        throw error;
+      }
+    }
+
+    const unmerged = prepared.filter(
+      ({ snapshot }) => !snapshot.pullRequest.merged
+    );
+    await persistPreparedPullRequests(unmerged, input.account, result);
+    const merged = prepared.filter(
+      ({ snapshot }) => snapshot.pullRequest.merged
+    );
+    if (merged.length > 0) {
+      try {
+        await persistPreparedPullRequests(
+          await withProviderRetryWait(
+            async () =>
+              await withResolvedMergeCommits(
+                merged,
+                input.token,
+                input.deadlineAt
+              ),
+            input
+          ),
+          input.account,
+          result
+        );
+      } catch (error) {
+        if (isDeadlineError(error)) {
+          return { reason: "deadline", retryAt: null };
+        }
+        const retry = providerRetryFrom(error);
+        if (retry !== null) {
+          return { reason: "provider_retry", retryAt: retry.retryAt };
+        }
+        throw error;
+      }
+    }
+    if (interrupted !== null) {
+      return interrupted;
+    }
+  }
+  return null;
+};
+
+// oxlint-disable-next-line complexity -- Provider retries, deadlines, stale snapshots, and partial batches fail closed distinctly.
+export const backfillGitHubPullRequests = async (input: {
+  account: TrackedGitHubAccount;
+  deadlineAt: number;
+  onRateLimitWait?: (retryAt: Date) => void;
+  repositoryId: string | null;
+  sinceAt: Date;
+  token: string;
+  untilAt: Date;
+}): Promise<GitHubPullRequestBackfillResult> => {
+  if (
+    Number.isNaN(input.sinceAt.getTime()) ||
+    Number.isNaN(input.untilAt.getTime()) ||
+    input.sinceAt > input.untilAt
+  ) {
+    throw new RangeError("The GitHub pull request backfill window is invalid.");
+  }
+  const result = emptyResult();
+  let repositories: readonly GitHubRepositoryFacts[];
+  try {
+    repositories = await withProviderRetryWait(
+      async () =>
+        await collectAccessibleGitHubRepositories(
+          input.token,
+          input.repositoryId,
+          { deadlineAt: input.deadlineAt }
+        ),
+      input
+    );
+  } catch (error) {
+    if (isDeadlineError(error)) {
+      return stop(result, "deadline");
+    }
+    const retry = providerRetryFrom(error);
+    if (retry !== null) {
+      return stop(result, "provider_retry", retry.retryAt);
+    }
+    throw error;
+  }
+
+  const authoredCandidates = new Map<
+    string,
+    GitHubPullRequestBackfillCandidate
+  >();
+  if (input.repositoryId === null) {
+    try {
+      const authored = await withProviderRetryWait(
+        async () =>
+          await collectGitHubAuthoredPullRequestBackfillCandidates({
+            account: input.account,
+            deadlineAt: input.deadlineAt,
+            token: input.token,
+          }),
+        input
+      );
+      result.authoredPullRequestPages = authored.pages;
+      result.authoredPullRequests = authored.totalCount;
+      mergeGitHubPullRequestBackfillCandidates(
+        authoredCandidates,
+        authored.pullRequests
+      );
+    } catch (error) {
+      if (isDeadlineError(error)) {
+        return stop(result, "deadline");
+      }
+      const retry = providerRetryFrom(error);
+      if (retry !== null) {
+        return stop(result, "provider_retry", retry.retryAt);
+      }
+      throw error;
+    }
+
+    // Repository-scoped Action runs can shard the affiliated inventory when it
+    // is large. Authored PRs in unaffiliated repositories have no equivalent
+    // shard, so persist them before the potentially long per-repository scan.
+    const accessibleRepositoryIds = new Set(
+      repositories.map((repository) => repository.id)
+    );
+    const externalCandidates = [...authoredCandidates.values()]
+      .filter(
+        (candidate) => !accessibleRepositoryIds.has(candidate.repositoryId)
+      )
+      .toSorted(comparePullRequestCandidates);
+    for (const candidate of externalCandidates) {
+      authoredCandidates.delete(candidate.nodeId);
+    }
+    result.repositories += new Set(
+      externalCandidates.map((candidate) => candidate.repositoryId)
+    ).size;
+    const interrupted = await processPullRequestCandidates(
+      externalCandidates,
+      input,
+      result
+    );
+    if (interrupted !== null) {
+      return stop(result, interrupted.reason, interrupted.retryAt);
+    }
+  }
+
+  for (const repository of repositories) {
+    if (deadlineReached(input.deadlineAt)) {
+      return stop(result, "deadline");
+    }
+    let candidates: GitHubPullRequestBackfillCandidateCollection;
+    try {
+      candidates = await withProviderRetryWait(
+        async () =>
+          await collectGitHubPullRequestBackfillCandidates({
+            account: input.account,
+            deadlineAt: input.deadlineAt,
+            onRateLimitWait: input.onRateLimitWait,
+            repository,
+            token: input.token,
+          }),
+        input
+      );
+    } catch (error) {
+      if (isDeadlineError(error)) {
+        return stop(result, "deadline");
+      }
+      const retry = providerRetryFrom(error);
+      if (retry !== null) {
+        return stop(result, "provider_retry", retry.retryAt);
+      }
+      throw error;
+    }
+    result.repositories += 1;
+    const repositoryCandidates = new Map<
+      string,
+      GitHubPullRequestBackfillCandidate
+    >();
+    mergeGitHubPullRequestBackfillCandidates(
+      repositoryCandidates,
+      candidates.pullRequests
+    );
+    for (const candidate of authoredCandidates.values()) {
+      if (candidate.repositoryId === repository.id) {
+        mergeGitHubPullRequestBackfillCandidates(repositoryCandidates, [
+          candidate,
+        ]);
+        authoredCandidates.delete(candidate.nodeId);
+      }
+    }
+    const interrupted = await processPullRequestCandidates(
+      [...repositoryCandidates.values()].toSorted(comparePullRequestCandidates),
+      input,
+      result
+    );
+    if (interrupted !== null) {
+      return stop(result, interrupted.reason, interrupted.retryAt);
+    }
+    if (!candidates.complete) {
+      return stop(result, "deadline");
+    }
+  }
+
+  if (authoredCandidates.size > 0) {
+    throw new TypeError(
+      "GitHub returned an authored pull request outside the reconciled repository inventory."
+    );
+  }
+  return result;
+};

--- a/src/lib/github-reconciliation.ts
+++ b/src/lib/github-reconciliation.ts
@@ -4,36 +4,11 @@ import {
   githubApiUrl,
   nextGitHubPage,
 } from "@/lib/github-api";
-import {
-  commitShaFrom,
-  pullRequestFromGitHub,
-  repositoryFactsFrom,
-  repositoryFrom,
-} from "@/lib/github-commits-core";
-import type {
-  GitHubEvent,
-  GitHubRepositoryFacts,
-  TrackedGitHubAccount,
-} from "@/lib/github-commits-core";
-import {
-  persistGitHubRepositoryBackfill,
-  persistGitHubRepositoryRefs,
-} from "@/lib/github-commits-store";
-import type {
-  GitHubBackfillWindow,
-  GitHubRepositoryRefSnapshot,
-} from "@/lib/github-commits-store";
+import { commitShaFrom, repositoryFactsFrom } from "@/lib/github-commits-core";
+import type { GitHubRepositoryFacts } from "@/lib/github-commits-core";
+import type { GitHubRepositoryRefSnapshot } from "@/lib/github-commits-store";
 
 const GITHUB_PAGE_SIZE = 100;
-const GITHUB_REQUEST_CONCURRENCY = 4;
-const MAXIMUM_BACKFILL_OBSERVATIONS = 5000;
-
-export class GitHubBackfillCapacityError extends RangeError {
-  constructor() {
-    super("The GitHub backfill would create too many durable observations.");
-    this.name = "GitHubBackfillCapacityError";
-  }
-}
 
 type JsonObject = Record<string, unknown>;
 
@@ -43,25 +18,6 @@ const isObject = (value: unknown): value is JsonObject =>
 const compareStrings = (left: string, right: string) =>
   left < right ? -1 : left > right ? 1 : 0;
 
-const mapWithConcurrency = async <Input, Output>(
-  values: readonly Input[],
-  mapper: (value: Input) => Promise<Output>
-) => {
-  const outputs: Output[] = [];
-  for (
-    let offset = 0;
-    offset < values.length;
-    offset += GITHUB_REQUEST_CONCURRENCY
-  ) {
-    outputs.push(
-      ...(await Promise.all(
-        values.slice(offset, offset + GITHUB_REQUEST_CONCURRENCY).map(mapper)
-      ))
-    );
-  }
-  return outputs;
-};
-
 const repositoryApiPath = (repository: string, suffix: string) => {
   const [owner, name, ...rest] = repository.split("/");
   if (owner === undefined || name === undefined || rest.length > 0) {
@@ -70,12 +26,23 @@ const repositoryApiPath = (repository: string, suffix: string) => {
   return `/repos/${encodeURIComponent(owner)}/${encodeURIComponent(name)}${suffix}`;
 };
 
-const fetchJson = async (url: URL, token: string) => {
-  const response = await fetchGitHub(url, { token });
+const fetchJson = async (
+  url: URL,
+  token: string,
+  options: { deadlineAt?: number } = {}
+) => {
+  const response = await fetchGitHub(url, {
+    deadlineAt: options.deadlineAt,
+    token,
+  });
   return { payload: (await response.json()) as unknown, response };
 };
 
-const fetchPaginatedArray = async (initialUrl: URL, token: string) => {
+const fetchPaginatedArray = async (
+  initialUrl: URL,
+  token: string,
+  options: { deadlineAt?: number } = {}
+) => {
   const values: unknown[] = [];
   const visited = new Set<string>();
   let url: URL | null = initialUrl;
@@ -84,7 +51,7 @@ const fetchPaginatedArray = async (initialUrl: URL, token: string) => {
       throw new TypeError("GitHub returned cyclic pagination links.");
     }
     visited.add(url.href);
-    const result = await fetchJson(url, token);
+    const result = await fetchJson(url, token, options);
     if (!Array.isArray(result.payload)) {
       throw new TypeError("GitHub returned an invalid paginated response.");
     }
@@ -96,12 +63,14 @@ const fetchPaginatedArray = async (initialUrl: URL, token: string) => {
 
 export const collectAccessibleGitHubRepositories = async (
   token: string,
-  repositoryId: string | null = null
+  repositoryId: string | null = null,
+  options: { deadlineAt?: number } = {}
 ) => {
   if (repositoryId !== null) {
     const { payload } = await fetchJson(
       githubApiUrl(`/repositories/${encodeURIComponent(repositoryId)}`),
-      token
+      token,
+      options
     );
     const facts = repositoryFactsFrom(payload);
     if (facts === null) {
@@ -115,7 +84,7 @@ export const collectAccessibleGitHubRepositories = async (
   url.searchParams.set("per_page", String(GITHUB_PAGE_SIZE));
   url.searchParams.set("sort", "full_name");
   url.searchParams.set("visibility", "all");
-  const values = await fetchPaginatedArray(url, token);
+  const values = await fetchPaginatedArray(url, token, options);
   const repositories = new Map<string, GitHubRepositoryFacts>();
   for (const value of values) {
     const repository = repositoryFactsFrom(value);
@@ -133,11 +102,6 @@ export const collectAccessibleGitHubRepositories = async (
   );
 };
 
-interface GitHubRefObject {
-  sha: string;
-  type: "blob" | "commit" | "tag" | "tree";
-}
-
 const containsControlCharacter = (value: string) => {
   for (const character of value) {
     const code = character.codePointAt(0) ?? 0;
@@ -148,284 +112,139 @@ const containsControlCharacter = (value: string) => {
   return false;
 };
 
-const refObjectFrom = (value: unknown): GitHubRefObject | null => {
-  if (!isObject(value)) {
-    return null;
-  }
-  const { sha: rawSha, type } = value;
-  const sha = commitShaFrom(rawSha);
-  return sha !== null &&
-    (type === "blob" || type === "commit" || type === "tag" || type === "tree")
-    ? { sha, type }
-    : null;
-};
-
-const refFrom = (value: unknown, kind: GitHubRepositoryRefSnapshot["kind"]) => {
-  if (!isObject(value) || typeof value.ref !== "string") {
-    throw new TypeError("GitHub returned an invalid Git reference.");
-  }
+const refFromListValue = (
+  value: unknown,
+  kind: GitHubRepositoryRefSnapshot["kind"]
+) => {
+  const commit =
+    isObject(value) && isObject(value.commit) ? value.commit : null;
+  const headSha = commitShaFrom(commit?.sha);
+  const name =
+    isObject(value) && typeof value.name === "string" ? value.name : null;
   const prefix = kind === "head" ? "refs/heads/" : "refs/tags/";
-  const refName = value.ref;
-  const object = refObjectFrom(value.object);
   if (
-    object === null ||
-    !refName.startsWith(prefix) ||
-    refName.length <= prefix.length ||
-    refName.length > 1024 ||
-    containsControlCharacter(refName) ||
-    (kind === "head" && object.type !== "commit")
+    headSha === null ||
+    name === null ||
+    name.length === 0 ||
+    name.length > 1000 ||
+    containsControlCharacter(name)
   ) {
     throw new TypeError("GitHub returned an invalid Git reference.");
   }
-  return { kind, object, refName };
+  return { headSha, kind, refName: `${prefix}${name}` };
 };
 
-const peelTagToCommit = async (
-  repository: GitHubRepositoryFacts,
-  initial: GitHubRefObject,
-  token: string
-) => {
-  const visited = new Set<string>();
-  let object = initial;
-  while (object.type === "tag") {
-    if (visited.has(object.sha)) {
-      throw new TypeError("GitHub returned a cyclic annotated tag.");
-    }
-    visited.add(object.sha);
-    const { payload } = await fetchJson(
-      githubApiUrl(
-        repositoryApiPath(
-          repository.fullName,
-          `/git/tags/${encodeURIComponent(object.sha)}`
-        )
-      ),
-      token
-    );
-    if (!isObject(payload)) {
-      throw new TypeError("GitHub returned an invalid annotated tag.");
-    }
-    const target = refObjectFrom(payload.object);
-    if (target === null) {
-      throw new TypeError("GitHub returned an invalid annotated tag target.");
-    }
-    object = target;
+const nextRepositoryRefPage = (response: Response, currentPage: number) => {
+  const next = nextGitHubPage(response);
+  if (next === null) {
+    return null;
   }
-  return object.type === "commit" ? object.sha : null;
+  const page = next.searchParams.get("page");
+  const perPage = next.searchParams.get("per_page");
+  if (
+    page !== String(currentPage + 1) ||
+    perPage !== String(GITHUB_PAGE_SIZE)
+  ) {
+    throw new TypeError("GitHub returned invalid reference pagination.");
+  }
+  return currentPage + 1;
 };
 
-const collectMatchingRefs = async (
+export interface GitHubRepositoryRefPage {
+  nextPage: number | null;
+  refs: readonly GitHubRepositoryRefSnapshot[];
+}
+
+export const collectGitHubRepositoryRefPage = async (
   repository: GitHubRepositoryFacts,
   kind: GitHubRepositoryRefSnapshot["kind"],
-  token: string
-) => {
-  const namespace = kind === "head" ? "heads" : "tags";
+  token: string,
+  input: {
+    deadlineAt?: number;
+    page: number;
+  }
+): Promise<GitHubRepositoryRefPage | null> => {
+  if (!Number.isSafeInteger(input.page) || input.page < 1) {
+    throw new RangeError("The GitHub reference page is invalid.");
+  }
+  const endpoint = kind === "head" ? "branches" : "tags";
   const url = githubApiUrl(
-    repositoryApiPath(repository.fullName, `/git/matching-refs/${namespace}/`)
+    repositoryApiPath(repository.fullName, `/${endpoint}`)
   );
   url.searchParams.set("per_page", String(GITHUB_PAGE_SIZE));
-  let values: readonly unknown[];
+  url.searchParams.set("page", String(input.page));
+
+  let response: Response;
   try {
-    values = await fetchPaginatedArray(url, token);
+    response = await fetchGitHub(url, {
+      deadlineAt: input.deadlineAt,
+      token,
+    });
   } catch (error) {
     if (error instanceof GitHubResponseError && error.status === 409) {
-      return [];
+      return { nextPage: null, refs: [] };
     }
-    throw error;
-  }
-
-  const refs: GitHubRepositoryRefSnapshot[] = [];
-  for (const value of values) {
-    const ref = refFrom(value, kind);
-    const headSha = await peelTagToCommit(repository, ref.object, token);
-    if (headSha !== null) {
-      refs.push({ headSha, kind, refName: ref.refName });
-    }
-  }
-  return refs;
-};
-
-export const collectGitHubRepositoryRefs = async (
-  repository: GitHubRepositoryFacts,
-  token: string
-): Promise<readonly GitHubRepositoryRefSnapshot[] | null> => {
-  try {
-    const heads = await collectMatchingRefs(repository, "head", token);
-    const tags = await collectMatchingRefs(repository, "tag", token);
-    const refs = new Map<string, GitHubRepositoryRefSnapshot>();
-    for (const ref of [...heads, ...tags]) {
-      const existing = refs.get(ref.refName);
-      if (
-        existing !== undefined &&
-        (existing.headSha !== ref.headSha || existing.kind !== ref.kind)
-      ) {
-        throw new TypeError("GitHub returned conflicting Git references.");
-      }
-      refs.set(ref.refName, ref);
-    }
-    return [...refs.values()].toSorted((left, right) =>
-      compareStrings(left.refName, right.refName)
-    );
-  } catch (error) {
     if (error instanceof GitHubResponseError && error.status === 404) {
       return null;
     }
     throw error;
   }
+  const payload = (await response.json()) as unknown;
+  if (!Array.isArray(payload)) {
+    throw new TypeError("GitHub returned an invalid reference page.");
+  }
+  const refs = new Map<string, GitHubRepositoryRefSnapshot>();
+  for (const value of payload) {
+    const ref = refFromListValue(value, kind);
+    const existing = refs.get(ref.refName);
+    if (existing !== undefined && existing.headSha !== ref.headSha) {
+      throw new TypeError("GitHub returned conflicting Git references.");
+    }
+    refs.set(ref.refName, ref);
+  }
+  return {
+    nextPage: nextRepositoryRefPage(response, input.page),
+    refs: [...refs.values()].toSorted((left, right) =>
+      compareStrings(left.refName, right.refName)
+    ),
+  };
 };
 
-export const hydrateSparseGitHubPullRequestEvents = async (
-  events: readonly GitHubEvent[],
-  token: string
-): Promise<readonly GitHubEvent[]> =>
-  await mapWithConcurrency(events, async (event) => {
-    const signal = event.pullRequestSignal;
-    if (signal === undefined) {
-      return event;
-    }
-    let payload: unknown;
-    try {
-      ({ payload } = await fetchJson(
-        githubApiUrl(
-          repositoryApiPath(
-            signal.repository.fullName,
-            `/pulls/${signal.number}`
-          )
-        ),
-        token
-      ));
-    } catch (error) {
-      if (error instanceof GitHubResponseError && error.status === 404) {
-        return event;
-      }
-      throw error;
-    }
-    const base =
-      isObject(payload) && isObject(payload.base) ? payload.base : null;
-    const currentRepository = base === null ? null : repositoryFrom(base.repo);
-    const pullRequest =
-      currentRepository?.id === signal.repository.id
-        ? pullRequestFromGitHub(payload, currentRepository, signal.action)
-        : null;
-    if (
-      pullRequest === null ||
-      pullRequest.number !== signal.number ||
-      pullRequest.repository.id !== signal.repository.id
-    ) {
-      throw new TypeError("GitHub returned an invalid pull request response.");
-    }
-    return {
-      id: event.id,
-      issue: event.issue,
-      occurredAt: event.occurredAt,
-      pullRequest,
-      push: event.push,
-    };
-  });
-
-export interface GitHubRefReconciliationResult {
-  knownCommits: number;
-  pushes: number;
-  refs: number;
-  repositories: number;
-}
-
-export interface GitHubHistoryBackfillResult {
-  duplicates: number;
-  observations: number;
-  refs: number;
-  repositories: number;
-}
-
-export const queueAccessibleGitHubHistoryBackfill = async (input: {
-  account: TrackedGitHubAccount;
-  repositoryId: string | null;
-  token: string;
-  windows: readonly GitHubBackfillWindow[];
-}): Promise<GitHubHistoryBackfillResult> => {
-  const repositories = await collectAccessibleGitHubRepositories(
-    input.token,
-    input.repositoryId
-  );
-  const collected = await mapWithConcurrency(
-    repositories,
-    async (repository) => ({
-      refs: await collectGitHubRepositoryRefs(repository, input.token),
-      repository,
-    })
-  );
-  const accessible = collected.flatMap(({ refs, repository }) =>
-    refs === null ? [] : [{ refs, repository }]
-  );
-  let observationCount = 0;
-  for (const { refs } of accessible) {
-    observationCount +=
-      new Set(refs.map(({ headSha }) => headSha)).size * input.windows.length;
-  }
-  if (observationCount > MAXIMUM_BACKFILL_OBSERVATIONS) {
-    throw new GitHubBackfillCapacityError();
-  }
-
-  const persisted = await mapWithConcurrency(
-    accessible,
-    async ({ refs, repository }) =>
-      await persistGitHubRepositoryBackfill({
-        account: input.account,
-        observedAt: new Date(),
-        refs,
+export const collectGitHubRepositoryRefs = async (
+  repository: GitHubRepositoryFacts,
+  token: string,
+  options: { deadlineAt?: number } = {}
+): Promise<readonly GitHubRepositoryRefSnapshot[] | null> => {
+  const refs = new Map<string, GitHubRepositoryRefSnapshot>();
+  for (const kind of ["head", "tag"] as const) {
+    let page = 1;
+    while (true) {
+      const collected = await collectGitHubRepositoryRefPage(
         repository,
-        windows: input.windows,
-      })
-  );
-  const result: GitHubHistoryBackfillResult = {
-    duplicates: 0,
-    observations: 0,
-    refs: 0,
-    repositories: 0,
-  };
-  for (const repository of persisted) {
-    result.duplicates += repository.duplicates;
-    result.observations += repository.observations;
-    result.refs += repository.refs;
-    result.repositories += 1;
-  }
-  return result;
-};
-
-export const reconcileAccessibleGitHubRepositoryRefs = async (
-  account: TrackedGitHubAccount,
-  token: string
-): Promise<GitHubRefReconciliationResult> => {
-  const repositories = await collectAccessibleGitHubRepositories(token);
-  const result: GitHubRefReconciliationResult = {
-    knownCommits: 0,
-    pushes: 0,
-    refs: 0,
-    repositories: 0,
-  };
-
-  const reconciled = await mapWithConcurrency(
-    repositories,
-    async (repository) => {
-      const observedAt = new Date();
-      const refs = await collectGitHubRepositoryRefs(repository, token);
-      return refs === null
-        ? null
-        : await persistGitHubRepositoryRefs({
-            account,
-            observedAt,
-            refs,
-            repository,
-          });
+        kind,
+        token,
+        { deadlineAt: options.deadlineAt, page }
+      );
+      if (collected === null) {
+        return null;
+      }
+      for (const ref of collected.refs) {
+        const existing = refs.get(ref.refName);
+        if (
+          existing !== undefined &&
+          (existing.headSha !== ref.headSha || existing.kind !== ref.kind)
+        ) {
+          throw new TypeError("GitHub returned conflicting Git references.");
+        }
+        refs.set(ref.refName, ref);
+      }
+      if (collected.nextPage === null) {
+        break;
+      }
+      page = collected.nextPage;
     }
-  );
-  for (const repository of reconciled) {
-    if (repository === null) {
-      continue;
-    }
-    result.knownCommits += repository.knownCommits;
-    result.pushes += repository.pushes;
-    result.refs += repository.refs;
-    result.repositories += 1;
   }
-  return result;
+  return [...refs.values()].toSorted((left, right) =>
+    compareStrings(left.refName, right.refName)
+  );
 };

--- a/src/lib/github-ref-reconciliation-batch.ts
+++ b/src/lib/github-ref-reconciliation-batch.ts
@@ -1,0 +1,242 @@
+import { GitHubRequestDeadlineError } from "@/lib/github-api";
+import type {
+  GitHubRepositoryFacts,
+  TrackedGitHubAccount,
+} from "@/lib/github-commits-core";
+import {
+  acquireGitHubRefReconciliationLease,
+  finishGitHubRefReconciliationLease,
+  persistGitHubRepositoryRefPage,
+  releaseGitHubRefReconciliationLease,
+  skipGitHubRefRepository,
+} from "@/lib/github-commits-store";
+import type { GitHubRepositoryRefKind } from "@/lib/github-commits-store";
+import {
+  collectAccessibleGitHubRepositories,
+  collectGitHubRepositoryRefPage,
+} from "@/lib/github-reconciliation";
+
+const LEASE_PADDING_MS = 30_000;
+const MINIMUM_REQUEST_BUDGET_MS = 10_000;
+
+export interface GitHubRefReconciliationBatchInput {
+  account: TrackedGitHubAccount;
+  deadlineAt: number;
+  kind: GitHubRepositoryRefKind;
+  repositoryLimit: number;
+  token: string;
+}
+
+export interface GitHubRefReconciliationBatchResult {
+  complete: boolean;
+  knownCommits: number;
+  pages: number;
+  pushes: number;
+  refs: number;
+  repositories: number;
+}
+
+const compareRepositoryIds = (
+  left: GitHubRepositoryFacts,
+  right: GitHubRepositoryFacts
+) => {
+  const leftId = BigInt(left.id);
+  const rightId = BigInt(right.id);
+  return leftId < rightId ? -1 : leftId > rightId ? 1 : 0;
+};
+
+export const sortGitHubRefRepositories = (
+  repositories: readonly GitHubRepositoryFacts[]
+) => repositories.toSorted(compareRepositoryIds);
+
+export const nextGitHubRefRepository = (
+  repositories: readonly GitHubRepositoryFacts[],
+  cursorRepositoryId: string | null
+) => {
+  if (cursorRepositoryId === null) {
+    return repositories[0] ?? null;
+  }
+  const cursor = BigInt(cursorRepositoryId);
+  return (
+    repositories.find((repository) => BigInt(repository.id) > cursor) ?? null
+  );
+};
+
+export const githubRefCycleIsComplete = (
+  repositories: readonly GitHubRepositoryFacts[],
+  cursorRepositoryId: string | null,
+  nextPage: number | null
+) =>
+  nextPage === null &&
+  nextGitHubRefRepository(repositories, cursorRepositoryId) === null;
+
+const emptyResult = (): GitHubRefReconciliationBatchResult => ({
+  complete: false,
+  knownCommits: 0,
+  pages: 0,
+  pushes: 0,
+  refs: 0,
+  repositories: 0,
+});
+
+const remainingBatchDurationMs = (input: GitHubRefReconciliationBatchInput) => {
+  const remaining = Math.floor(input.deadlineAt - Date.now());
+  if (
+    !Number.isFinite(input.deadlineAt) ||
+    !Number.isSafeInteger(remaining) ||
+    remaining > 270_000 ||
+    !Number.isSafeInteger(input.repositoryLimit) ||
+    input.repositoryLimit < 1 ||
+    input.repositoryLimit > 8
+  ) {
+    throw new RangeError("The GitHub ref reconciliation bounds are invalid.");
+  }
+  if (remaining < MINIMUM_REQUEST_BUDGET_MS) {
+    throw new GitHubRequestDeadlineError();
+  }
+  return remaining;
+};
+
+/**
+ * Reconciles at most `repositoryLimit` API pages and distinct repositories.
+ * A large repository therefore resumes on its persisted next page instead of
+ * monopolizing a serverless invocation. Missing refs remain active until the
+ * final page commits the scan watermark.
+ */
+export const reconcileGitHubRepositoryRefBatch = async (
+  input: GitHubRefReconciliationBatchInput
+): Promise<GitHubRefReconciliationBatchResult> => {
+  const remainingDurationMs = remainingBatchDurationMs(input);
+  const { deadlineAt } = input;
+  const lease = await acquireGitHubRefReconciliationLease({
+    account: input.account,
+    kind: input.kind,
+    leaseDurationMs: remainingDurationMs + LEASE_PADDING_MS,
+  });
+  const result = emptyResult();
+  if (lease === null) {
+    return result;
+  }
+  const {
+    cursorRepositoryId: leasedCursorRepositoryId,
+    leaseToken,
+    nextPage: leasedNextPage,
+    scanStartedAt: leasedScanStartedAt,
+  } = lease;
+
+  try {
+    const repositories = await collectAccessibleGitHubRepositories(
+      input.token,
+      null,
+      {
+        deadlineAt,
+      }
+    );
+    const orderedRepositories = sortGitHubRefRepositories(repositories);
+    const repositoriesById = new Map(
+      orderedRepositories.map((repository) => [repository.id, repository])
+    );
+    let cursorRepositoryId = leasedCursorRepositoryId;
+    let nextPage = leasedNextPage;
+    let scanStartedAt = leasedScanStartedAt;
+    const visitedRepositories = new Set<string>();
+
+    while (
+      result.pages < input.repositoryLimit &&
+      visitedRepositories.size < input.repositoryLimit &&
+      Date.now() + MINIMUM_REQUEST_BUDGET_MS < deadlineAt
+    ) {
+      const repository =
+        nextPage === null
+          ? nextGitHubRefRepository(orderedRepositories, cursorRepositoryId)
+          : (repositoriesById.get(cursorRepositoryId ?? "") ?? null);
+      if (repository === null) {
+        if (nextPage !== null && cursorRepositoryId !== null) {
+          await skipGitHubRefRepository({
+            account: input.account,
+            kind: input.kind,
+            leaseToken,
+            repositoryId: cursorRepositoryId,
+          });
+          nextPage = null;
+          scanStartedAt = null;
+          continue;
+        }
+        result.complete = true;
+        break;
+      }
+      visitedRepositories.add(repository.id);
+
+      const page = nextPage ?? 1;
+      const pageScanStartedAt = scanStartedAt ?? new Date();
+      const collected = await collectGitHubRepositoryRefPage(
+        repository,
+        input.kind,
+        input.token,
+        { deadlineAt, page }
+      );
+      result.pages += 1;
+
+      if (collected === null) {
+        await skipGitHubRefRepository({
+          account: input.account,
+          kind: input.kind,
+          leaseToken,
+          repositoryId: repository.id,
+        });
+        cursorRepositoryId = repository.id;
+        nextPage = null;
+        scanStartedAt = null;
+        continue;
+      }
+
+      const { nextPage: collectedNextPage, refs } = collected;
+      const complete = collectedNextPage === null;
+      const persisted = await persistGitHubRepositoryRefPage({
+        account: input.account,
+        complete,
+        kind: input.kind,
+        leaseToken,
+        nextPage: collectedNextPage,
+        observedAt: new Date(),
+        refs,
+        repository,
+        scanStartedAt: pageScanStartedAt,
+      });
+      result.knownCommits += persisted.knownCommits;
+      result.pushes += persisted.pushes;
+      result.refs += persisted.refs;
+      if (complete) {
+        result.repositories += 1;
+      }
+      cursorRepositoryId = repository.id;
+      nextPage = collectedNextPage;
+      scanStartedAt = complete ? null : pageScanStartedAt;
+    }
+
+    if (
+      !result.complete &&
+      githubRefCycleIsComplete(
+        orderedRepositories,
+        cursorRepositoryId,
+        nextPage
+      )
+    ) {
+      result.complete = true;
+    }
+    await finishGitHubRefReconciliationLease({
+      account: input.account,
+      complete: result.complete,
+      kind: input.kind,
+      leaseToken,
+    });
+    return result;
+  } catch (error) {
+    await releaseGitHubRefReconciliationLease({
+      account: input.account,
+      kind: input.kind,
+      leaseToken,
+    });
+    throw error;
+  }
+};

--- a/src/lib/site-url.ts
+++ b/src/lib/site-url.ts
@@ -1,0 +1,1 @@
+export const CANONICAL_SITE_URL = "https://f0rr0.dev";

--- a/src/lib/site.ts
+++ b/src/lib/site.ts
@@ -1,7 +1,7 @@
 import { resumeData } from "@/content/resume";
 import { env } from "@/env";
+import { CANONICAL_SITE_URL } from "@/lib/site-url";
 
-const CANONICAL_SITE_URL = "https://f0rr0.dev";
 const [currentExperience] = resumeData.experience;
 const [currentRole] = currentExperience?.roles ?? [];
 const foundedExperience = resumeData.experience.find((experience) =>
@@ -31,10 +31,6 @@ const withProtocol = (value: string) => {
 };
 
 const resolveSiteUrl = () => {
-  if (env.SITE_URL !== undefined && env.SITE_URL !== "") {
-    return withProtocol(env.SITE_URL);
-  }
-
   if (env.NODE_ENV === "development") {
     const devPort = env.PORT ?? env.NEXT_PUBLIC_PORT ?? "3000";
     return `http://localhost:${devPort}`;

--- a/tests/github-activity-feed-postgres.test.mjs
+++ b/tests/github-activity-feed-postgres.test.mjs
@@ -23,6 +23,7 @@ const dockerAvailable =
   }).exitCode === 0;
 
 const migrationsFolder = new URL("../drizzle", import.meta.url).pathname;
+const repositoryRoot = new URL("..", import.meta.url).pathname;
 const postgresImage = "postgres:17-alpine";
 const postgresPassword = "github-activity-test";
 
@@ -71,6 +72,10 @@ describe.skipIf(!dockerAvailable)(
     let admin;
     let canonicalizeGitHubCommitActivity;
     let claimDueGitHubPullRequests;
+    let claimGitHubCommitsForEnrichment;
+    let claimGitHubCommitsForPullRequestDiscovery;
+    let claimGitHubPullRequestSignals;
+    let claimGitHubPushObservations;
     let claimGitHubSummaryAttempts;
     let closeDatabase;
     let completeGitHubPullRequestReconciliation;
@@ -78,13 +83,28 @@ describe.skipIf(!dockerAvailable)(
     let containerId;
     let databaseUrl;
     let ensureGitHubSummaryAttempt;
+    let ensureGitHubEvidenceIntegrity;
     let ensureMissingGitHubSummaryAttempts;
+    let inspectGitHubEvidenceRecovery;
     let originalCronSecret;
     let originalDatabaseUrl;
+    let acquireGitHubRefReconciliationLease;
+    let beginGitHubEventPoll;
+    let finishGitHubRefReconciliationLease;
     let persistAccountIntake;
-    let persistGitHubRepositoryBackfill;
-    let persistGitHubRepositoryRefs;
+    let persistGitHubPullRequestSnapshot;
+    let persistGitHubRepositoryRefPage;
+    let persistGitHubWebhookPullRequest;
+    let persistGitHubWebhookPush;
+    let readGitHubAccountCheckpoint;
     let readPublicGitHubActivityPage;
+    let releaseGitHubCommitEnrichment;
+    let releaseGitHubPullRequestDiscovery;
+    let releaseGitHubPullRequestReconciliation;
+    let releaseGitHubPullRequestSignal;
+    let releaseGitHubPushObservation;
+    let releaseGitHubSummaryAttempt;
+    let repairLegacyGitHubEvidence;
 
     beforeAll(async () => {
       originalCronSecret = env.CRON_SECRET;
@@ -156,16 +176,35 @@ describe.skipIf(!dockerAvailable)(
       ({
         canonicalizeGitHubCommitActivity,
         claimDueGitHubPullRequests,
+        claimGitHubCommitsForEnrichment,
+        claimGitHubCommitsForPullRequestDiscovery,
+        claimGitHubPullRequestSignals,
+        claimGitHubPushObservations,
         claimGitHubSummaryAttempts,
         completeGitHubPullRequestReconciliation,
         completeGitHubSummaryAttempt,
+        ensureGitHubEvidenceIntegrity,
         ensureGitHubSummaryAttempt,
         ensureMissingGitHubSummaryAttempts,
+        inspectGitHubEvidenceRecovery,
+        persistGitHubPullRequestSnapshot,
+        releaseGitHubCommitEnrichment,
+        releaseGitHubPullRequestDiscovery,
+        releaseGitHubPullRequestReconciliation,
+        releaseGitHubPullRequestSignal,
+        releaseGitHubPushObservation,
+        releaseGitHubSummaryAttempt,
+        repairLegacyGitHubEvidence,
       } = await import("../src/lib/github-activity-worker-store.ts"));
       ({
+        acquireGitHubRefReconciliationLease,
+        beginGitHubEventPoll,
+        finishGitHubRefReconciliationLease,
         persistAccountIntake,
-        persistGitHubRepositoryBackfill,
-        persistGitHubRepositoryRefs,
+        persistGitHubRepositoryRefPage,
+        persistGitHubWebhookPullRequest,
+        persistGitHubWebhookPush,
+        readGitHubAccountCheckpoint,
       } = await import("../src/lib/github-commits-store.ts"));
     });
 
@@ -190,166 +229,1209 @@ describe.skipIf(!dockerAvailable)(
       }
     });
 
-    test("checkpoints repository refs and emits only new reachable ranges", async () => {
+    test("establishes a paginated ref baseline before emitting later changes", async () => {
       const repository = {
-        fullName: "example-org/ref-checkpoints",
-        htmlUrl: "https://github.com/example-org/ref-checkpoints",
-        id: "404",
+        fullName: "example-org/paginated-ref-baseline",
+        htmlUrl: "https://github.com/example-org/paginated-ref-baseline",
+        id: "408",
         ownerAvatarUrl: null,
         ownerId: "202",
         ownerLogin: "example-org",
         ownerType: "Organization",
         visibility: "private",
       };
-      const firstSha = "6".repeat(40);
-      const secondSha = "7".repeat(40);
-      const first = await persistGitHubRepositoryRefs({
+      const baselineStartedAt = new Date("2026-08-29T12:00:00.000Z");
+      const firstSha = "8".repeat(40);
+      const secondSha = "9".repeat(40);
+      const lease = await acquireGitHubRefReconciliationLease({
         account: "f0rr0",
-        observedAt: new Date("2026-08-29T08:00:00.000Z"),
-        refs: [
-          { headSha: firstSha, kind: "head", refName: "refs/heads/main" },
-          { headSha: firstSha, kind: "tag", refName: "refs/tags/v1" },
-        ],
-        repository,
+        kind: "tag",
+        leaseDurationMs: 120_000,
+        now: baselineStartedAt,
       });
-      expect(first).toEqual({ knownCommits: 0, pushes: 1, refs: 2 });
+      expect(lease).not.toBeNull();
 
-      const unchanged = await persistGitHubRepositoryRefs({
+      const firstPage = await persistGitHubRepositoryRefPage({
         account: "f0rr0",
-        observedAt: new Date("2026-08-29T09:00:00.000Z"),
-        refs: [
-          { headSha: firstSha, kind: "head", refName: "refs/heads/main" },
-          { headSha: firstSha, kind: "tag", refName: "refs/tags/v1" },
-        ],
+        complete: false,
+        kind: "tag",
+        leaseToken: lease.leaseToken,
+        nextPage: 2,
+        observedAt: new Date("2026-08-29T12:00:10.000Z"),
+        refs: [{ headSha: firstSha, kind: "tag", refName: "refs/tags/v1" }],
         repository,
+        scanStartedAt: baselineStartedAt,
       });
-      expect(unchanged.pushes).toBe(0);
+      expect(firstPage).toMatchObject({ pushes: 0, refs: 1 });
+      expect(
+        await admin`
+          select tags_last_reconciled_at
+          from github_repositories
+          where id = '408'
+        `
+      ).toEqual([{ tags_last_reconciled_at: null }]);
 
-      const moved = await persistGitHubRepositoryRefs({
+      const finalPage = await persistGitHubRepositoryRefPage({
         account: "f0rr0",
-        observedAt: new Date("2026-08-29T10:00:00.000Z"),
-        refs: [
-          { headSha: secondSha, kind: "head", refName: "refs/heads/main" },
-        ],
+        complete: true,
+        kind: "tag",
+        leaseToken: lease.leaseToken,
+        nextPage: null,
+        observedAt: new Date("2026-08-29T12:00:20.000Z"),
+        refs: [{ headSha: secondSha, kind: "tag", refName: "refs/tags/v2" }],
         repository,
+        scanStartedAt: baselineStartedAt,
       });
-      expect(moved.pushes).toBe(1);
-
-      const refs = await admin`
-        select active, head_sha, ref_name
-        from github_repository_refs
-        where repository_id = '404'
-        order by ref_name
+      expect(finalPage).toMatchObject({ pushes: 0, refs: 1 });
+      expect(
+        await admin`
+          select count(*)::integer as count
+          from github_push_observations
+          where repository_id = '408'
+        `
+      ).toEqual([{ count: 0 }]);
+      const [baselineRepository] = await admin`
+        select tags_last_reconciled_at
+        from github_repositories
+        where id = '408'
       `;
-      expect(refs).toEqual([
-        { active: true, head_sha: secondSha, ref_name: "refs/heads/main" },
-        { active: false, head_sha: firstSha, ref_name: "refs/tags/v1" },
-      ]);
-      const observations = await admin`
-        select after_sha, before_sha, ref_name, source
-        from github_push_observations
-        where repository_id = '404'
-        order by observed_at
-      `;
-      expect(observations).toEqual([
+      expect(
+        new Date(baselineRepository.tags_last_reconciled_at).toISOString()
+      ).toBe("2026-08-29T12:00:20.000Z");
+      await finishGitHubRefReconciliationLease({
+        account: "f0rr0",
+        complete: true,
+        kind: "tag",
+        leaseToken: lease.leaseToken,
+        now: new Date("2026-08-29T12:00:30.000Z"),
+      });
+
+      const nextScanStartedAt = new Date("2026-08-29T12:15:00.000Z");
+      const nextLease = await acquireGitHubRefReconciliationLease({
+        account: "f0rr0",
+        kind: "tag",
+        leaseDurationMs: 120_000,
+        now: nextScanStartedAt,
+      });
+      expect(nextLease).not.toBeNull();
+      const changed = await persistGitHubRepositoryRefPage({
+        account: "f0rr0",
+        complete: true,
+        kind: "tag",
+        leaseToken: nextLease.leaseToken,
+        nextPage: null,
+        observedAt: new Date("2026-08-29T12:15:10.000Z"),
+        refs: [
+          {
+            headSha: "a".repeat(40),
+            kind: "tag",
+            refName: "refs/tags/v1",
+          },
+          { headSha: secondSha, kind: "tag", refName: "refs/tags/v2" },
+          {
+            headSha: "b".repeat(40),
+            kind: "tag",
+            refName: "refs/tags/v3",
+          },
+        ],
+        repository,
+        scanStartedAt: nextScanStartedAt,
+      });
+      expect(changed).toMatchObject({ pushes: 2, refs: 3 });
+      expect(
+        await admin`
+          select after_sha, before_sha, ref_name
+          from github_push_observations
+          where repository_id = '408'
+          order by ref_name
+        `
+      ).toEqual([
         {
-          after_sha: firstSha,
-          before_sha: "0".repeat(40),
-          ref_name: "refs/heads/main",
-          source: "refs",
-        },
-        {
-          after_sha: secondSha,
+          after_sha: "a".repeat(40),
           before_sha: firstSha,
-          ref_name: "refs/heads/main",
-          source: "refs",
+          ref_name: "refs/tags/v1",
+        },
+        {
+          after_sha: "b".repeat(40),
+          before_sha: "0".repeat(40),
+          ref_name: "refs/tags/v3",
         },
       ]);
+      await admin`
+        delete from github_push_observations where repository_id = '408'
+      `;
+      await admin`
+        delete from github_repository_refs where repository_id = '408'
+      `;
+      await admin`delete from github_repositories where id = '408'`;
+      await admin`
+        delete from github_account_checkpoints where account = 'f0rr0'
+      `;
     });
 
-    test("queues idempotent bounded backfill observations per distinct ref head", async () => {
-      const headSha = "8".repeat(40);
+    test("defers event polling until the provider interval is due", async () => {
+      await admin`
+        insert into github_account_checkpoints (
+          account, events_next_poll_at, events_last_attempted_at
+        ) values (
+          'yuppiestechdev', '2026-08-29T13:10:00.000Z', null
+        )
+        on conflict (account) do update set
+          events_next_poll_at = excluded.events_next_poll_at,
+          events_last_attempted_at = null,
+          events_last_succeeded_at = null,
+          latest_event_id = null,
+          paused = false
+      `;
+      const early = await beginGitHubEventPoll(
+        "yuppiestechdev",
+        new Date("2026-08-29T13:05:00.000Z")
+      );
+      expect(early.shouldPoll).toBe(false);
+      expect(early.checkpoint.eventsLastAttemptedAt).toBeNull();
+
+      const started = await beginGitHubEventPoll(
+        "yuppiestechdev",
+        new Date("2026-08-29T13:10:00.000Z")
+      );
+      expect(started.shouldPoll).toBe(true);
+      expect(started.checkpoint.eventsLastAttemptedAt).toEqual(
+        new Date("2026-08-29T13:10:00.000Z")
+      );
+      const overlapping = await beginGitHubEventPoll(
+        "yuppiestechdev",
+        new Date("2026-08-29T13:10:10.000Z")
+      );
+      expect(overlapping.shouldPoll).toBe(false);
+
+      await persistAccountIntake({
+        account: "yuppiestechdev",
+        events: [],
+        eventsEtag: 'W/"events"',
+        eventsNextPollAt: new Date("2026-08-29T13:20:00.000Z"),
+        expectedCheckpoint: started.checkpoint,
+        gap: null,
+        latestEventId: null,
+      });
+      const [health] = await admin`
+        select events_etag, events_last_attempted_at,
+          events_last_succeeded_at, events_next_poll_at
+        from github_account_checkpoints
+        where account = 'yuppiestechdev'
+      `;
+      expect({
+        eventsEtag: health.events_etag,
+        lastAttemptedAt: new Date(
+          health.events_last_attempted_at
+        ).toISOString(),
+        lastSucceeded: Number.isNaN(
+          new Date(health.events_last_succeeded_at).getTime()
+        )
+          ? null
+          : "valid",
+        nextPollAt: new Date(health.events_next_poll_at).toISOString(),
+      }).toEqual({
+        eventsEtag: 'W/"events"',
+        lastAttemptedAt: "2026-08-29T13:10:00.000Z",
+        lastSucceeded: "valid",
+        nextPollAt: "2026-08-29T13:20:00.000Z",
+      });
+      await admin`
+        delete from github_account_checkpoints
+        where account = 'yuppiestechdev'
+      `;
+    });
+
+    test("rejects an older event poll after a newer poll starts", async () => {
+      const firstAttemptAt = new Date("2026-08-29T14:00:00.000Z");
+      const secondAttemptAt = new Date("2026-08-29T14:01:00.000Z");
+      await admin`
+        insert into github_account_checkpoints (
+          account, events_last_attempted_at, events_next_poll_at,
+          latest_event_id, paused
+        ) values (
+          'yuppiestechdev', null, ${firstAttemptAt.toISOString()},
+          '900000100', false
+        )
+        on conflict (account) do update set
+          events_last_attempted_at = null,
+          events_next_poll_at = excluded.events_next_poll_at,
+          latest_event_id = excluded.latest_event_id,
+          paused = false
+      `;
+
+      const first = await beginGitHubEventPoll(
+        "yuppiestechdev",
+        firstAttemptAt
+      );
+      const second = await beginGitHubEventPoll(
+        "yuppiestechdev",
+        secondAttemptAt
+      );
+      expect(first.shouldPoll).toBe(true);
+      expect(second.shouldPoll).toBe(true);
+
+      await persistAccountIntake({
+        account: "yuppiestechdev",
+        events: [],
+        eventsEtag: 'W/"newer"',
+        eventsNextPollAt: new Date("2026-08-29T14:10:00.000Z"),
+        expectedCheckpoint: second.checkpoint,
+        gap: null,
+        latestEventId: "900000100",
+      });
+      await expect(
+        persistAccountIntake({
+          account: "yuppiestechdev",
+          events: [],
+          eventsEtag: 'W/"older"',
+          eventsNextPollAt: new Date("2026-08-29T14:05:00.000Z"),
+          expectedCheckpoint: first.checkpoint,
+          gap: null,
+          latestEventId: "900000100",
+        })
+      ).rejects.toThrow("checkpoint changed");
+
+      const [checkpoint] = await admin`
+        select events_etag, events_last_attempted_at, events_next_poll_at
+        from github_account_checkpoints
+        where account = 'yuppiestechdev'
+      `;
+      expect({
+        eventsEtag: checkpoint.events_etag,
+        lastAttemptedAt: new Date(
+          checkpoint.events_last_attempted_at
+        ).toISOString(),
+        nextPollAt: new Date(checkpoint.events_next_poll_at).toISOString(),
+      }).toEqual({
+        eventsEtag: 'W/"newer"',
+        lastAttemptedAt: "2026-08-29T14:01:00.000Z",
+        nextPollAt: "2026-08-29T14:10:00.000Z",
+      });
+      await admin`
+        delete from github_account_checkpoints
+        where account = 'yuppiestechdev'
+      `;
+    });
+
+    test("promotes exact webhook evidence over a sparse ref observation", async () => {
       const repository = {
-        fullName: "example-org/backfill-checkpoints",
-        htmlUrl: "https://github.com/example-org/backfill-checkpoints",
-        id: "405",
+        fullName: "example-org/ref-evidence-promotion",
+        htmlUrl: "https://github.com/example-org/ref-evidence-promotion",
+        id: "406",
         ownerAvatarUrl: null,
         ownerId: "202",
         ownerLogin: "example-org",
         ownerType: "Organization",
         visibility: "private",
       };
-      const input = {
+      const firstSha = "1".repeat(40);
+      const headSha = "2".repeat(40);
+      const baselineStartedAt = new Date("2026-08-29T10:45:00.000Z");
+      const baselineLease = await acquireGitHubRefReconciliationLease({
         account: "f0rr0",
-        observedAt: new Date("2026-08-29T11:00:00.000Z"),
-        refs: [
-          { headSha, kind: "head", refName: "refs/heads/main" },
-          { headSha, kind: "tag", refName: "refs/tags/v1" },
-        ],
+        kind: "head",
+        leaseDurationMs: 120_000,
+        now: baselineStartedAt,
+      });
+      expect(baselineLease).not.toBeNull();
+      await persistGitHubRepositoryRefPage({
+        account: "f0rr0",
+        complete: true,
+        kind: "head",
+        leaseToken: baselineLease.leaseToken,
+        nextPage: null,
+        observedAt: new Date("2026-08-29T10:45:10.000Z"),
+        refs: [],
         repository,
-        windows: [
-          {
-            sinceAt: new Date("2026-07-01T00:00:00.000Z"),
-            untilAt: new Date("2026-07-31T23:59:59.999Z"),
-          },
-          {
-            sinceAt: new Date("2026-08-01T00:00:00.000Z"),
-            untilAt: new Date("2026-08-29T23:59:59.999Z"),
-          },
-        ],
-      };
+        scanStartedAt: baselineStartedAt,
+      });
+      await finishGitHubRefReconciliationLease({
+        account: "f0rr0",
+        complete: true,
+        kind: "head",
+        leaseToken: baselineLease.leaseToken,
+        now: new Date("2026-08-29T10:45:20.000Z"),
+      });
 
-      try {
-        expect(await persistGitHubRepositoryBackfill(input)).toEqual({
-          duplicates: 0,
-          observations: 2,
-          refs: 1,
-        });
-        expect(await persistGitHubRepositoryBackfill(input)).toEqual({
-          duplicates: 2,
-          observations: 0,
-          refs: 1,
-        });
-        const observations = await admin`
-        select before_sha, history_since_at, history_until_at, ref_name, source
-        from github_push_observations
-        where repository_id = '405'
-        order by history_since_at
-      `;
-        expect(observations).toEqual([
-          {
-            before_sha: "0".repeat(40),
-            history_since_at: "2026-07-01 00:00:00+00",
-            history_until_at: "2026-07-31 23:59:59.999+00",
-            ref_name: "refs/heads/main",
-            source: "backfill",
-          },
-          {
-            before_sha: "0".repeat(40),
-            history_since_at: "2026-08-01 00:00:00+00",
-            history_until_at: "2026-08-29 23:59:59.999+00",
-            ref_name: "refs/heads/main",
-            source: "backfill",
-          },
-        ]);
-
-        await admin`
+      const changedStartedAt = new Date("2026-08-29T11:00:00.000Z");
+      const changedLease = await acquireGitHubRefReconciliationLease({
+        account: "f0rr0",
+        kind: "head",
+        leaseDurationMs: 120_000,
+        now: changedStartedAt,
+      });
+      expect(changedLease).not.toBeNull();
+      await persistGitHubRepositoryRefPage({
+        account: "f0rr0",
+        complete: true,
+        kind: "head",
+        leaseToken: changedLease.leaseToken,
+        nextPage: null,
+        observedAt: new Date("2026-08-29T11:00:10.000Z"),
+        refs: [{ headSha, kind: "head", refName: "refs/heads/exact-evidence" }],
+        repository,
+        scanStartedAt: changedStartedAt,
+      });
+      await finishGitHubRefReconciliationLease({
+        account: "f0rr0",
+        complete: true,
+        kind: "head",
+        leaseToken: changedLease.leaseToken,
+        now: new Date("2026-08-29T11:00:20.000Z"),
+      });
+      await admin`
         update github_push_observations
-        set state = 'unavailable'
-        where repository_id = '405'
-          and history_since_at = '2026-07-01T00:00:00.000Z'
+        set attempt_count = 7, error_code = 'sparse_history_incomplete',
+          lease_until = '2026-08-30T11:00:00.000Z', state = 'deferred'
+        where repository_id = '406'
       `;
-        expect(
-          await persistGitHubRepositoryBackfill({
-            ...input,
-            observedAt: new Date("2026-08-29T12:00:00.000Z"),
+      const push = {
+        before: "0".repeat(40),
+        commitShas: [firstSha, headSha],
+        head: headSha,
+        pushedBy: "f0rr0",
+        ref: "refs/heads/exact-evidence",
+        repository,
+        size: 2,
+      };
+      const promoted = await persistGitHubWebhookPush(
+        "00000000-0000-4000-8000-000000000406",
+        push
+      );
+      expect(promoted).toMatchObject({ knownCommits: 2, pushes: 1 });
+
+      const [observation] = await admin`
+        select attempt_count, error_code, expected_commit_count, id,
+          lease_token, source, state
+        from github_push_observations
+        where repository_id = '406'
+      `;
+      expect(observation).toMatchObject({
+        attempt_count: 0,
+        error_code: null,
+        expected_commit_count: 2,
+        lease_token: null,
+        source: "refs",
+        state: "pending",
+      });
+      expect(
+        await admin`
+          select position, sha
+          from github_push_observation_commits
+          where observation_id = ${observation.id}::uuid
+          order by position
+        `
+      ).toEqual([
+        { position: 0, sha: firstSha },
+        { position: 1, sha: headSha },
+      ]);
+
+      await expect(
+        persistGitHubWebhookPush("00000000-0000-4000-8000-000000000407", {
+          ...push,
+          commitShas: ["3".repeat(40), headSha],
+        })
+      ).rejects.toThrow("Conflicting GitHub push evidence");
+      await admin`
+        delete from github_push_observation_commits
+        where observation_id in (
+          select id from github_push_observations where repository_id = '406'
+        )
+      `;
+      await admin`
+        delete from github_push_observations where repository_id = '406'
+      `;
+      await admin`
+        delete from github_webhook_deliveries where repository_id = '406'
+      `;
+      await admin`
+        delete from github_repository_refs where repository_id = '406'
+      `;
+      await admin`delete from github_repositories where id = '406'`;
+      await admin`
+        delete from github_account_checkpoints where account = 'f0rr0'
+      `;
+    });
+
+    test("releases deadline claims without spending retry attempts or backoff", async () => {
+      const repositoryId = "419";
+      const sha = "4".repeat(40);
+      const summaryActivityId = "00000000-0000-4000-8000-000000000419";
+      const priorRetryAt = new Date("2026-08-30T11:00:00.000Z");
+      const priorAttemptedAt = new Date("2026-08-30T10:00:00.000Z");
+      const claimedAt = new Date("2026-08-30T12:00:00.000Z");
+
+      await admin`
+        insert into github_account_checkpoints (account)
+        values ('f0rr0')
+        on conflict (account) do nothing
+      `;
+      await admin`
+        insert into github_repositories (full_name, id)
+        values ('f0rr0/deadline-release', ${repositoryId})
+      `;
+      await admin`
+        insert into github_push_observations (
+          account, after_sha, attempt_count, before_sha, error_code,
+          lease_until, observed_at, ref_name, repository_id,
+          repository_name_snapshot, source, source_id, state
+        ) values (
+          'f0rr0', ${"4".repeat(40)}, 7, ${"3".repeat(40)},
+          'observation_retry', ${priorRetryAt.toISOString()}, '2018-01-01T00:00:00.000Z',
+          'refs/heads/deadline-release', ${repositoryId},
+          'f0rr0/deadline-release', 'refs', 'deadline-release-observation',
+          'deferred'
+        )
+      `;
+      await admin`
+        insert into github_commits (
+          author_login, committed_at, enrichment_attempts, enrichment_error,
+          enrichment_lease_until, enrichment_state, first_observed_at,
+          message, pr_discovery_attempts, pr_discovery_error,
+          pr_discovery_lease_until, pr_discovery_state, repository,
+          repository_id, sha
+        ) values (
+          'f0rr0', '2018-01-01T00:00:00.000Z', 7, 'enrichment_retry',
+          ${priorRetryAt.toISOString()}, 'pending', '2018-01-01T00:00:00.000Z',
+          'fix: release deadline claims', 6, 'discovery_retry',
+          ${priorRetryAt.toISOString()}, 'pending', 'f0rr0/deadline-release', ${repositoryId},
+          ${sha}
+        )
+      `;
+      await admin`
+        insert into github_pull_request_signals (
+          account, action, attempt_count, error_code, event_id, lease_until,
+          number, observed_at, occurred_at, repository_id,
+          repository_name_snapshot, state
+        ) values (
+          'f0rr0', 'synchronize', 5, 'signal_retry', '910000000',
+          ${priorRetryAt.toISOString()}, 419, '2018-01-01T00:00:00.000Z',
+          '2018-01-01T00:00:00.000Z', ${repositoryId},
+          'f0rr0/deadline-release', 'pending'
+        )
+      `;
+      await admin`
+        insert into github_pull_requests (
+          account, author_login, author_user_id, created_at, next_reconcile_at,
+          node_id, number, provider_updated_at, reconcile_attempts,
+          reconcile_error, repository_id, state, title, title_snapshot, url
+        ) values (
+          'f0rr0', 'f0rr0', '101', '2018-01-01T00:00:00.000Z',
+          ${priorRetryAt.toISOString()}, 'PR_deadline_release', 419,
+          '2018-01-01T00:00:00.000Z', 4, 'pull_request_retry', ${repositoryId},
+          'open', 'Release deadline claim', 'Release deadline claim',
+          'https://github.com/f0rr0/deadline-release/pull/419'
+        )
+      `;
+
+      const [observation] = await claimGitHubPushObservations(
+        1,
+        ["f0rr0"],
+        claimedAt
+      );
+      const [enrichment] = await claimGitHubCommitsForEnrichment(
+        1,
+        ["f0rr0"],
+        claimedAt
+      );
+      const [signal] = await claimGitHubPullRequestSignals(
+        1,
+        ["f0rr0"],
+        claimedAt
+      );
+      const [pullRequest] = await claimDueGitHubPullRequests(
+        "f0rr0",
+        Number.POSITIVE_INFINITY,
+        1,
+        claimedAt
+      );
+      expect(observation.repositoryId).toBe(repositoryId);
+      expect(enrichment.repositoryId).toBe(repositoryId);
+      expect(signal.repositoryId).toBe(repositoryId);
+      expect(pullRequest.nodeId).toBe("PR_deadline_release");
+
+      await releaseGitHubPushObservation(observation);
+      await releaseGitHubCommitEnrichment(enrichment);
+      await releaseGitHubPullRequestSignal(signal);
+      await releaseGitHubPullRequestReconciliation(pullRequest);
+
+      const [releasedEnrichment] = await admin`
+        select enrichment_attempts, enrichment_error, enrichment_lease_token,
+          enrichment_lease_until, enrichment_state
+        from github_commits
+        where repository_id = ${repositoryId} and sha = ${sha}
+      `;
+      expect({
+        ...releasedEnrichment,
+        enrichment_lease_until: new Date(
+          releasedEnrichment.enrichment_lease_until
+        ).toISOString(),
+      }).toEqual({
+        enrichment_attempts: 7,
+        enrichment_error: "enrichment_retry",
+        enrichment_lease_token: null,
+        enrichment_lease_until: priorRetryAt.toISOString(),
+        enrichment_state: "pending",
+      });
+
+      await admin`
+        update github_commits
+        set activity_public_id = ${summaryActivityId},
+          canonicalized_at = '2026-08-30T10:30:00.000Z',
+          enrichment_error = null, enrichment_lease_until = null,
+          enrichment_state = 'complete',
+          languages = '[]'::jsonb, parent_shas = ${JSON.stringify([
+            "2".repeat(40),
+          ])}::jsonb
+        where repository_id = ${repositoryId} and sha = ${sha}
+      `;
+      const [discovery] = await claimGitHubCommitsForPullRequestDiscovery(
+        1,
+        ["f0rr0"],
+        claimedAt
+      );
+      expect(discovery.repositoryId).toBe(repositoryId);
+      await releaseGitHubPullRequestDiscovery(discovery);
+
+      await admin`
+        insert into github_public_activities (
+          public_id, kind, occurred_at, repository_id, revision, source_node_id
+        ) values (
+          ${summaryActivityId}, 'commit', '2018-01-01T00:00:00.000Z',
+          ${repositoryId}, 1, ${sha}
+        )
+      `;
+      await admin`
+        insert into github_summary_attempts (
+          activity_public_id, attempt_count, attempted_at, created_at,
+          error_code, lease_until, revision, state
+        ) values (
+          ${summaryActivityId}, 3, ${priorAttemptedAt.toISOString()},
+          '2018-01-01T00:00:00.000Z', 'summary_retry', ${priorRetryAt.toISOString()}, 1,
+          'pending'
+        )
+      `;
+      const [summary] = await claimGitHubSummaryAttempts(
+        1,
+        ["f0rr0"],
+        claimedAt
+      );
+      expect(summary.activityPublicId).toBe(summaryActivityId);
+      await releaseGitHubSummaryAttempt(summary);
+
+      const [releasedObservation] = await admin`
+        select attempt_count, error_code, lease_until, state
+        from github_push_observations
+        where repository_id = ${repositoryId}
+      `;
+      const [releasedCommit] = await admin`
+        select enrichment_attempts, enrichment_lease_token,
+          pr_discovery_attempts, pr_discovery_error,
+          pr_discovery_lease_token, pr_discovery_lease_until,
+          pr_discovery_state
+        from github_commits
+        where repository_id = ${repositoryId} and sha = ${sha}
+      `;
+      const [releasedSignal] = await admin`
+        select attempt_count, error_code, lease_until, state
+        from github_pull_request_signals where event_id = '910000000'
+      `;
+      const [releasedPullRequest] = await admin`
+        select next_reconcile_at, reconcile_attempts, reconcile_error
+        from github_pull_requests where node_id = 'PR_deadline_release'
+      `;
+      const [releasedSummary] = await admin`
+        select attempt_count, attempted_at, error_code, lease_until, state
+        from github_summary_attempts where activity_public_id = ${summaryActivityId}
+      `;
+      expect({
+        ...releasedObservation,
+        lease_until: new Date(releasedObservation.lease_until).toISOString(),
+      }).toEqual({
+        attempt_count: 7,
+        error_code: "observation_retry",
+        lease_until: priorRetryAt.toISOString(),
+        state: "deferred",
+      });
+      await admin`
+        update github_push_observations
+        set attempt_count = 9, error_code = 'expired_worker',
+          lease_token = '30000000-0000-4000-8000-000000000419',
+          lease_until = ${priorRetryAt.toISOString()}, state = 'processing'
+        where repository_id = ${repositoryId}
+      `;
+      const [reclaimedObservation] = await claimGitHubPushObservations(
+        1,
+        ["f0rr0"],
+        claimedAt
+      );
+      expect(reclaimedObservation).toMatchObject({
+        attemptCount: 10,
+        priorAttemptCount: 9,
+        priorErrorCode: "expired_worker",
+        priorState: "deferred",
+        repositoryId,
+      });
+      await releaseGitHubPushObservation(reclaimedObservation);
+      const [releasedExpiredObservation] = await admin`
+        select attempt_count, error_code, lease_until, state
+        from github_push_observations where repository_id = ${repositoryId}
+      `;
+      expect({
+        ...releasedExpiredObservation,
+        lease_until: new Date(
+          releasedExpiredObservation.lease_until
+        ).toISOString(),
+      }).toEqual({
+        attempt_count: 9,
+        error_code: "expired_worker",
+        lease_until: priorRetryAt.toISOString(),
+        state: "deferred",
+      });
+      expect({
+        ...releasedCommit,
+        pr_discovery_lease_until: new Date(
+          releasedCommit.pr_discovery_lease_until
+        ).toISOString(),
+      }).toEqual({
+        enrichment_attempts: 7,
+        enrichment_lease_token: null,
+        pr_discovery_attempts: 6,
+        pr_discovery_error: "discovery_retry",
+        pr_discovery_lease_token: null,
+        pr_discovery_lease_until: priorRetryAt.toISOString(),
+        pr_discovery_state: "pending",
+      });
+      expect({
+        ...releasedSignal,
+        lease_until: new Date(releasedSignal.lease_until).toISOString(),
+      }).toEqual({
+        attempt_count: 5,
+        error_code: "signal_retry",
+        lease_until: priorRetryAt.toISOString(),
+        state: "pending",
+      });
+      expect({
+        ...releasedPullRequest,
+        next_reconcile_at: new Date(
+          releasedPullRequest.next_reconcile_at
+        ).toISOString(),
+      }).toEqual({
+        next_reconcile_at: priorRetryAt.toISOString(),
+        reconcile_attempts: 4,
+        reconcile_error: "pull_request_retry",
+      });
+      expect({
+        ...releasedSummary,
+        attempted_at: new Date(releasedSummary.attempted_at).toISOString(),
+        lease_until: new Date(releasedSummary.lease_until).toISOString(),
+      }).toEqual({
+        attempt_count: 3,
+        attempted_at: priorAttemptedAt.toISOString(),
+        error_code: "summary_retry",
+        lease_until: priorRetryAt.toISOString(),
+        state: "pending",
+      });
+
+      const repository = {
+        fullName: "f0rr0/deadline-release",
+        htmlUrl: "https://github.com/f0rr0/deadline-release",
+        id: repositoryId,
+        ownerAvatarUrl: null,
+        ownerId: "101",
+        ownerLogin: "f0rr0",
+        ownerType: "User",
+        visibility: "public",
+      };
+      const newerEvidenceAt = new Date("2026-08-30T12:05:00.000Z");
+      const newerPullRequest = {
+        action: "synchronize",
+        additions: 1,
+        author: "f0rr0",
+        authorAccount: "f0rr0",
+        authorUserId: "101",
+        baseRef: "main",
+        baseRepository: repository,
+        baseSha: "1".repeat(40),
+        body: null,
+        changedFiles: 1,
+        closedAt: null,
+        commitCount: 1,
+        createdAt: "2018-01-01T00:00:00.000Z",
+        deletions: 0,
+        draft: false,
+        headRef: "feature",
+        headRepository: repository,
+        headSha: "5".repeat(40),
+        id: "419",
+        mergeCommitSha: null,
+        merged: false,
+        mergedAt: null,
+        nodeId: "PR_deadline_release",
+        number: 419,
+        providerUpdatedAt: "2018-01-02T00:00:00.000Z",
+        repository,
+        state: "open",
+        title: "Release a newer evidence retry",
+        url: "https://github.com/f0rr0/deadline-release/pull/419",
+      };
+      const storedNewerEvidence = await persistGitHubPullRequestSnapshot(
+        "f0rr0",
+        newerPullRequest,
+        { refreshMembership: true },
+        newerEvidenceAt
+      );
+      expect(storedNewerEvidence).toMatchObject({
+        retryLifecycleReset: true,
+      });
+      const [requeuedNewerEvidence] = await admin`
+        select next_reconcile_at, reconcile_attempts, reconcile_error
+        from github_pull_requests where node_id = 'PR_deadline_release'
+      `;
+      expect({
+        ...requeuedNewerEvidence,
+        next_reconcile_at: new Date(
+          requeuedNewerEvidence.next_reconcile_at
+        ).toISOString(),
+      }).toEqual({
+        next_reconcile_at: newerEvidenceAt.toISOString(),
+        reconcile_attempts: 0,
+        reconcile_error: null,
+      });
+      const claimAfterNewerEvidence = new Date("2026-08-30T12:06:00.000Z");
+      const [newerEvidenceClaim] = await claimDueGitHubPullRequests(
+        "f0rr0",
+        Number.POSITIVE_INFINITY,
+        1,
+        claimAfterNewerEvidence
+      );
+      const latestPullRequest = {
+        ...newerPullRequest,
+        headSha: "6".repeat(40),
+        providerUpdatedAt: "2018-01-03T00:00:00.000Z",
+      };
+      const storedDuringClaim = await persistGitHubPullRequestSnapshot(
+        "f0rr0",
+        latestPullRequest,
+        {
+          reconciliationLeaseUntil: newerEvidenceClaim.leaseUntil,
+          refreshMembership: true,
+        },
+        new Date("2026-08-30T12:06:01.000Z")
+      );
+      expect(storedDuringClaim).toMatchObject({ retryLifecycleReset: true });
+      const [leasePreserved] = await admin`
+        select next_reconcile_at, reconcile_attempts, reconcile_error
+        from github_pull_requests where node_id = 'PR_deadline_release'
+      `;
+      expect({
+        ...leasePreserved,
+        next_reconcile_at: new Date(
+          leasePreserved.next_reconcile_at
+        ).toISOString(),
+      }).toEqual({
+        next_reconcile_at: newerEvidenceClaim.leaseUntil.toISOString(),
+        reconcile_attempts: 0,
+        reconcile_error: null,
+      });
+      newerEvidenceClaim.attemptCount = 1;
+      newerEvidenceClaim.priorAttemptCount = 0;
+      newerEvidenceClaim.priorErrorCode = null;
+      await releaseGitHubPullRequestReconciliation(newerEvidenceClaim);
+      const [releasedAfterNewerEvidence] = await admin`
+        select next_reconcile_at, reconcile_attempts, reconcile_error
+        from github_pull_requests where node_id = 'PR_deadline_release'
+      `;
+      expect({
+        ...releasedAfterNewerEvidence,
+        next_reconcile_at: new Date(
+          releasedAfterNewerEvidence.next_reconcile_at
+        ).toISOString(),
+      }).toEqual({
+        next_reconcile_at: newerEvidenceClaim.priorRetryAt.toISOString(),
+        reconcile_attempts: 0,
+        reconcile_error: null,
+      });
+      const [retryAfterDeadline] = await claimDueGitHubPullRequests(
+        "f0rr0",
+        Number.POSITIVE_INFINITY,
+        1,
+        new Date("2026-08-30T12:06:03.000Z")
+      );
+      expect(retryAfterDeadline).toMatchObject({
+        attemptCount: 1,
+        nodeId: "PR_deadline_release",
+      });
+      await persistGitHubPullRequestSnapshot(
+        "f0rr0",
+        latestPullRequest,
+        {
+          reconciliationLeaseUntil: retryAfterDeadline.leaseUntil,
+          refreshMembership: true,
+        },
+        new Date("2026-08-30T12:06:04.000Z")
+      );
+      expect(
+        await completeGitHubPullRequestReconciliation(
+          retryAfterDeadline,
+          latestPullRequest,
+          new Date("2026-08-30T12:06:05.000Z")
+        )
+      ).toBe(true);
+
+      await admin`
+        delete from github_summary_attempts where activity_public_id = ${summaryActivityId}
+      `;
+      await admin`
+        delete from github_public_activities where public_id = ${summaryActivityId}
+      `;
+      await admin`delete from github_commits where repository_id = ${repositoryId}`;
+      await admin`
+        delete from github_pull_request_signals where repository_id = ${repositoryId}
+      `;
+      await admin`
+        delete from github_push_observations where repository_id = ${repositoryId}
+      `;
+      await admin`
+        delete from github_pull_requests where repository_id = ${repositoryId}
+      `;
+      await admin`delete from github_repositories where id = ${repositoryId}`;
+      await admin`
+        delete from github_account_checkpoints where account = 'f0rr0'
+      `;
+    });
+
+    test("unpublishes base and fork PR aliases when a webhook reports a new head", async () => {
+      const baseRepository = {
+        fullName: "example-org/alias-invalidation",
+        htmlUrl: "https://github.com/example-org/alias-invalidation",
+        id: "408",
+        ownerAvatarUrl: null,
+        ownerId: "202",
+        ownerLogin: "example-org",
+        ownerType: "Organization",
+        visibility: "private",
+      };
+      const headRepository = {
+        fullName: "f0rr0/alias-invalidation-fork",
+        htmlUrl: "https://github.com/f0rr0/alias-invalidation-fork",
+        id: "409",
+        ownerAvatarUrl: null,
+        ownerId: "101",
+        ownerLogin: "f0rr0",
+        ownerType: "User",
+        visibility: "public",
+      };
+      const pullRequestNodeId = "PR_alias_invalidation";
+      const oldHeadSha = "4".repeat(40);
+      const newHeadSha = "5".repeat(40);
+      const eventHeadSha = "8".repeat(40);
+      const sourceSha = "6".repeat(40);
+      const baseAliasSha = "7".repeat(40);
+      const sourceActivityId = "00000000-0000-4000-8000-000000000408";
+      const baseAliasActivityId = "00000000-0000-4000-8000-000000000409";
+      const headAliasActivityId = "00000000-0000-4000-8000-000000000410";
+
+      await admin.begin(async (transaction) => {
+        await transaction`
+          insert into github_repositories (
+            id, full_name, html_url, owner_id, owner_login, owner_type,
+            visibility
+          ) values
+            (
+              ${baseRepository.id}, ${baseRepository.fullName},
+              ${baseRepository.htmlUrl}, ${baseRepository.ownerId},
+              ${baseRepository.ownerLogin}, ${baseRepository.ownerType},
+              ${baseRepository.visibility}
+            ),
+            (
+              ${headRepository.id}, ${headRepository.fullName},
+              ${headRepository.htmlUrl}, ${headRepository.ownerId},
+              ${headRepository.ownerLogin}, ${headRepository.ownerType},
+              ${headRepository.visibility}
+            )
+        `;
+        await transaction`
+          insert into github_public_activities (
+            alias_evidence, alias_reason, canonical_public_id, hidden_at,
+            kind, occurred_at, public_id, published_at, repository_id,
+            revision, source_node_id
+          ) values
+            (
+              null, null, null, null, 'commit',
+              '2026-08-29T09:00:00.000Z', ${sourceActivityId},
+              null, ${headRepository.id}, 1, ${sourceSha}
+            ),
+            (
+              ${JSON.stringify({ pullRequestNodeId })}::jsonb,
+              'pr_history_exact_copy', ${sourceActivityId},
+              '2026-08-29T10:05:00.000Z', 'commit',
+              '2026-08-29T09:30:00.000Z', ${baseAliasActivityId},
+              '2026-08-29T10:00:00.000Z', ${baseRepository.id}, 1,
+              ${baseAliasSha}
+            ),
+            (
+              ${JSON.stringify({ pullRequestNodeId })}::jsonb,
+              'pr_history_exact_copy', ${sourceActivityId},
+              '2026-08-29T10:05:00.000Z', 'commit',
+              '2026-08-29T09:30:00.000Z', ${headAliasActivityId},
+              '2026-08-29T10:00:00.000Z', ${headRepository.id}, 1,
+              ${oldHeadSha}
+            )
+        `;
+        await transaction`
+          insert into github_commits (
+            activity_public_id, author_login, canonicalized_at, committed_at,
+            enrichment_state, message, parent_shas, pr_discovery_state,
+            repository, repository_id, sha
+          ) values
+            (
+              ${sourceActivityId}, 'f0rr0', '2026-08-29T10:00:00.000Z',
+              '2026-08-29T09:00:00.000Z', 'complete', 'Canonical source',
+              '[]'::jsonb, 'complete', ${headRepository.fullName},
+              ${headRepository.id}, ${sourceSha}
+            ),
+            (
+              ${baseAliasActivityId}, 'f0rr0',
+              '2026-08-29T10:00:00.000Z', '2026-08-29T09:30:00.000Z',
+              'complete', 'Derived base PR alias',
+              ${JSON.stringify([sourceSha])}::jsonb, 'complete',
+              ${baseRepository.fullName}, ${baseRepository.id},
+              ${baseAliasSha}
+            ),
+            (
+              ${headAliasActivityId}, 'f0rr0',
+              '2026-08-29T10:00:00.000Z', '2026-08-29T09:30:00.000Z',
+              'complete', 'Derived fork PR alias',
+              ${JSON.stringify([sourceSha])}::jsonb, 'complete',
+              ${headRepository.fullName}, ${headRepository.id}, ${oldHeadSha}
+            )
+        `;
+        await transaction`
+          insert into github_summary_attempts (
+            activity_public_id, attempt_count, attempted_at, completed_at,
+            error_code, input_hash, model, revision, state, summary_headline,
+            summary_short
+          ) values
+            (
+              ${baseAliasActivityId}, 4, '2026-08-29T10:00:00.000Z',
+              '2026-08-29T10:05:00.000Z', 'canonical_alias',
+              ${"a".repeat(64)}, 'gpt-test', 1, 'indeterminate',
+              'Stale base alias headline', 'Stale base alias summary'
+            ),
+            (
+              ${headAliasActivityId}, 4, '2026-08-29T10:00:00.000Z',
+              '2026-08-29T10:05:00.000Z', 'canonical_alias',
+              ${"b".repeat(64)}, 'gpt-test', 1, 'indeterminate',
+              'Stale fork alias headline', 'Stale fork alias summary'
+            )
+        `;
+        await transaction`
+          insert into github_pull_requests (
+            account, author_login, author_user_id, base_ref_name,
+            base_repository_id, base_sha, created_at, head_ref_name,
+            head_repository_id, head_sha, node_id, number,
+            provider_updated_at, reconcile_attempts, reconcile_error,
+            repository_id, state, title, title_snapshot, url
+          ) values (
+            'f0rr0', 'f0rr0', '101', 'main', ${baseRepository.id},
+            ${"1".repeat(40)}, '2026-08-29T08:00:00.000Z', 'feature',
+            ${headRepository.id}, ${oldHeadSha}, ${pullRequestNodeId}, 408,
+            '2026-08-29T11:00:00.000Z', 7, 'synchronize_failed',
+            ${baseRepository.id}, 'open',
+            'Refresh aliases after a force push',
+            'Refresh aliases after a force push',
+            'https://github.com/example-org/alias-invalidation/pull/408'
+          )
+        `;
+      });
+
+      const synchronizedPullRequest = {
+        action: "synchronize",
+        additions: null,
+        author: "f0rr0",
+        authorAccount: "f0rr0",
+        authorUserId: "101",
+        baseRef: "main",
+        baseRepository,
+        baseSha: "1".repeat(40),
+        body: null,
+        changedFiles: null,
+        closedAt: null,
+        commitCount: null,
+        createdAt: "2026-08-29T08:00:00.000Z",
+        deletions: null,
+        draft: false,
+        headRef: "feature",
+        headRepository,
+        headSha: newHeadSha,
+        id: "408",
+        mergeCommitSha: null,
+        merged: false,
+        mergedAt: null,
+        nodeId: pullRequestNodeId,
+        number: 408,
+        providerUpdatedAt: "2026-08-29T12:00:00.000Z",
+        repository: baseRepository,
+        state: "open",
+        title: "Refresh aliases after a force push",
+        url: "https://github.com/example-org/alias-invalidation/pull/408",
+      };
+      expect(
+        await persistGitHubWebhookPullRequest(
+          "00000000-0000-4000-8000-000000000408",
+          "f0rr0",
+          synchronizedPullRequest
+        )
+      ).toMatchObject({ ignored: false, pullRequests: 1 });
+
+      const aliases = await admin`
+        select alias_evidence, alias_reason, canonical_public_id, hidden_at,
+          public_id, published_at
+        from github_public_activities
+        where public_id in (${baseAliasActivityId}, ${headAliasActivityId})
+        order by public_id
+      `;
+      expect(aliases).toEqual([
+        {
+          alias_evidence: null,
+          alias_reason: null,
+          canonical_public_id: null,
+          hidden_at: null,
+          public_id: baseAliasActivityId,
+          published_at: null,
+        },
+        {
+          alias_evidence: null,
+          alias_reason: null,
+          canonical_public_id: null,
+          hidden_at: null,
+          public_id: headAliasActivityId,
+          published_at: null,
+        },
+      ]);
+      const summaries = await admin`
+        select attempt_count, attempted_at, completed_at, error_code,
+          input_hash, model, state, summary_headline, summary_short,
+          activity_public_id
+        from github_summary_attempts
+        where activity_public_id in (
+          ${baseAliasActivityId}, ${headAliasActivityId}
+        )
+        order by activity_public_id
+      `;
+      expect(summaries).toEqual(
+        [baseAliasActivityId, headAliasActivityId].map(
+          (activity_public_id) => ({
+            activity_public_id,
+            attempt_count: 0,
+            attempted_at: null,
+            completed_at: null,
+            error_code: null,
+            input_hash: null,
+            model: null,
+            state: "pending",
+            summary_headline: null,
+            summary_short: null,
           })
-        ).toEqual({ duplicates: 1, observations: 1, refs: 1 });
-      } finally {
-        await admin`delete from github_push_observations where repository_id = '405'`;
-        await admin`delete from github_repositories where id = '405'`;
-        await admin`delete from github_account_checkpoints where account = 'f0rr0'`;
-      }
+        )
+      );
+      expect(
+        await admin`
+          select canonicalized_at, repository_id
+          from github_commits
+          where repository_id in (${baseRepository.id}, ${headRepository.id})
+          order by repository_id, sha
+        `
+      ).toEqual([
+        { canonicalized_at: null, repository_id: baseRepository.id },
+        { canonicalized_at: null, repository_id: headRepository.id },
+        { canonicalized_at: null, repository_id: headRepository.id },
+      ]);
+      const [storedPullRequest] = await admin`
+        select head_repository_id, head_sha, next_reconcile_at,
+          reconcile_attempts, reconcile_error, state
+        from github_pull_requests
+        where node_id = ${pullRequestNodeId}
+      `;
+      expect(storedPullRequest).toMatchObject({
+        head_repository_id: headRepository.id,
+        head_sha: newHeadSha,
+        reconcile_attempts: 0,
+        reconcile_error: null,
+        state: "open",
+      });
+      expect(storedPullRequest.next_reconcile_at).not.toBeNull();
+
+      await admin`
+        update github_public_activities
+        set alias_evidence = ${JSON.stringify({ pullRequestNodeId })}::jsonb,
+          alias_reason = 'pr_history_exact_copy',
+          canonical_public_id = ${sourceActivityId},
+          hidden_at = '2026-08-29T12:05:00.000Z',
+          published_at = '2026-08-29T12:00:00.000Z'
+        where public_id = ${baseAliasActivityId}
+      `;
+      await admin`
+        update github_summary_attempts
+        set attempt_count = 2, attempted_at = '2026-08-29T12:00:00.000Z',
+          completed_at = '2026-08-29T12:05:00.000Z',
+          error_code = 'canonical_alias', state = 'indeterminate'
+        where activity_public_id = ${baseAliasActivityId}
+      `;
+      await admin`
+        update github_commits
+        set canonicalized_at = '2026-08-29T12:05:00.000Z'
+        where activity_public_id = ${baseAliasActivityId}
+      `;
+      const eventPoll = await beginGitHubEventPoll(
+        "f0rr0",
+        new Date("2026-08-29T13:00:00.000Z")
+      );
+      expect(eventPoll.shouldPoll).toBe(true);
+      expect(
+        await persistAccountIntake({
+          account: "f0rr0",
+          events: [
+            {
+              id: "900000408",
+              issue: null,
+              occurredAt: "2026-08-29T13:00:00.000Z",
+              pullRequest: {
+                ...synchronizedPullRequest,
+                headSha: eventHeadSha,
+                providerUpdatedAt: "2026-08-29T13:00:00.000Z",
+              },
+              push: null,
+            },
+          ],
+          expectedCheckpoint: eventPoll.checkpoint,
+          gap: null,
+          latestEventId: "900000408",
+        })
+      ).toMatchObject({ pullRequests: 1 });
+      const [eventResetAlias] = await admin`
+        select alias_evidence, alias_reason, canonical_public_id, hidden_at,
+          published_at
+        from github_public_activities
+        where public_id = ${baseAliasActivityId}
+      `;
+      expect(eventResetAlias).toEqual({
+        alias_evidence: null,
+        alias_reason: null,
+        canonical_public_id: null,
+        hidden_at: null,
+        published_at: null,
+      });
+      const [eventStoredPullRequest] = await admin`
+        select head_sha from github_pull_requests
+        where node_id = ${pullRequestNodeId}
+      `;
+      expect(eventStoredPullRequest.head_sha).toBe(eventHeadSha);
+      await admin`
+        delete from github_account_checkpoints where account = 'f0rr0'
+      `;
     });
 
     test("pages complete UTC days and projects only current complete PR membership", async () => {
@@ -963,10 +2045,12 @@ describe.skipIf(!dockerAvailable)(
       await admin`
         insert into github_pull_requests (
           account, author_login, author_user_id, created_at, node_id, number,
-          provider_updated_at, repository_id, state, title, title_snapshot, url
+          provider_updated_at, reconcile_attempts, reconcile_error,
+          repository_id, state, title, title_snapshot, url
         ) values (
           'f0rr0', 'f0rr0', '101', '2025-01-01T00:00:00.000Z',
-          'PR_old_equal_terminal', 79, '2026-08-28T19:00:00.000Z', '202',
+          'PR_old_equal_terminal', 79, '2026-08-28T19:00:00.000Z', 7,
+          'terminal_fetch_failed', '202',
           'open', 'Old open title', 'Old open title',
           'https://github.com/example-org/upstream/pull/79'
         )
@@ -994,19 +2078,25 @@ describe.skipIf(!dockerAvailable)(
             push: null,
           },
         ],
-        expectedCheckpoint: {
-          latestEventId: "900000002",
-          paused: false,
-        },
+        expectedCheckpoint: await readGitHubAccountCheckpoint("f0rr0"),
         gap: null,
         latestEventId: "900000003",
       });
       expect(terminalIntake.pullRequests).toBe(1);
+      const [requeuedOldPullRequest] = await admin`
+        select reconcile_attempts, reconcile_error
+        from github_pull_requests
+        where node_id = 'PR_old_equal_terminal'
+      `;
+      expect(requeuedOldPullRequest).toEqual({
+        reconcile_attempts: 0,
+        reconcile_error: null,
+      });
       const claimNow = new Date(Date.now() + 60_000);
       const claimed = await claimDueGitHubPullRequests(
         "f0rr0",
         30,
-        25,
+        8,
         claimNow
       );
       const oldTerminalClaim = claimed.find(
@@ -1033,17 +2123,20 @@ describe.skipIf(!dockerAvailable)(
       await admin`
         insert into github_pull_requests (
           account, author_login, author_user_id, created_at, node_id, number,
-          provider_updated_at, repository_id, state, title, title_snapshot, url
+          provider_updated_at, reconcile_attempts, reconcile_error,
+          repository_id, state, title, title_snapshot, url
         ) values
           (
             'f0rr0', 'somebody-else', '999', '2025-01-01T00:00:00.000Z',
-            'PR_sparse_terminal', 80, '2026-08-28T20:00:00.000Z', '202',
+            'PR_sparse_terminal', 80, '2026-08-28T20:00:00.000Z', 7,
+            'terminal_fetch_failed', '202',
             'open', 'Immutable sparse-event title', 'Immutable sparse-event title',
             'https://github.com/example-org/upstream/pull/80'
           ),
           (
             'f0rr0', 'somebody-else', '999', '2025-01-01T00:00:00.000Z',
-            'PR_sparse_stale', 82, '2026-08-28T22:00:00.000Z', '202',
+            'PR_sparse_stale', 82, '2026-08-28T22:00:00.000Z', 7,
+            'terminal_fetch_failed', '202',
             'open', 'Newer open title', 'Newer open title',
             'https://github.com/example-org/upstream/pull/82'
           )
@@ -1117,16 +2210,14 @@ describe.skipIf(!dockerAvailable)(
             push: null,
           },
         ],
-        expectedCheckpoint: {
-          latestEventId: "900000003",
-          paused: false,
-        },
+        expectedCheckpoint: await readGitHubAccountCheckpoint("f0rr0"),
         gap: null,
         latestEventId: "900000007",
       });
       expect(sparseIntake.pullRequests).toBe(1);
       const [provisionalTerminal] = await admin`
-        select closed_at, provider_updated_at, state, terminal_at, title
+        select closed_at, provider_updated_at, reconcile_attempts,
+          reconcile_error, state, terminal_at, title
         from github_pull_requests
         where node_id = 'PR_sparse_terminal'
       `;
@@ -1140,6 +2231,8 @@ describe.skipIf(!dockerAvailable)(
       }).toEqual({
         closed_at: "2026-08-28T21:00:00.000Z",
         provider_updated_at: "2026-08-28T20:00:00.000Z",
+        reconcile_attempts: 0,
+        reconcile_error: null,
         state: "closed",
         terminal_at: "2026-08-28T21:00:00.000Z",
         title: "Immutable sparse-event title",
@@ -1172,7 +2265,7 @@ describe.skipIf(!dockerAvailable)(
       const sparseClaims = await claimDueGitHubPullRequests(
         "f0rr0",
         1,
-        25,
+        8,
         new Date(Date.now() + 60_000)
       );
       expect(
@@ -1433,11 +2526,10 @@ describe.skipIf(!dockerAvailable)(
           ),
           (
             ${exactCopyIds.headlineCandidate}, 'f0rr0',
-            '2026-08-28T10:30:00.000Z', '101', ${"d".repeat(64)},
+            '2026-08-28T07:30:00.000Z', '101', ${"d".repeat(64)},
             '2026-08-28T10:30:00.000Z', '2026-08-28T10:30:00.000Z',
             'complete', true, '2026-08-28T15:30:00.000Z',
-            'Ship the squash-safe feature (#123)\n\nReviewed squash body',
-            'Ship the squash-safe feature (#123)',
+            'Ship the squash-safe feature', 'Ship the squash-safe feature',
             ${JSON.stringify(["2".repeat(40)])}::jsonb, 'complete',
             'f0rr0/exact-copies', '303', ${exactCopyShas.headlineCandidate}
           )
@@ -1490,7 +2582,7 @@ describe.skipIf(!dockerAvailable)(
         )
       ).toEqual({
         aliased: false,
-        aliases: 1,
+        aliases: 0,
         publicId: exactCopyIds.rebased,
       });
       expect(
@@ -1511,8 +2603,8 @@ describe.skipIf(!dockerAvailable)(
           new Date("2026-08-28T16:01:30.000Z")
         )
       ).toEqual({
-        aliased: true,
-        aliases: 1,
+        aliased: false,
+        aliases: 0,
         publicId: exactCopyIds.headlineCandidate,
       });
       expect(
@@ -1539,14 +2631,9 @@ describe.skipIf(!dockerAvailable)(
       `;
       expect(exactCopyAliases).toEqual([
         {
-          alias_evidence: {
-            authoredAt: "2026-08-28T08:00:00.000Z",
-            authorUserId: "101",
-            canonicalCommitterAt: "2026-08-28T12:00:00.000Z",
-            sourceSha: exactCopyShas.rebased,
-          },
-          alias_reason: "same_authored_rewrite",
-          canonical_public_id: exactCopyIds.rebased,
+          alias_evidence: null,
+          alias_reason: null,
+          canonical_public_id: null,
           public_id: exactCopyIds.rebasedSource,
         },
         {
@@ -1557,11 +2644,9 @@ describe.skipIf(!dockerAvailable)(
         },
         {
           alias_evidence: {
-            authoredAt: null,
             directMergeParent: true,
             fingerprint: "b".repeat(64),
             fingerprintComplete: true,
-            headline: null,
             pullRequestNodeId: null,
             sourceSha: exactCopyShas.mergeParent,
           },
@@ -1576,22 +2661,14 @@ describe.skipIf(!dockerAvailable)(
           public_id: exactCopyIds.controlCandidate,
         },
         {
-          alias_evidence: {
-            authoredAt: null,
-            directMergeParent: false,
-            fingerprint: "d".repeat(64),
-            fingerprintComplete: true,
-            headline: "Ship the squash-safe feature",
-            pullRequestNodeId: null,
-            sourceSha: exactCopyShas.headlineSource,
-          },
-          alias_reason: "same_author_headline_exact_copy",
-          canonical_public_id: exactCopyIds.headlineSource,
+          alias_evidence: null,
+          alias_reason: null,
+          canonical_public_id: null,
           public_id: exactCopyIds.headlineCandidate,
         },
       ]);
 
-      const retargetedRewriteAliases = await admin`
+      const existingAliases = await admin`
         select alias_evidence, canonical_public_id, public_id
         from github_public_activities
         where public_id in (
@@ -1600,23 +2677,15 @@ describe.skipIf(!dockerAvailable)(
         )
         order by public_id
       `;
-      expect(retargetedRewriteAliases).toEqual([
+      expect(existingAliases).toEqual([
         {
-          alias_evidence: {
-            canonicalRetargetedFrom: exactCopyIds.rebasedSource,
-            canonicalRetargetReason: "same_authored_rewrite",
-            preexistingAlias: true,
-          },
-          canonical_public_id: exactCopyIds.rebased,
+          alias_evidence: { preexistingAlias: true },
+          canonical_public_id: exactCopyIds.rebasedSource,
           public_id: exactCopyIds.rebasedAlias,
         },
         {
-          alias_evidence: {
-            canonicalRetargetedFrom: exactCopyIds.rebasedAlias,
-            canonicalRetargetReason: "same_authored_rewrite",
-            preexistingAlias: true,
-          },
-          canonical_public_id: exactCopyIds.rebased,
+          alias_evidence: { preexistingAlias: true },
+          canonical_public_id: exactCopyIds.rebasedAlias,
           public_id: exactCopyIds.rebasedAliasAncestor,
         },
       ]);
@@ -1627,8 +2696,8 @@ describe.skipIf(!dockerAvailable)(
           and revision = 1
       `;
       expect(supersededSummaryAttempt).toEqual({
-        error_code: "canonical_alias",
-        state: "indeterminate",
+        error_code: null,
+        state: "pending",
       });
 
       await admin`
@@ -1729,13 +2798,15 @@ describe.skipIf(!dockerAvailable)(
       await admin`
         insert into github_pull_requests (
           account, author_login, author_user_id, created_at, merged_at,
-          merge_sha, node_id, number, provider_updated_at, repository_id,
-          state, terminal_at, title, title_snapshot, url
+          merge_sha, merge_sha_verified_at, node_id, number,
+          provider_updated_at, repository_id, state, terminal_at, title,
+          title_snapshot, url
         ) values (
           'f0rr0', 'f0rr0', '101', '2026-08-28T16:00:00.000Z',
           '2026-08-28T18:00:00.000Z', ${memberRewriteShas.latest},
-          'PR_rebase_member', 99, '2026-08-28T18:00:00.000Z', '303',
-          'merged', '2026-08-28T18:00:00.000Z',
+          '2026-08-28T18:05:00.000Z', 'PR_rebase_member', 99,
+          '2026-08-28T18:00:00.000Z', '303', 'merged',
+          '2026-08-28T18:00:00.000Z',
           'Keep a rebase-merge member canonical',
           'Keep a rebase-merge member canonical',
           'https://github.com/f0rr0/exact-copies/pull/99'
@@ -1767,7 +2838,7 @@ describe.skipIf(!dockerAvailable)(
         )
       ).toEqual({
         aliased: false,
-        aliases: 1,
+        aliases: 0,
         publicId: memberRewriteIds.latest,
       });
       const memberRewriteActivities = await admin`
@@ -1780,8 +2851,8 @@ describe.skipIf(!dockerAvailable)(
       `;
       expect(memberRewriteActivities).toEqual([
         {
-          alias_reason: "same_authored_rewrite",
-          canonical_public_id: memberRewriteIds.latest,
+          alias_reason: null,
+          canonical_public_id: null,
           public_id: memberRewriteIds.old,
         },
         {
@@ -1889,7 +2960,7 @@ describe.skipIf(!dockerAvailable)(
         )
       ).toEqual({
         aliased: false,
-        aliases: 2,
+        aliases: 0,
         publicId: evolvingRewriteIds[2],
       });
       const rewritePage = await readPublicGitHubActivityPage(
@@ -1903,8 +2974,8 @@ describe.skipIf(!dockerAvailable)(
       expect(rewritePage.days).toHaveLength(1);
       expect(rewritePage.days[0]?.day).toBe("2026-08-25");
       expect(rewritePage.days[0]?.totals).toEqual({
-        additions: 300,
-        deletions: 30,
+        additions: 600,
+        deletions: 60,
         issuesOpened: 0,
         pullRequestsMerged: 0,
         repositories: 1,
@@ -1915,7 +2986,353 @@ describe.skipIf(!dockerAvailable)(
           id: evolvingRewriteIds[2],
           kind: "commit",
         },
+        {
+          commit: { headline: "Middle ISR headline" },
+          id: evolvingRewriteIds[1],
+          kind: "commit",
+        },
+        {
+          commit: { headline: "Old ISR headline" },
+          id: evolvingRewriteIds[0],
+          kind: "commit",
+        },
       ]);
+    });
+
+    test("repairs legacy merge evidence atomically and only once", async () => {
+      const recoveryAt = new Date("2026-08-30T10:00:00.000Z");
+      const repositoryId = "909";
+      const sourceActivityId = "00000000-0000-4000-8000-000000000090";
+      const aliasActivityId = "00000000-0000-4000-8000-000000000091";
+      const sourceSha = `${"a".repeat(39)}9`;
+      const aliasSha = `${"b".repeat(39)}9`;
+      const legacyMergeSha = `${"c".repeat(39)}9`;
+      const discoveryLease = "20000000-0000-4000-8000-000000000090";
+
+      await admin.begin(async (transaction) => {
+        await transaction`
+          insert into github_repositories (
+            id, full_name, owner_id, owner_login, owner_type, visibility
+          ) values (
+            ${repositoryId}, 'example-org/recovery', '909', 'example-org',
+            'Organization', 'private'
+          )
+        `;
+        await transaction`
+          insert into github_public_activities (
+            public_id, kind, occurred_at, published_at, repository_id,
+            revision, source_node_id
+          ) values (
+            ${sourceActivityId}, 'commit', '2026-08-29T08:00:00.000Z',
+            '2026-08-29T12:00:00.000Z', ${repositoryId}, 1, ${sourceSha}
+          )
+        `;
+        await transaction`
+          insert into github_public_activities (
+            public_id, alias_evidence, alias_reason, canonical_public_id,
+            hidden_at, kind, occurred_at, published_at, repository_id,
+            revision, source_node_id
+          ) values (
+            ${aliasActivityId}, '{"legacy":true}'::jsonb, 'regular_merge',
+            ${sourceActivityId}, '2026-08-29T12:00:00.000Z', 'commit',
+            '2026-08-29T09:00:00.000Z', '2026-08-29T12:00:00.000Z',
+            ${repositoryId}, 1, ${aliasSha}
+          )
+        `;
+        await transaction`
+          insert into github_commits (
+            activity_public_id, author_login, canonicalized_at, committed_at,
+            enrichment_state, message, parent_shas, pr_discovery_attempts,
+            pr_discovery_state, repository, repository_id, sha
+          ) values (
+            ${sourceActivityId}, 'f0rr0', '2026-08-29T11:00:00.000Z',
+            '2026-08-29T08:00:00.000Z', 'complete', 'Recovery source',
+            '[]'::jsonb, 3, 'complete', 'example-org/recovery',
+            ${repositoryId}, ${sourceSha}
+          )
+        `;
+        await transaction`
+          insert into github_commits (
+            activity_public_id, author_login, canonicalized_at, committed_at,
+            enrichment_state, message, parent_shas,
+            pr_discovery_attempts, pr_discovery_lease_token,
+            pr_discovery_lease_until,
+            pr_discovery_state, repository, repository_id, sha
+          ) values (
+            ${aliasActivityId}, 'f0rr0', '2026-08-29T11:00:00.000Z',
+            '2026-08-29T09:00:00.000Z', 'complete', 'Recovery alias',
+            ${JSON.stringify([sourceSha, "d".repeat(40)])}::jsonb,
+            5, ${discoveryLease}, '2026-08-30T10:05:00.000Z', 'processing',
+            'example-org/recovery', ${repositoryId}, ${aliasSha}
+          )
+        `;
+        await transaction`
+          insert into github_pull_requests (
+            account, author_login, author_user_id, created_at, merged_at,
+            merge_sha, node_id, number, provider_updated_at, reconcile_error,
+            reconcile_attempts, repository_id, state, terminal_at, title,
+            title_snapshot, url
+          ) values (
+            'f0rr0', 'f0rr0', '101', '2026-08-20T08:00:00.000Z',
+            '2026-08-29T10:00:00.000Z', ${legacyMergeSha},
+            'PR_recovery_legacy', 90, '2026-08-29T10:00:00.000Z',
+            'source_invalid', 4, ${repositoryId}, 'merged',
+            '2026-08-29T10:00:00.000Z', 'Legacy merge evidence',
+            'Legacy merge evidence',
+            'https://github.com/example-org/recovery/pull/90'
+          )
+        `;
+        await transaction`
+          insert into github_summary_attempts (
+            activity_public_id, attempt_count, completed_at, error_code,
+            revision, state
+          ) values
+            (${sourceActivityId}, 7, null, 'lease_expired', 1, 'pending'),
+            (
+              ${aliasActivityId}, 2, '2026-08-29T12:00:00.000Z',
+              'canonical_alias', 1, 'indeterminate'
+            )
+        `;
+      });
+
+      await expect(
+        repairLegacyGitHubEvidence("not-confirmed", recoveryAt)
+      ).rejects.toThrow("confirmation is invalid");
+      const preview = await inspectGitHubEvidenceRecovery();
+      expect(preview.constraintInstalled).toBe(false);
+      expect(preview.unverifiedMergeShasToClear).toBeGreaterThanOrEqual(1);
+      expect(preview.aliasesToClear).toBeGreaterThanOrEqual(1);
+      expect(preview.summariesToRequeue).toBeGreaterThanOrEqual(1);
+
+      const repaired = await repairLegacyGitHubEvidence(
+        "REPAIR_GITHUB_EVIDENCE_V1",
+        recoveryAt
+      );
+      expect(repaired.status).toBe("applied");
+      expect(repaired.repairedAt).toBe(recoveryAt.toISOString());
+
+      const [pullRequest] = await admin`
+        select merge_sha, merge_sha_verified_at, next_reconcile_at,
+          reconcile_attempts, reconcile_error
+        from github_pull_requests
+        where node_id = 'PR_recovery_legacy'
+      `;
+      expect({
+        ...pullRequest,
+        next_reconcile_at: new Date(
+          pullRequest.next_reconcile_at
+        ).toISOString(),
+      }).toEqual({
+        merge_sha: null,
+        merge_sha_verified_at: null,
+        next_reconcile_at: recoveryAt.toISOString(),
+        reconcile_attempts: 0,
+        reconcile_error: null,
+      });
+
+      const commits = await admin`
+        select canonicalized_at, pr_discovery_attempts, pr_discovery_error,
+          pr_discovery_lease_token, pr_discovery_state, sha
+        from github_commits
+        where repository_id = ${repositoryId}
+        order by sha
+      `;
+      expect(commits).toEqual([
+        {
+          canonicalized_at: null,
+          pr_discovery_attempts: 0,
+          pr_discovery_error: null,
+          pr_discovery_lease_token: null,
+          pr_discovery_state: "pending",
+          sha: sourceSha,
+        },
+        {
+          canonicalized_at: null,
+          pr_discovery_attempts: 0,
+          pr_discovery_error: null,
+          pr_discovery_lease_token: null,
+          pr_discovery_state: "pending",
+          sha: aliasSha,
+        },
+      ]);
+      const activities = await admin`
+        select alias_evidence, alias_reason, canonical_public_id, hidden_at,
+          public_id, published_at
+        from github_public_activities
+        where repository_id = ${repositoryId} and kind = 'commit'
+        order by public_id
+      `;
+      expect(
+        activities.map((activity) => ({
+          ...activity,
+          published_at:
+            activity.published_at === null
+              ? null
+              : new Date(activity.published_at).toISOString(),
+        }))
+      ).toEqual([
+        {
+          alias_evidence: null,
+          alias_reason: null,
+          canonical_public_id: null,
+          hidden_at: null,
+          public_id: sourceActivityId,
+          published_at: "2026-08-29T12:00:00.000Z",
+        },
+        {
+          alias_evidence: null,
+          alias_reason: null,
+          canonical_public_id: null,
+          hidden_at: null,
+          public_id: aliasActivityId,
+          published_at: null,
+        },
+      ]);
+      const summaries = await admin`
+        select activity_public_id, attempt_count, completed_at, error_code,
+          lease_token, state
+        from github_summary_attempts
+        where activity_public_id in (${sourceActivityId}, ${aliasActivityId})
+          and revision = 1
+        order by activity_public_id
+      `;
+      expect(summaries).toEqual([
+        {
+          activity_public_id: sourceActivityId,
+          attempt_count: 0,
+          completed_at: null,
+          error_code: null,
+          lease_token: null,
+          state: "pending",
+        },
+        {
+          activity_public_id: aliasActivityId,
+          attempt_count: 0,
+          completed_at: null,
+          error_code: null,
+          lease_token: null,
+          state: "pending",
+        },
+      ]);
+      expect(
+        await admin`
+          select public_id
+          from github_public_activities
+          where repository_id = ${repositoryId}
+        `
+      ).toHaveLength(2);
+
+      await expect(
+        (async () => {
+          await admin`
+            update github_pull_requests
+            set merge_sha = ${legacyMergeSha}, merge_sha_verified_at = null
+            where node_id = 'PR_recovery_legacy'
+          `;
+        })()
+      ).rejects.toThrow("github_pull_requests_verified_merge_sha");
+      await admin`
+        update github_pull_requests
+        set merge_sha = ${legacyMergeSha},
+          merge_sha_verified_at = '2026-08-30T10:30:00.000Z'
+        where node_id = 'PR_recovery_legacy'
+      `;
+      await admin`
+        alter table github_pull_requests
+        drop constraint github_pull_requests_verified_merge_sha
+      `;
+      const freshDatabasePreview = await inspectGitHubEvidenceRecovery();
+      expect(freshDatabasePreview.constraintInstalled).toBe(false);
+      expect(freshDatabasePreview.unverifiedMergeShasToClear).toBe(0);
+      const runRepairScript = async (confirmation) => {
+        const child = Bun.spawn(
+          [
+            "bun",
+            "scripts/repair-github-evidence.ts",
+            "--mode",
+            "apply",
+            "--confirm",
+            confirmation,
+          ],
+          {
+            cwd: repositoryRoot,
+            env: { ...process.env, DATABASE_URL: databaseUrl },
+            stderr: "pipe",
+            stdout: "pipe",
+          }
+        );
+        const [exitCode, stderr, stdout] = await Promise.all([
+          child.exited,
+          new Response(child.stderr).text(),
+          new Response(child.stdout).text(),
+        ]);
+        return { exitCode, stderr, stdout };
+      };
+      const refused = await runRepairScript("not-confirmed");
+      expect(refused.exitCode).toBe(1);
+      expect(refused.stderr).toContain("confirmation is invalid");
+      expect(refused.stdout).toBe("");
+      const concurrentRepairs = await Promise.all([
+        runRepairScript("REPAIR_GITHUB_EVIDENCE_V1"),
+        runRepairScript("REPAIR_GITHUB_EVIDENCE_V1"),
+      ]);
+      expect(concurrentRepairs.map(({ exitCode }) => exitCode)).toEqual([0, 0]);
+      const concurrentResults = concurrentRepairs.map(({ stdout }) =>
+        JSON.parse(stdout.split("\n", 1)[0])
+      );
+      expect(
+        concurrentResults
+          .map(({ status }) => status)
+          .toSorted((left, right) => left.localeCompare(right))
+      ).toEqual(["already_applied", "applied"]);
+      expect(
+        concurrentResults.find(({ status }) => status === "applied").plan
+          .unverifiedMergeShasToClear
+      ).toBe(0);
+      await admin`
+        alter table github_pull_requests
+        drop constraint github_pull_requests_verified_merge_sha
+      `;
+      const ensured = await ensureGitHubEvidenceIntegrity(
+        new Date("2026-08-30T10:45:00.000Z")
+      );
+      expect(ensured.status).toBe("applied");
+      expect(ensured.plan.unverifiedMergeShasToClear).toBe(0);
+      await admin`
+        update github_pull_requests
+        set merge_sha = null,
+          merge_sha_verified_at = '2026-08-30T10:50:00.000Z'
+        where node_id = 'PR_recovery_legacy'
+      `;
+      await admin`
+        update github_pull_requests
+        set merge_sha = ${legacyMergeSha},
+          merge_sha_verified_at = '2026-08-30T10:55:00.000Z',
+          next_reconcile_at = '2026-09-01T00:00:00.000Z'
+        where node_id = 'PR_recovery_legacy'
+      `;
+      const repeated = await repairLegacyGitHubEvidence(
+        "REPAIR_GITHUB_EVIDENCE_V1",
+        new Date("2026-08-30T11:00:00.000Z")
+      );
+      expect(repeated.status).toBe("already_applied");
+      expect(repeated.repairedAt).toBeNull();
+      const [unchanged] = await admin`
+        select merge_sha, merge_sha_verified_at, next_reconcile_at
+        from github_pull_requests
+        where node_id = 'PR_recovery_legacy'
+      `;
+      expect({
+        ...unchanged,
+        merge_sha_verified_at: new Date(
+          unchanged.merge_sha_verified_at
+        ).toISOString(),
+        next_reconcile_at: new Date(unchanged.next_reconcile_at).toISOString(),
+      }).toEqual({
+        merge_sha: legacyMergeSha,
+        merge_sha_verified_at: "2026-08-30T10:55:00.000Z",
+        next_reconcile_at: "2026-09-01T00:00:00.000Z",
+      });
     });
   }
 );

--- a/tests/github-activity-processor.test.mjs
+++ b/tests/github-activity-processor.test.mjs
@@ -1,17 +1,26 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { setTimeout as delay } from "node:timers/promises";
 
 import { env } from "../src/env.ts";
 import {
   fetchGitHubActivityCommitSource,
   fetchGitHubAssociatedPullRequests,
+  fetchGitHubPullRequestSnapshot,
   fetchGitHubPullRequestSource,
+  fetchGitHubPullRequestMembershipWithToken,
   fetchGitHubPushObservationSource,
+  generateValidatedGitHubActivitySummary,
+  GITHUB_ACTIVITY_FALLBACK_SUMMARY_MODEL,
+  resolveGitHubPullRequestMergeCommits,
 } from "../src/lib/github-activity-processor.ts";
+import { GitHubRequestDeadlineError } from "../src/lib/github-api.ts";
 
 const originalFetch = globalThis.fetch;
 const originalF0rr0Token = env.GITHUB_F0RR0_TOKEN;
 const originalYuppiesTechDevToken = env.GITHUB_YUPPIESTECHDEV_TOKEN;
 const originalDefaultToken = env.GITHUB_TOKEN;
+const originalOpenAiKey = env.OPENAI_API_KEY;
+const originalProcessOpenAiKey = process.env.OPENAI_API_KEY;
 
 const pushCommitValue = (sha, login, id) => ({
   author: { id, login },
@@ -23,11 +32,38 @@ const pushCommitValue = (sha, login, id) => ({
   sha,
 });
 
-const restoreEnvironmentValue = (name, value) => {
+const summarySource = (isPrivate) => ({
+  authorUserId: "1",
+  authoredAt: "2026-08-28T12:00:00.000Z",
+  commit: {
+    committedAt: "2026-08-28T12:00:00.000Z",
+    files: [],
+    message: "feat(billing): add AI credit ledger",
+    parents: ["a".repeat(40)],
+    providerFileCapReached: false,
+    sha: "b".repeat(40),
+    stats: { additions: 0, deletions: 0, total: 0 },
+    treeSha: "c".repeat(40),
+  },
+  committerAt: "2026-08-28T12:00:00.000Z",
+  committerUserId: "1",
+  repository: {
+    avatarUrl: null,
+    description: null,
+    fullName: "private-owner/private-repo",
+    homepageUrl: null,
+    ownerLogin: "private-owner",
+    ownerType: "Organization",
+    private: isPrivate,
+    topics: [],
+  },
+});
+
+const restoreEnvironmentValue = (name, value, target = env) => {
   if (value === undefined) {
-    Reflect.deleteProperty(env, name);
+    Reflect.deleteProperty(target, name);
   } else {
-    env[name] = value;
+    target[name] = value;
   }
 };
 
@@ -35,6 +71,7 @@ beforeEach(() => {
   delete env.GITHUB_F0RR0_TOKEN;
   delete env.GITHUB_YUPPIESTECHDEV_TOKEN;
   delete env.GITHUB_TOKEN;
+  delete env.OPENAI_API_KEY;
 });
 
 afterEach(() => {
@@ -45,6 +82,50 @@ afterEach(() => {
     originalYuppiesTechDevToken
   );
   restoreEnvironmentValue("GITHUB_TOKEN", originalDefaultToken);
+  restoreEnvironmentValue("OPENAI_API_KEY", originalOpenAiKey);
+  restoreEnvironmentValue(
+    "OPENAI_API_KEY",
+    originalProcessOpenAiKey,
+    process.env
+  );
+});
+
+test("summarizes privately without sending source evidence to a model", async () => {
+  const summary = await generateValidatedGitHubActivitySummary(
+    summarySource(true)
+  );
+
+  expect(summary.model).toBe(GITHUB_ACTIVITY_FALLBACK_SUMMARY_MODEL);
+  expect(summary.summary).toEqual({
+    headline: "Add AI credit ledger",
+    short: "Add AI credit ledger",
+  });
+});
+
+test("bounds model summaries by the worker deadline and falls back deterministically", async () => {
+  env.OPENAI_API_KEY = "test-key";
+  process.env.OPENAI_API_KEY = "test-key";
+  let providerSignal;
+  globalThis.fetch = async (_input, init) => {
+    providerSignal = init.signal;
+    await delay(60_000, undefined, { signal: providerSignal });
+    return Response.json({});
+  };
+
+  const startedAt = Date.now();
+  const summary = await generateValidatedGitHubActivitySummary(
+    summarySource(false),
+    { deadlineAt: startedAt + 50 }
+  );
+
+  expect(providerSignal).toBeInstanceOf(AbortSignal);
+  expect(providerSignal.aborted).toBe(true);
+  expect(Date.now() - startedAt).toBeLessThan(1000);
+  expect(summary.model).toBe(GITHUB_ACTIVITY_FALLBACK_SUMMARY_MODEL);
+  expect(summary.summary).toEqual({
+    headline: "Add AI credit ledger",
+    short: "Add AI credit ledger",
+  });
 });
 
 describe("GitHub activity commit acquisition", () => {
@@ -407,6 +488,7 @@ describe("GitHub activity commit acquisition", () => {
                   {
                     author: { user: { login: "f0rr0" } },
                     authoredDate: "2026-08-28T12:00:00Z",
+                    committedDate: "2026-08-28T12:01:00Z",
                     message: "head",
                     oid: afterSha,
                     url: `https://github.com/example-org/example-repo/commit/${afterSha}`,
@@ -414,6 +496,7 @@ describe("GitHub activity commit acquisition", () => {
                   {
                     author: { user: { login: "octocat" } },
                     authoredDate: "2026-08-28T11:00:00Z",
+                    committedDate: "2026-08-28T11:01:00Z",
                     message: "older",
                     oid: olderSha,
                     url: `https://github.com/example-org/example-repo/commit/${olderSha}`,
@@ -445,6 +528,7 @@ describe("GitHub activity commit acquisition", () => {
     ]);
     expect(source.commitShas).toEqual([olderSha, afterSha]);
     expect(source.commits.map(({ sha }) => sha)).toEqual([afterSha]);
+    expect(source.commits[0]?.committedAt).toBe("2026-08-28T12:01:00.000Z");
   });
 
   test("bounds a new branch by the observed count without slicing history", async () => {
@@ -469,6 +553,7 @@ describe("GitHub activity commit acquisition", () => {
                   {
                     author: { user: { login: "f0rr0" } },
                     authoredDate: "2026-08-28T12:00:00Z",
+                    committedDate: "2026-08-28T12:01:00Z",
                     message: "head",
                     oid: afterSha,
                     url: `https://github.com/example-org/example-repo/commit/${afterSha}`,
@@ -476,6 +561,7 @@ describe("GitHub activity commit acquisition", () => {
                   {
                     author: { user: { login: "octocat" } },
                     authoredDate: "2026-08-28T11:00:00Z",
+                    committedDate: "2026-08-28T11:01:00Z",
                     message: "older",
                     oid: olderSha,
                     url: `https://github.com/example-org/example-repo/commit/${olderSha}`,
@@ -528,6 +614,7 @@ describe("GitHub activity commit acquisition", () => {
                       {
                         author: { user: { login: "octocat" } },
                         authoredDate: "2026-08-28T10:00:00Z",
+                        committedDate: "2026-08-28T10:01:00Z",
                         message: "older",
                         oid: olderSha,
                         url: `https://github.com/example-org/example-repo/commit/${olderSha}`,
@@ -540,6 +627,7 @@ describe("GitHub activity commit acquisition", () => {
                       {
                         author: { user: { login: "f0rr0" } },
                         authoredDate: "2026-08-28T12:00:00Z",
+                        committedDate: "2026-08-28T12:01:00Z",
                         message: "head",
                         oid: afterSha,
                         url: `https://github.com/example-org/example-repo/commit/${afterSha}`,
@@ -547,6 +635,7 @@ describe("GitHub activity commit acquisition", () => {
                       {
                         author: { user: { login: "f0rr0" } },
                         authoredDate: "2026-08-28T11:00:00Z",
+                        committedDate: "2026-08-28T11:01:00Z",
                         message: "middle",
                         oid: middleSha,
                         url: `https://github.com/example-org/example-repo/commit/${middleSha}`,
@@ -597,6 +686,7 @@ describe("GitHub activity commit acquisition", () => {
                   {
                     author: { user: { login: "f0rr0" } },
                     authoredDate: "2026-07-15T12:00:00Z",
+                    committedDate: "2026-07-15T12:01:00Z",
                     message: "historical change",
                     oid: rangedSha,
                     url: `https://github.com/example-org/example-repo/commit/${rangedSha}`,
@@ -663,6 +753,168 @@ describe("GitHub activity commit acquisition", () => {
   });
 });
 
+describe("GitHub pull request merge commit resolution", () => {
+  test("batches node IDs and returns authoritative merge commits in input order", async () => {
+    const firstSha = "6".repeat(40);
+    const secondSha = "7".repeat(40);
+    let calls = 0;
+    globalThis.fetch = async (input, init) => {
+      calls += 1;
+      const url =
+        input instanceof Request ? new URL(input.url) : new URL(input);
+      expect(url.pathname).toBe("/graphql");
+      expect(init?.method).toBe("POST");
+      const request = JSON.parse(init?.body);
+      expect(request.variables.ids).toEqual(["PR_first", "PR_second"]);
+      return Response.json({
+        data: {
+          nodes: [
+            {
+              __typename: "PullRequest",
+              id: "PR_second",
+              mergeCommit: { oid: secondSha },
+              merged: true,
+            },
+            {
+              __typename: "PullRequest",
+              id: "PR_first",
+              mergeCommit: { oid: firstSha },
+              merged: true,
+            },
+          ],
+        },
+      });
+    };
+
+    expect(
+      await resolveGitHubPullRequestMergeCommits(
+        ["PR_first", "PR_second"],
+        "test-token"
+      )
+    ).toEqual([
+      { mergeCommitSha: firstSha, nodeId: "PR_first" },
+      { mergeCommitSha: secondSha, nodeId: "PR_second" },
+    ]);
+    expect(calls).toBe(1);
+  });
+
+  test("resolves an authoritative null merge commit for a rebase merge", async () => {
+    globalThis.fetch = async () =>
+      Response.json({
+        data: {
+          nodes: [
+            {
+              __typename: "PullRequest",
+              id: "PR_pending",
+              mergeCommit: null,
+              merged: true,
+            },
+          ],
+        },
+      });
+
+    expect(
+      await resolveGitHubPullRequestMergeCommits(["PR_pending"], "test-token")
+    ).toEqual([{ mergeCommitSha: null, nodeId: "PR_pending" }]);
+  });
+
+  test("rejects HTTP-200 GraphQL errors instead of consuming partial data", async () => {
+    globalThis.fetch = async () =>
+      Response.json({
+        data: {
+          nodes: [
+            {
+              __typename: "PullRequest",
+              id: "PR_partial",
+              mergeCommit: { oid: "8".repeat(40) },
+              merged: true,
+            },
+          ],
+        },
+        errors: [{ message: "Resolver timed out", type: "INTERNAL" }],
+      });
+
+    await expect(
+      resolveGitHubPullRequestMergeCommits(["PR_partial"], "test-token")
+    ).rejects.toMatchObject({
+      code: "source_incomplete",
+      kind: "partial_response",
+      retryable: true,
+    });
+  });
+
+  test("classifies HTTP-200 GraphQL rate limits with their reset time", async () => {
+    const resetAt = new Date("2026-08-30T18:00:00.000Z");
+    globalThis.fetch = async () =>
+      Response.json(
+        {
+          data: null,
+          errors: [
+            { message: "API rate limit exceeded", type: "RATE_LIMITED" },
+          ],
+        },
+        {
+          headers: {
+            "x-ratelimit-remaining": "0",
+            "x-ratelimit-reset": String(resetAt.getTime() / 1000),
+          },
+        }
+      );
+
+    await expect(
+      resolveGitHubPullRequestMergeCommits(["PR_limited"], "test-token")
+    ).rejects.toMatchObject({
+      code: "source_incomplete",
+      kind: "rate_limited",
+      retryable: true,
+      retryAt: resetAt,
+    });
+  });
+
+  test("waits at least one minute for a headerless GraphQL secondary limit", async () => {
+    const requestedAt = Date.now();
+    globalThis.fetch = async () =>
+      Response.json({
+        data: null,
+        errors: [{ message: "Secondary rate limit exceeded" }],
+      });
+
+    let caught;
+    try {
+      await resolveGitHubPullRequestMergeCommits(
+        ["PR_secondary_limited"],
+        "test-token"
+      );
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught).toMatchObject({
+      code: "source_incomplete",
+      kind: "rate_limited",
+      retryable: true,
+    });
+    expect(caught.retryAt.getTime()).toBeGreaterThanOrEqual(
+      requestedAt + 60_000
+    );
+  });
+
+  test("classifies a rejected GraphQL request as non-retryable", async () => {
+    globalThis.fetch = async () =>
+      Response.json({
+        data: null,
+        errors: [{ message: "Resource not accessible", type: "FORBIDDEN" }],
+      });
+
+    await expect(
+      resolveGitHubPullRequestMergeCommits(["PR_hidden"], "test-token")
+    ).rejects.toMatchObject({
+      code: "source_invalid",
+      kind: "request_rejected",
+      retryable: false,
+    });
+  });
+});
+
 describe("GitHub pull request acquisition", () => {
   const repository = {
     full_name: "example-org/example-repo",
@@ -677,9 +929,9 @@ describe("GitHub pull request acquisition", () => {
     private: false,
     visibility: "public",
   };
-  const headSha = "d".repeat(40);
   const baseSha = "e".repeat(40);
   const memberShas = ["f".repeat(40), "1".repeat(40)];
+  const headSha = memberShas.at(-1);
   const pullRequest = {
     base: { ref: "main", repo: repository, sha: baseSha },
     body: "Adds the public activity worker.",
@@ -690,7 +942,6 @@ describe("GitHub pull request acquisition", () => {
     head: { ref: "feature/worker", repo: repository, sha: headSha },
     html_url: "https://github.com/example-org/example-repo/pull/7",
     id: 700,
-    merge_commit_sha: null,
     merged: false,
     merged_at: null,
     node_id: "PR_node_700",
@@ -700,6 +951,173 @@ describe("GitHub pull request acquisition", () => {
     updated_at: "2026-08-28T10:00:00Z",
     user: { id: 900, login: "other-maintainer" },
   };
+  const authoritativeMergeSha = "2".repeat(40);
+  const rest2026MergedPullRequest = {
+    ...pullRequest,
+    closed_at: "2026-08-28T11:00:00Z",
+    merged: true,
+    merged_at: "2026-08-28T11:00:00Z",
+    state: "closed",
+    updated_at: "2026-08-28T11:00:00Z",
+  };
+
+  test("rejects an invalid associated-PR item instead of completing empty", async () => {
+    env.GITHUB_F0RR0_TOKEN = "test-token";
+    globalThis.fetch = async () =>
+      Response.json([{ ...pullRequest, node_id: null }]);
+
+    await expect(
+      fetchGitHubAssociatedPullRequests({
+        author: "f0rr0",
+        committedAt: "2026-08-28T12:00:00.000Z",
+        message: "feat: reject ambiguous PR evidence",
+        repository: repository.full_name,
+        repositoryId: String(repository.id),
+        sha: "3".repeat(40),
+      })
+    ).rejects.toMatchObject({ code: "source_invalid" });
+  });
+
+  test("resolves an associated REST 2026 merged PR through GraphQL", async () => {
+    expect(Object.hasOwn(rest2026MergedPullRequest, "merge_commit_sha")).toBe(
+      false
+    );
+    env.GITHUB_F0RR0_TOKEN = "test-token";
+    globalThis.fetch = async (input) => {
+      const url =
+        input instanceof Request ? new URL(input.url) : new URL(input);
+      if (url.pathname === "/graphql") {
+        return Response.json({
+          data: {
+            nodes: [
+              {
+                __typename: "PullRequest",
+                id: pullRequest.node_id,
+                mergeCommit: { oid: authoritativeMergeSha },
+                merged: true,
+              },
+            ],
+          },
+        });
+      }
+      return Response.json([rest2026MergedPullRequest]);
+    };
+
+    const [associated] = await fetchGitHubAssociatedPullRequests({
+      author: "f0rr0",
+      committedAt: "2026-08-28T12:00:00.000Z",
+      message: "feat: resolve merged PR identity",
+      repository: repository.full_name,
+      repositoryId: String(repository.id),
+      sha: "4".repeat(40),
+    });
+    expect(associated?.mergeCommitSha).toBe(authoritativeMergeSha);
+  });
+
+  test("resolves an authoritative merge SHA for REST 2026 snapshots", async () => {
+    env.GITHUB_F0RR0_TOKEN = "test-token";
+    const requestedPaths = [];
+    globalThis.fetch = async (input) => {
+      const url =
+        input instanceof Request ? new URL(input.url) : new URL(input);
+      requestedPaths.push(url.pathname);
+      if (url.pathname === "/graphql") {
+        return Response.json({
+          data: {
+            nodes: [
+              {
+                __typename: "PullRequest",
+                id: pullRequest.node_id,
+                mergeCommit: { oid: authoritativeMergeSha },
+                merged: true,
+              },
+            ],
+          },
+        });
+      }
+      return Response.json(rest2026MergedPullRequest);
+    };
+
+    const snapshot = await fetchGitHubPullRequestSnapshot({
+      account: "f0rr0",
+      number: 7,
+      repository: repository.full_name,
+      repositoryId: String(repository.id),
+    });
+    expect(snapshot.pullRequest.mergeCommitSha).toBe(authoritativeMergeSha);
+    expect(requestedPaths).toEqual([
+      `/repos/${repository.full_name}/pulls/7`,
+      "/graphql",
+    ]);
+  });
+
+  test("preserves an authoritative null merge SHA for a rebase merge", async () => {
+    env.GITHUB_F0RR0_TOKEN = "test-token";
+    globalThis.fetch = async (input) => {
+      const url =
+        input instanceof Request ? new URL(input.url) : new URL(input);
+      if (url.pathname === "/graphql") {
+        return Response.json({
+          data: {
+            nodes: [
+              {
+                __typename: "PullRequest",
+                id: pullRequest.node_id,
+                mergeCommit: null,
+                merged: true,
+              },
+            ],
+          },
+        });
+      }
+      return Response.json(rest2026MergedPullRequest);
+    };
+
+    const snapshot = await fetchGitHubPullRequestSnapshot({
+      account: "f0rr0",
+      number: 7,
+      repository: repository.full_name,
+      repositoryId: String(repository.id),
+    });
+    expect(snapshot.pullRequest.mergeCommitSha).toBeNull();
+  });
+
+  test("retains tracked PR commits at their committer timestamp", async () => {
+    const sha = headSha;
+    globalThis.fetch = async () =>
+      Response.json([
+        {
+          author: { login: "f0rr0" },
+          commit: {
+            author: { date: "2026-08-01T09:00:00Z" },
+            committer: { date: "2026-08-01T12:00:00Z" },
+            message: "feat: retain the provider timestamp",
+          },
+          sha,
+        },
+      ]);
+
+    const membership = await fetchGitHubPullRequestMembershipWithToken(
+      {
+        account: "f0rr0",
+        number: 7,
+        repository: repository.full_name,
+        repositoryId: String(repository.id),
+      },
+      1,
+      "test-token",
+      { expectedHeadSha: sha }
+    );
+    expect(membership).toMatchObject({
+      commits: [
+        {
+          committedAt: "2026-08-01T12:00:00.000Z",
+          sha,
+        },
+      ],
+      membershipComplete: true,
+    });
+  });
 
   test("accepts an upstream PR discovered from a fork commit", async () => {
     const commitSha = "9".repeat(40);
@@ -821,14 +1239,14 @@ describe("GitHub pull request acquisition", () => {
     ]);
   });
 
-  test("falls back to GraphQL for pull requests beyond the REST cap", async () => {
+  test("fully paginates GraphQL membership beyond the REST cap", async () => {
     env.GITHUB_F0RR0_TOKEN = "test-token";
     const graphQlCursors = [];
     globalThis.fetch = async (input, init) => {
       const url =
         input instanceof Request ? new URL(input.url) : new URL(input);
       if (url.pathname.endsWith("/pulls/7")) {
-        return Response.json({ ...pullRequest, commits: 251 });
+        return Response.json({ ...pullRequest, commits: 3051 });
       }
       if (url.pathname.endsWith("/pulls/7/commits")) {
         const page = Number(url.searchParams.get("page") ?? "1");
@@ -853,14 +1271,24 @@ describe("GitHub pull request acquisition", () => {
         const { cursor } = request.variables;
         graphQlCursors.push(cursor);
         const page = cursor === null ? 0 : Number(cursor.slice(7));
-        const count = page < 2 ? 100 : 51;
+        const count = page < 30 ? 100 : 51;
         const nodes = Array.from({ length: count }, (_, index) => ({
           commit: {
+            ...(page === 0 && index === 0
+              ? {
+                  author: { user: { login: "f0rr0" } },
+                  committedDate: "2026-08-02T12:00:00Z",
+                  message: "feat: GraphQL membership",
+                }
+              : {}),
             oid: (BigInt(page * 100 + index) + 10_000n)
               .toString(16)
               .padStart(40, "0"),
           },
         }));
+        if (page === 30) {
+          nodes.at(-1).commit.oid = headSha;
+        }
         return Response.json({
           data: {
             repository: {
@@ -868,10 +1296,10 @@ describe("GitHub pull request acquisition", () => {
                 commits: {
                   nodes,
                   pageInfo: {
-                    endCursor: page < 2 ? `cursor-${String(page + 1)}` : null,
-                    hasNextPage: page < 2,
+                    endCursor: page < 30 ? `cursor-${String(page + 1)}` : null,
+                    hasNextPage: page < 30,
                   },
-                  totalCount: 251,
+                  totalCount: 3051,
                 },
               },
             },
@@ -887,8 +1315,73 @@ describe("GitHub pull request acquisition", () => {
       repository: "example-org/example-repo",
       repositoryId: "123",
     });
-    expect(source.commitShas).toHaveLength(251);
+    expect(source.commitShas).toHaveLength(3051);
     expect(source.membershipComplete).toBe(true);
-    expect(graphQlCursors).toEqual([null, "cursor-1", "cursor-2"]);
+    expect(source.commits[0]?.committedAt).toBe("2026-08-02T12:00:00.000Z");
+    expect(graphQlCursors).toHaveLength(31);
+    expect(graphQlCursors.at(0)).toBeNull();
+    expect(graphQlCursors.at(-1)).toBe("cursor-30");
+  });
+});
+
+describe("GitHub activity provider deadlines", () => {
+  test("propagates one absolute deadline through every worker acquisition path", async () => {
+    env.GITHUB_F0RR0_TOKEN = "test-token";
+    let calls = 0;
+    globalThis.fetch = async () => {
+      calls += 1;
+      return Response.json({});
+    };
+    const deadlineAt = Date.now() - 1;
+    const commit = {
+      author: "f0rr0",
+      committedAt: "2026-08-28T12:00:00.000Z",
+      message: "feat: enforce the worker deadline",
+      repository: "example-org/example-repo",
+      repositoryId: "123",
+      sha: "2".repeat(40),
+    };
+    const pullRequest = {
+      account: "f0rr0",
+      number: 7,
+      repository: "example-org/example-repo",
+      repositoryId: "123",
+    };
+    const observation = {
+      account: "f0rr0",
+      afterSha: "2".repeat(40),
+      beforeSha: "1".repeat(40),
+      expectedCommitCount: 1,
+      historySinceAt: new Date("2026-08-01T00:00:00.000Z"),
+      historyUntilAt: null,
+      knownShas: ["2".repeat(40)],
+      observedAt: new Date("2026-08-28T12:00:00.000Z"),
+      refName: "refs/heads/main",
+      repository: "example-org/example-repo",
+      repositoryId: "123",
+    };
+
+    const callsWithDeadline = [
+      async () => await fetchGitHubActivityCommitSource(commit, { deadlineAt }),
+      async () =>
+        await fetchGitHubPushObservationSource(observation, { deadlineAt }),
+      async () =>
+        await fetchGitHubAssociatedPullRequests(commit, { deadlineAt }),
+      async () =>
+        await fetchGitHubPullRequestSnapshot(pullRequest, { deadlineAt }),
+      async () =>
+        await fetchGitHubPullRequestMembershipWithToken(
+          pullRequest,
+          1,
+          "test-token",
+          { deadlineAt }
+        ),
+      async () =>
+        await fetchGitHubPullRequestSource(pullRequest, { deadlineAt }),
+    ];
+    for (const call of callsWithDeadline) {
+      await expect(call()).rejects.toBeInstanceOf(GitHubRequestDeadlineError);
+    }
+    expect(calls).toBe(0);
   });
 });

--- a/tests/github-activity-schema.test.mjs
+++ b/tests/github-activity-schema.test.mjs
@@ -10,6 +10,7 @@ import {
   githubPublicActivities,
   githubPullRequestMemberships,
   githubPullRequests,
+  githubPullRequestSignals,
   githubPullRequestVersions,
   githubPushObservationCommits,
   githubPushObservations,
@@ -57,7 +58,29 @@ describe("GitHub activity persistence schema", () => {
     expect(githubAccountCheckpoints.gapState.default).toBe("clear");
     expect(githubAccountCheckpoints.refBackfillSinceAt.hasDefault).toBe(true);
     expect(githubAccountCheckpoints.refBackfillSinceAt.notNull).toBe(true);
+    expect(githubAccountCheckpoints.eventsEtag.name).toBe("events_etag");
+    expect(githubAccountCheckpoints.eventsNextPollAt.name).toBe(
+      "events_next_poll_at"
+    );
+    expect(githubAccountCheckpoints.headRefNextPage.name).toBe(
+      "head_ref_next_page"
+    );
+    expect(githubAccountCheckpoints.tagRefNextPage.name).toBe(
+      "tag_ref_next_page"
+    );
+    expect(checkNames(githubAccountCheckpoints)).toEqual(
+      expect.arrayContaining([
+        "github_account_checkpoints_ref_leases",
+        "github_account_checkpoints_ref_scans",
+      ])
+    );
     expect(getTableName(githubRepositories)).toBe("github_repositories");
+    expect(githubRepositories.headsLastReconciledAt.name).toBe(
+      "heads_last_reconciled_at"
+    );
+    expect(githubRepositories.tagsLastReconciledAt.name).toBe(
+      "tags_last_reconciled_at"
+    );
     expect(getTableName(githubPushObservations)).toBe(
       "github_push_observations"
     );
@@ -119,9 +142,18 @@ describe("GitHub activity persistence schema", () => {
     );
     expect(githubPullRequests.lastReconciledAt.name).toBe("last_reconciled_at");
     expect(githubPullRequests.nextReconcileAt.name).toBe("next_reconcile_at");
+    expect(githubPullRequests.mergeShaVerifiedAt.name).toBe(
+      "merge_sha_verified_at"
+    );
     expect(githubPullRequests.reconcileUntil).toBeUndefined();
     expect(indexNames(githubPullRequests)).toContain(
       "github_pull_requests_reconciliation_idx"
+    );
+    expect(checkNames(githubPullRequests)).toEqual(
+      expect.arrayContaining([
+        "github_pull_requests_nonnegative_attempts",
+        "github_pull_requests_verified_merge_sha",
+      ])
     );
   });
 
@@ -187,6 +219,7 @@ describe("GitHub activity persistence schema", () => {
       githubPushObservations,
       githubPushObservationCommits,
       githubPullRequests,
+      githubPullRequestSignals,
       githubPullRequestVersions,
       githubPullRequestMemberships,
       githubIssues,

--- a/tests/github-activity-worker.test.mjs
+++ b/tests/github-activity-worker.test.mjs
@@ -4,6 +4,7 @@ import {
   boundedWorkerLimit,
   DEFAULT_GITHUB_ACTIVITY_WORKER_BATCH_SIZE,
   exactGitHubDiffDigest,
+  githubActivityRetryAt,
   githubCommitActivityOccurredAt,
   githubPullRequestSnapshotDisposition,
   githubPrReconciliationCutoff,
@@ -134,11 +135,11 @@ describe("GitHub exact diff digest", () => {
 describe("GitHub activity worker bounds", () => {
   test("accepts only deliberately small batches", () => {
     expect(DEFAULT_GITHUB_ACTIVITY_WORKER_BATCH_SIZE).toBe(4);
-    expect(MAXIMUM_GITHUB_ACTIVITY_WORKER_BATCH_SIZE).toBe(16);
+    expect(MAXIMUM_GITHUB_ACTIVITY_WORKER_BATCH_SIZE).toBe(8);
     expect(boundedWorkerLimit()).toBe(4);
-    expect(boundedWorkerLimit(16)).toBe(16);
+    expect(boundedWorkerLimit(8)).toBe(8);
     expect(() => boundedWorkerLimit(0)).toThrow("batch size");
-    expect(() => boundedWorkerLimit(17)).toThrow("batch size");
+    expect(() => boundedWorkerLimit(9)).toThrow("batch size");
     expect(workerBatchSizeFrom(null)).toBeUndefined();
     expect(workerBatchSizeFrom("8")).toBe(8);
     expect(workerBatchSizeFrom("9")).toBeNull();
@@ -166,15 +167,44 @@ describe("GitHub activity worker bounds", () => {
     ).toBe("2026-08-28T15:00:00.000Z");
   });
 
-  test("applies the bounded PR reconciliation horizon", () => {
-    expect(GITHUB_PR_RECONCILIATION_MAX_AGE_DAYS).toBe(30);
+  test("keeps open PR reconciliation unbounded with age-aware cadence", () => {
+    expect(GITHUB_PR_RECONCILIATION_MAX_AGE_DAYS).toBe(Infinity);
     const now = new Date("2026-08-28T12:00:00.000Z");
-    expect(githubPrReconciliationCutoff(30, now)?.toISOString()).toBe(
-      "2026-07-29T12:00:00.000Z"
-    );
+    expect(githubPrReconciliationCutoff(Infinity, now)).toBeNull();
     expect(
       githubPrReconciliationCutoff(Number.MAX_SAFE_INTEGER, now)
     ).toBeNull();
+    expect(
+      nextGitHubPullRequestReconciliationAt(
+        "open",
+        now,
+        new Date("2026-06-01T00:00:00.000Z")
+      )?.toISOString()
+    ).toBe("2026-08-29T12:00:00.000Z");
+    expect(
+      nextGitHubPullRequestReconciliationAt(
+        "open",
+        now,
+        new Date("2025-01-01T00:00:00.000Z")
+      )?.toISOString()
+    ).toBe("2026-09-04T12:00:00.000Z");
+  });
+
+  test("backs off repeated transient work with a provider-aware cap", () => {
+    const now = new Date("2026-08-28T12:00:00.000Z");
+    expect(githubActivityRetryAt(1, now).toISOString()).toBe(
+      "2026-08-28T12:15:00.000Z"
+    );
+    expect(githubActivityRetryAt(20, now).toISOString()).toBe(
+      "2026-08-29T12:00:00.000Z"
+    );
+    expect(
+      githubActivityRetryAt(
+        1,
+        now,
+        new Date("2026-08-28T14:00:00.000Z")
+      ).toISOString()
+    ).toBe("2026-08-28T14:00:00.000Z");
   });
 
   test("keeps a one-shot summary unpublished while canonicalization is dirty", () => {

--- a/tests/github-backfill.test.mjs
+++ b/tests/github-backfill.test.mjs
@@ -1,15 +1,86 @@
 import { describe, expect, test } from "bun:test";
 
+import { backfillArgumentsFrom } from "../scripts/backfill-github-activity.ts";
 import {
+  GITHUB_BACKFILL_WORKER_BATCH_SIZE,
+  githubBackfillProcessingCountsFrom,
   githubBackfillRequestFrom,
-  githubBackfillRequestSeriesFrom,
-  splitGitHubBackfillRequest,
 } from "../src/lib/github-backfill-core.ts";
 
 const now = new Date("2026-08-29T15:00:00.000Z");
 
 describe("GitHub history backfill requests", () => {
-  test("normalizes inclusive UTC dates into bounded 31-day windows", () => {
+  test("rejects duplicate and unknown command arguments", () => {
+    expect(() =>
+      backfillArgumentsFrom(["--account", "f0rr0", "--account", "f0rr0"])
+    ).toThrow("arguments are invalid");
+    expect(() => backfillArgumentsFrom(["--unexpected", "value"])).toThrow(
+      "arguments are invalid"
+    );
+  });
+
+  test("uses the maximum batch size accepted by every configurable worker stage", () => {
+    expect(GITHUB_BACKFILL_WORKER_BATCH_SIZE).toBe(8);
+  });
+
+  test("reports disjoint outcomes across every stage including PR reconciliation", () => {
+    expect(
+      githubBackfillProcessingCountsFrom({
+        aliases: 7,
+        commits: {
+          claimed: 4,
+          completed: 1,
+          deferred: 1,
+          failed: 3,
+          unavailable: 1,
+        },
+        observations: {
+          claimed: 2,
+          completed: 2,
+          deferred: 0,
+          failed: 0,
+          unavailable: 0,
+        },
+        pullRequestDiscovery: {
+          claimed: 3,
+          completed: 1,
+          deferred: 2,
+          failed: 2,
+          unavailable: 0,
+        },
+        pullRequests: {
+          claimed: 5,
+          completed: 2,
+          deferred: 1,
+          failed: 3,
+          unavailable: 1,
+        },
+        pullRequestSignals: {
+          claimed: 2,
+          completed: 1,
+          deferred: 0,
+          failed: 0,
+          unavailable: 0,
+        },
+        summaries: {
+          claimed: 4,
+          completed: 2,
+          deferred: 1,
+          failed: 2,
+          unavailable: 0,
+        },
+      })
+    ).toEqual({
+      aliases: 7,
+      claimed: 20,
+      deferred: 5,
+      failed: 3,
+      processed: 9,
+      unavailable: 2,
+    });
+  });
+
+  test("normalizes one arbitrary inclusive UTC range", () => {
     const request = githubBackfillRequestFrom(
       {
         account: "all",
@@ -26,16 +97,8 @@ describe("GitHub history backfill requests", () => {
       repositoryId: "123456789",
       startDate: "2026-07-01",
     });
-    expect(request?.windows).toEqual([
-      {
-        sinceAt: new Date("2026-07-01T00:00:00.000Z"),
-        untilAt: new Date("2026-07-31T23:59:59.999Z"),
-      },
-      {
-        sinceAt: new Date("2026-08-01T00:00:00.000Z"),
-        untilAt: new Date("2026-08-29T23:59:59.999Z"),
-      },
-    ]);
+    expect(request?.sinceAt).toEqual(new Date("2026-07-01T00:00:00.000Z"));
+    expect(request?.untilAt).toEqual(new Date("2026-08-29T23:59:59.999Z"));
   });
 
   test("accepts one account and an unfiltered repository set", () => {
@@ -52,54 +115,44 @@ describe("GitHub history backfill requests", () => {
     ).toMatchObject({ accounts: ["f0rr0"], repositoryId: null });
   });
 
-  test("splits an arbitrary inclusive range into bounded requests", () => {
-    const requests = githubBackfillRequestSeriesFrom(
+  test("accepts a range longer than 366 days without splitting it", () => {
+    const request = githubBackfillRequestFrom(
       {
         account: "f0rr0",
-        endDate: "2025-01-01",
+        endDate: "2026-08-29",
         repositoryId: "",
         startDate: "2024-01-01",
       },
       now
     );
 
-    expect(
-      requests?.map(({ endDate, startDate }) => ({ endDate, startDate }))
-    ).toEqual([
-      { endDate: "2024-12-31", startDate: "2024-01-01" },
-      { endDate: "2025-01-01", startDate: "2025-01-01" },
-    ]);
+    expect(request).toMatchObject({
+      endDate: "2026-08-29",
+      startDate: "2024-01-01",
+    });
   });
 
-  test("bisects a bounded request without gaps or overlap", () => {
-    const request = githubBackfillRequestFrom(
-      {
-        account: "f0rr0",
-        endDate: "2026-08-04",
-        repositoryId: "123456789",
-        startDate: "2026-08-01",
-      },
-      now
-    );
-
-    expect(request).not.toBeNull();
+  test("accepts GitHub's documented final timestamp day", () => {
     expect(
-      request === null
-        ? null
-        : splitGitHubBackfillRequest(request)?.map(
-            ({ endDate, startDate }) => ({ endDate, startDate })
-          )
-    ).toEqual([
-      { endDate: "2026-08-02", startDate: "2026-08-01" },
-      { endDate: "2026-08-04", startDate: "2026-08-03" },
-    ]);
+      githubBackfillRequestFrom(
+        {
+          account: "f0rr0",
+          endDate: "2099-12-31",
+          repositoryId: "",
+          startDate: "2099-12-31",
+        },
+        new Date("2100-01-01T00:00:00.000Z")
+      )
+    ).toMatchObject({
+      sinceAt: new Date("2099-12-31T00:00:00.000Z"),
+      untilAt: new Date("2099-12-31T23:59:59.999Z"),
+    });
   });
 
-  test("rejects malformed, future, reversed, and oversized ranges", () => {
+  test("rejects malformed, future, and reversed ranges", () => {
     const requests = [
       { endDate: "2026-08-29", startDate: "2026-08-30" },
       { endDate: "2026-08-30", startDate: "2026-08-29" },
-      { endDate: "2026-08-29", startDate: "2025-08-28" },
       { endDate: "2026-02-30", startDate: "2026-02-01" },
     ];
     for (const request of requests) {

--- a/tests/github-commits.test.mjs
+++ b/tests/github-commits.test.mjs
@@ -1,7 +1,9 @@
 import { afterEach, describe, expect, test } from "bun:test";
+import { setTimeout as delay } from "node:timers/promises";
 
 import {
   fetchGitHub,
+  GitHubRequestDeadlineError,
   GitHubResponseError,
   githubApiUrl,
 } from "../src/lib/github-api.ts";
@@ -21,7 +23,10 @@ import {
   repositoryFrom,
 } from "../src/lib/github-commits-core.ts";
 import { isGitHubAccountPaused } from "../src/lib/github-commits-store.ts";
-import { collectGitHubEvents } from "../src/lib/github-commits.ts";
+import {
+  assertGitHubTokenIdentity,
+  collectGitHubEvents,
+} from "../src/lib/github-commits.ts";
 
 const originalFetch = globalThis.fetch;
 const accountEvent = (id) => ({
@@ -30,6 +35,8 @@ const accountEvent = (id) => ({
   id,
   type: "WatchEvent",
 });
+const githubEventResponse = (events) =>
+  Response.json(events, { headers: { "X-Poll-Interval": "60" } });
 
 afterEach(() => {
   globalThis.fetch = originalFetch;
@@ -161,6 +168,22 @@ describe("GitHub commit normalization", () => {
       sha,
       url: apiCommit.html_url,
     });
+  });
+
+  test("uses committer time for activity ordering", () => {
+    const normalizedRepository = repositoryFrom(repository);
+    expect(normalizedRepository).not.toBeNull();
+    const commit = commitFromGitHub(
+      {
+        ...apiCommit,
+        commit: {
+          ...apiCommit.commit,
+          committer: { date: "2026-08-27T09:30:00Z" },
+        },
+      },
+      normalizedRepository
+    );
+    expect(commit?.committedAt).toBe("2026-08-27T09:30:00.000Z");
   });
 
   test("accepts Git's valid empty commit message", () => {
@@ -644,6 +667,63 @@ describe("pull request observation normalization", () => {
     });
   });
 
+  test("accepts the REST 2026 merged PR shape with merge_commit_sha absent", () => {
+    const normalizedRepository = repositoryFrom(repository);
+    expect(normalizedRepository).not.toBeNull();
+    const {
+      merge_commit_sha: _removedLegacyMergeSha,
+      ...rest2026MergedPullRequest
+    } = {
+      ...pullRequest,
+      closed_at: "2026-08-26T13:00:00Z",
+      merged: true,
+      merged_at: "2026-08-26T13:00:00Z",
+      state: "closed",
+      updated_at: "2026-08-26T13:00:00Z",
+    };
+    expect(Object.hasOwn(rest2026MergedPullRequest, "merge_commit_sha")).toBe(
+      false
+    );
+
+    const normalized = pullRequestFromGitHub(
+      rest2026MergedPullRequest,
+      normalizedRepository
+    );
+    expect(normalized).not.toBeNull();
+    expect(normalized?.merged).toBe(true);
+    expect(normalized?.mergeCommitSha).toBeUndefined();
+  });
+
+  test("discards the synthetic REST test merge SHA while a PR is open", () => {
+    const normalizedRepository = repositoryFrom(repository);
+    expect(normalizedRepository).not.toBeNull();
+    expect(
+      pullRequestFromGitHub(
+        { ...pullRequest, merge_commit_sha: "c".repeat(40) },
+        normalizedRepository
+      )
+    ).toMatchObject({ mergeCommitSha: null, merged: false, state: "open" });
+  });
+
+  test("rejects a malformed merge SHA when a PR is merged", () => {
+    const normalizedRepository = repositoryFrom(repository);
+    expect(normalizedRepository).not.toBeNull();
+    expect(
+      pullRequestFromGitHub(
+        {
+          ...pullRequest,
+          closed_at: "2026-08-26T13:00:00Z",
+          merge_commit_sha: "not-a-sha",
+          merged: true,
+          merged_at: "2026-08-26T13:00:00Z",
+          state: "closed",
+          updated_at: "2026-08-26T13:00:00Z",
+        },
+        normalizedRepository
+      )
+    ).toBeNull();
+  });
+
   test("uses PR authorship rather than webhook sender identity", () => {
     expect(
       pullRequestFromWebhook({
@@ -878,6 +958,28 @@ describe("token identity", () => {
     );
     expect(authenticatedGitHubAccountFrom({ login: "someone" })).toBeNull();
   });
+
+  test("verifies the authenticated account before an inventory scan", async () => {
+    globalThis.fetch = async (input, init) => {
+      expect(new Request(input).url).toBe("https://api.github.com/user");
+      expect(new Headers(init?.headers).get("authorization")).toBe(
+        "Bearer token"
+      );
+      return Response.json({ login: "F0RR0" });
+    };
+
+    await expect(
+      assertGitHubTokenIdentity("f0rr0", "token")
+    ).resolves.toBeUndefined();
+  });
+
+  test("rejects a token authenticated as the wrong account", async () => {
+    globalThis.fetch = async () => Response.json({ login: "someone-else" });
+
+    await expect(assertGitHubTokenIdentity("f0rr0", "token")).rejects.toThrow(
+      "GITHUB_F0RR0_TOKEN is not authenticated as f0rr0"
+    );
+  });
 });
 
 describe("account pause state", () => {
@@ -893,9 +995,39 @@ describe("account pause state", () => {
 });
 
 describe("bounded event collection", () => {
+  test("uses the saved feed validator and treats 304 as a healthy no-op", async () => {
+    globalThis.fetch = async (_input, init) => {
+      expect(new Headers(init?.headers).get("if-none-match")).toBe(
+        'W/"events"'
+      );
+      return new Response(null, {
+        headers: { etag: 'W/"events"', "X-Poll-Interval": "60" },
+        status: 304,
+      });
+    };
+
+    const startedAt = Date.now();
+    const collected = await collectGitHubEvents(
+      "f0rr0",
+      "token",
+      "12",
+      'W/"events"'
+    );
+    expect(collected).toMatchObject({
+      etag: 'W/"events"',
+      events: [],
+      gap: null,
+      latestEventId: "12",
+      notModified: true,
+    });
+    expect(collected.nextPollAt.getTime()).toBeGreaterThanOrEqual(
+      startedAt + 59_000
+    );
+  });
+
   test("collects a real sparse pull request event without poisoning its page", async () => {
     globalThis.fetch = async () =>
-      Response.json([
+      githubEventResponse([
         {
           actor: { login: "f0rr0" },
           created_at: "2026-08-26T12:03:00Z",
@@ -926,7 +1058,7 @@ describe("bounded event collection", () => {
 
   test("stops at the saved checkpoint without replaying it", async () => {
     globalThis.fetch = async () =>
-      Response.json([
+      githubEventResponse([
         accountEvent("12"),
         accountEvent("11"),
         accountEvent("10"),
@@ -940,7 +1072,7 @@ describe("bounded event collection", () => {
 
   test("records the bounded feed discontinuity and keeps available events", async () => {
     globalThis.fetch = async () =>
-      Response.json([
+      githubEventResponse([
         accountEvent("12"),
         accountEvent("11"),
         accountEvent("9"),
@@ -953,9 +1085,66 @@ describe("bounded event collection", () => {
     });
     expect(collected.latestEventId).toBe("12");
   });
+
+  test("rejects a missing or malformed provider poll interval", async () => {
+    globalThis.fetch = async () => Response.json([accountEvent("12")]);
+    expect(collectGitHubEvents("f0rr0", "token", null)).rejects.toBeInstanceOf(
+      TypeError
+    );
+  });
+
+  test("applies the cron deadline to every Events page", async () => {
+    let calls = 0;
+    globalThis.fetch = async () => {
+      calls += 1;
+      return githubEventResponse([]);
+    };
+
+    await expect(
+      collectGitHubEvents("f0rr0", "token", null, null, {
+        deadlineAt: Date.now() - 1,
+      })
+    ).rejects.toBeInstanceOf(GitHubRequestDeadlineError);
+    expect(calls).toBe(0);
+  });
 });
 
 describe("GitHub request deferral", () => {
+  test("fails before a provider call when its absolute deadline has passed", async () => {
+    let calls = 0;
+    globalThis.fetch = async () => {
+      calls += 1;
+      return Response.json({});
+    };
+
+    await expect(
+      fetchGitHub(githubApiUrl("/user"), {
+        deadlineAt: Date.now() - 1,
+        token: "token",
+      })
+    ).rejects.toBeInstanceOf(GitHubRequestDeadlineError);
+    expect(calls).toBe(0);
+  });
+
+  test("aborts an in-flight provider call at its absolute deadline", async () => {
+    let calls = 0;
+    globalThis.fetch = async (_input, init) => {
+      calls += 1;
+      await delay(60_000, undefined, { signal: init.signal });
+      return Response.json({});
+    };
+
+    const startedAt = Date.now();
+    await expect(
+      fetchGitHub(githubApiUrl("/user"), {
+        deadlineAt: startedAt + 50,
+        token: "token",
+      })
+    ).rejects.toBeInstanceOf(GitHubRequestDeadlineError);
+    expect(calls).toBe(1);
+    expect(Date.now() - startedAt).toBeLessThan(1000);
+  });
+
   test("does not immediately retry a rate-limited request", async () => {
     let calls = 0;
     globalThis.fetch = async () => {
@@ -997,6 +1186,85 @@ describe("GitHub request deferral", () => {
     expect(caught).toBeInstanceOf(GitHubResponseError);
     expect(caught).toMatchObject({ retryable: true, status: 403 });
     expect(caught.retryAt.toISOString()).toBe("2033-05-18T03:33:20.000Z");
+  });
+
+  test("defers a headerless secondary-limit response for at least one minute", async () => {
+    globalThis.fetch = async () =>
+      Response.json(
+        {
+          documentation_url:
+            "https://docs.github.com/rest/using-the-rest-api/rate-limits-for-the-rest-api#about-secondary-rate-limits",
+          message: "You have exceeded a secondary rate limit.",
+        },
+        { status: 403 }
+      );
+    const startedAt = Date.now();
+    let caught;
+    try {
+      await fetchGitHub(githubApiUrl("/user"), { token: "token" });
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught).toBeInstanceOf(GitHubResponseError);
+    expect(caught).toMatchObject({ retryable: true, status: 403 });
+    expect(caught.retryAt.getTime()).toBeGreaterThanOrEqual(startedAt + 59_000);
+  });
+
+  test("keeps a real permission 403 terminal", async () => {
+    globalThis.fetch = async () =>
+      Response.json(
+        {
+          documentation_url:
+            "https://docs.github.com/rest/repos/repos#get-a-repository",
+          message: "Resource not accessible by personal access token",
+        },
+        { status: 403 }
+      );
+    let caught;
+    try {
+      await fetchGitHub(githubApiUrl("/user"), { token: "token" });
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught).toBeInstanceOf(GitHubResponseError);
+    expect(caught).toMatchObject({
+      retryAt: null,
+      retryable: false,
+      status: 403,
+    });
+  });
+
+  test("fails closed when a 403 error body exceeds the inspection bound", async () => {
+    globalThis.fetch = async () =>
+      Response.json(
+        { message: `${"x".repeat(17_000)} secondary rate limit` },
+        { status: 403 }
+      );
+    let caught;
+    try {
+      await fetchGitHub(githubApiUrl("/user"), { token: "token" });
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught).toMatchObject({
+      retryAt: null,
+      retryable: false,
+      status: 403,
+    });
+  });
+
+  test("gives a headerless 429 a usable retry time", async () => {
+    globalThis.fetch = async () =>
+      Response.json({ message: "Too many requests" }, { status: 429 });
+    const startedAt = Date.now();
+    let caught;
+    try {
+      await fetchGitHub(githubApiUrl("/user"), { token: "token" });
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught).toMatchObject({ retryable: true, status: 429 });
+    expect(caught.retryAt.getTime()).toBeGreaterThanOrEqual(startedAt + 59_000);
   });
 
   test("allows authenticated GraphQL query POSTs", async () => {

--- a/tests/github-cron-config.test.mjs
+++ b/tests/github-cron-config.test.mjs
@@ -1,0 +1,92 @@
+import { describe, expect, test } from "bun:test";
+
+import { GitHubRequestDeadlineError } from "../src/lib/github-api.ts";
+import {
+  GITHUB_CRON_EXECUTION_DURATION_MS,
+  githubCronStatusFromFailedAccounts,
+  GITHUB_EVENTS_CRON_JOB,
+  GITHUB_HEAD_REFS_CRON_JOB,
+  GITHUB_REF_REPOSITORY_BATCH_SIZE,
+  GITHUB_TAG_REFS_CRON_JOB,
+  GITHUB_WORKER_CRON_JOB,
+  githubRefKindFrom,
+  githubRefRepositoryLimitFrom,
+} from "../src/lib/github-cron-config.ts";
+import {
+  githubRefCycleIsComplete,
+  nextGitHubRefRepository,
+  reconcileGitHubRepositoryRefBatch,
+  sortGitHubRefRepositories,
+} from "../src/lib/github-ref-reconciliation-batch.ts";
+import vercelConfig from "../vercel.json";
+
+describe("GitHub cron configuration", () => {
+  test("staggered schedules keep routine jobs from starting together", () => {
+    expect(GITHUB_EVENTS_CRON_JOB).toEqual({
+      name: "github-events-every-five-minutes",
+      schedule: "*/5 * * * *",
+    });
+    expect(GITHUB_WORKER_CRON_JOB).toEqual({
+      name: "github-activity-worker-every-five-minutes",
+      schedule: "2-57/5 * * * *",
+    });
+    expect(GITHUB_HEAD_REFS_CRON_JOB).toEqual({
+      name: "github-head-refs-every-fifteen-minutes",
+      schedule: "4,19,34,49 * * * *",
+    });
+    expect(GITHUB_TAG_REFS_CRON_JOB).toEqual({
+      name: "github-tag-refs-every-fifteen-minutes",
+      schedule: "9,24,39,54 * * * *",
+    });
+  });
+
+  test("bounds scheduled repository reconciliation", () => {
+    expect(GITHUB_REF_REPOSITORY_BATCH_SIZE).toBe(8);
+    expect(GITHUB_CRON_EXECUTION_DURATION_MS).toBe(90_000);
+    expect(githubRefRepositoryLimitFrom(null)).toBe(8);
+    expect(githubRefRepositoryLimitFrom("1")).toBe(1);
+    expect(githubRefRepositoryLimitFrom("8")).toBe(8);
+    for (const invalid of ["", "0", "9", "01", "4.0", "all"]) {
+      expect(githubRefRepositoryLimitFrom(invalid)).toBeNull();
+    }
+    expect(githubRefKindFrom(null)).toBe("head");
+    expect(githubRefKindFrom("head")).toBe("head");
+    expect(githubRefKindFrom("tag")).toBe("tag");
+    expect(githubRefKindFrom("all")).toBeNull();
+  });
+
+  test("fails before claiming a ref lease when the shared deadline is exhausted", async () => {
+    await expect(
+      reconcileGitHubRepositoryRefBatch({
+        account: "f0rr0",
+        deadlineAt: Date.now() - 1,
+        kind: "head",
+        repositoryLimit: 8,
+        token: "token",
+      })
+    ).rejects.toBeInstanceOf(GitHubRequestDeadlineError);
+  });
+
+  test("treats every partial account result as an operational failure", () => {
+    expect(githubCronStatusFromFailedAccounts([])).toBe(200);
+    expect(githubCronStatusFromFailedAccounts([{ account: "f0rr0" }])).toBe(
+      503
+    );
+  });
+
+  test("orders the persisted cursor by immutable numeric repository ID", () => {
+    const repositories = sortGitHubRefRepositories([
+      { fullName: "renamed/z", id: "100" },
+      { fullName: "original/a", id: "9" },
+      { fullName: "middle/m", id: "42" },
+    ]);
+    expect(repositories.map(({ id }) => id)).toEqual(["9", "42", "100"]);
+    expect(nextGitHubRefRepository(repositories, "42")?.id).toBe("100");
+    expect(githubRefCycleIsComplete(repositories, "100", null)).toBe(true);
+    expect(githubRefCycleIsComplete(repositories, "100", 2)).toBe(false);
+  });
+
+  test("runs server functions beside the Tokyo database", () => {
+    expect(vercelConfig.regions).toEqual(["hnd1"]);
+  });
+});

--- a/tests/github-direct-backfill.test.mjs
+++ b/tests/github-direct-backfill.test.mjs
@@ -1,0 +1,184 @@
+import { afterEach, describe, expect, test } from "bun:test";
+
+import {
+  backfillGitHubCommitsFromCurrentRefs,
+  collectGitHubCommitsFromHead,
+  distinctGitHubCurrentRefHeads,
+} from "../src/lib/github-direct-backfill.ts";
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+const repository = {
+  fullName: "example-org/example-repo",
+  htmlUrl: "https://github.com/example-org/example-repo",
+  id: "123",
+  ownerAvatarUrl: null,
+  ownerId: "456",
+  ownerLogin: "example-org",
+  ownerType: "Organization",
+  visibility: "private",
+};
+
+const rawRepository = {
+  full_name: repository.fullName,
+  html_url: repository.htmlUrl,
+  id: Number(repository.id),
+  owner: {
+    avatar_url: null,
+    id: Number(repository.ownerId),
+    login: repository.ownerLogin,
+    type: repository.ownerType,
+  },
+  private: true,
+  visibility: repository.visibility,
+};
+
+const commitValue = (sha, authoredAt, committedAt) => ({
+  author: { login: "f0rr0" },
+  commit: {
+    author: { date: authoredAt },
+    committer: { date: committedAt },
+    message: `feat: discover ${sha.slice(0, 4)}\n\nbody`,
+  },
+  sha,
+});
+
+describe("direct GitHub ref backfill", () => {
+  test("orders heads before tags and deduplicates their target SHAs", () => {
+    const sharedSha = "a".repeat(40);
+    const tagOnlySha = "b".repeat(40);
+    expect(
+      distinctGitHubCurrentRefHeads([
+        {
+          headSha: tagOnlySha,
+          kind: "tag",
+          refName: "refs/tags/v2",
+        },
+        {
+          headSha: sharedSha,
+          kind: "tag",
+          refName: "refs/tags/v1",
+        },
+        {
+          headSha: sharedSha,
+          kind: "head",
+          refName: "refs/heads/main",
+        },
+      ])
+    ).toEqual([
+      { headSha: sharedSha, refName: "refs/heads/main" },
+      { headSha: tagOnlySha, refName: "refs/tags/v2" },
+    ]);
+  });
+
+  test("uses one author-filtered inclusive range and committer timestamps", async () => {
+    const headSha = "c".repeat(40);
+    const firstSha = "d".repeat(40);
+    const lastSha = "e".repeat(40);
+    const sinceAt = new Date("2024-01-01T00:00:00.000Z");
+    const untilAt = new Date("2026-08-29T23:59:59.999Z");
+    const requests = [];
+    globalThis.fetch = async (input) => {
+      const url = new URL(input instanceof Request ? input.url : input);
+      requests.push(url);
+      const page = Number(url.searchParams.get("page"));
+      if (page === 1) {
+        const next = new URL(url);
+        next.searchParams.set("page", "2");
+        return Response.json(
+          [
+            commitValue(
+              firstSha,
+              "2023-12-01T00:00:00Z",
+              sinceAt.toISOString()
+            ),
+          ],
+          { headers: { link: `<${next.href}>; rel="next"` } }
+        );
+      }
+      return Response.json([
+        commitValue(lastSha, "2026-08-01T00:00:00Z", untilAt.toISOString()),
+      ]);
+    };
+
+    const result = await collectGitHubCommitsFromHead({
+      account: "f0rr0",
+      deadlineAt: Date.now() + 120_000,
+      headSha,
+      repository,
+      sinceAt,
+      token: "test-token",
+      untilAt,
+    });
+
+    expect(result.pages).toBe(2);
+    expect(
+      result.commits.map(({ committedAt, sha }) => ({ committedAt, sha }))
+    ).toEqual([
+      { committedAt: sinceAt.toISOString(), sha: firstSha },
+      { committedAt: untilAt.toISOString(), sha: lastSha },
+    ]);
+    expect(requests).toHaveLength(2);
+    for (const [index, url] of requests.entries()) {
+      expect(url.pathname).toBe("/repos/example-org/example-repo/commits");
+      expect(url.searchParams.get("author")).toBe("f0rr0");
+      expect(url.searchParams.get("page")).toBe(String(index + 1));
+      expect(url.searchParams.get("per_page")).toBe("100");
+      expect(url.searchParams.get("sha")).toBe(headSha);
+      expect(url.searchParams.get("since")).toBe(sinceAt.toISOString());
+      expect(url.searchParams.get("until")).toBe(untilAt.toISOString());
+    }
+  });
+
+  test("rejects pagination that drops an inventory constraint", async () => {
+    const headSha = "f".repeat(40);
+    globalThis.fetch = async (input) => {
+      const next = new URL(input instanceof Request ? input.url : input);
+      next.searchParams.delete("author");
+      next.searchParams.set("page", "2");
+      return Response.json([], {
+        headers: { link: `<${next.href}>; rel="next"` },
+      });
+    };
+
+    await expect(
+      collectGitHubCommitsFromHead({
+        account: "f0rr0",
+        deadlineAt: Date.now() + 120_000,
+        headSha,
+        repository,
+        sinceAt: new Date("2026-08-01T00:00:00.000Z"),
+        token: "test-token",
+        untilAt: new Date("2026-08-29T23:59:59.999Z"),
+      })
+    ).rejects.toThrow("invalid commit pagination");
+  });
+
+  test("fails incomplete when a listed repository becomes inaccessible", async () => {
+    globalThis.fetch = async (input) => {
+      const url = new URL(input instanceof Request ? input.url : input);
+      if (url.pathname === "/user/repos") {
+        return Response.json([rawRepository]);
+      }
+      if (url.pathname === "/repos/example-org/example-repo/branches") {
+        return Response.json({ message: "Not Found" }, { status: 404 });
+      }
+      throw new Error(`Unexpected GitHub request: ${url.href}`);
+    };
+
+    expect(
+      await backfillGitHubCommitsFromCurrentRefs({
+        account: "f0rr0",
+        deadlineAt: Date.now() + 120_000,
+        repositoryId: null,
+        sinceAt: new Date("2026-08-01T00:00:00.000Z"),
+        token: "test-token",
+        untilAt: new Date("2026-08-31T23:59:59.999Z"),
+      })
+    ).toMatchObject({ complete: false, stopReason: "provider_retry" });
+  });
+});

--- a/tests/github-pull-request-backfill.test.mjs
+++ b/tests/github-pull-request-backfill.test.mjs
@@ -1,0 +1,522 @@
+import { afterEach, describe, expect, test } from "bun:test";
+
+import {
+  backfillGitHubPullRequests,
+  collectGitHubAuthoredPullRequestBackfillCandidates,
+  collectGitHubPullRequestBackfillCandidates,
+  githubPullRequestBelongsInBackfillWindow,
+  persistGitHubPullRequestBackfillMembership,
+} from "../src/lib/github-pull-request-backfill.ts";
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+const repository = {
+  fullName: "example-org/example-repo",
+  htmlUrl: "https://github.com/example-org/example-repo",
+  id: "123",
+  ownerAvatarUrl: null,
+  ownerId: "456",
+  ownerLogin: "example-org",
+  ownerType: "Organization",
+  visibility: "private",
+};
+
+const rawRepository = {
+  full_name: repository.fullName,
+  html_url: repository.htmlUrl,
+  id: Number(repository.id),
+  owner: {
+    avatar_url: null,
+    id: Number(repository.ownerId),
+    login: repository.ownerLogin,
+    type: repository.ownerType,
+  },
+  private: true,
+  visibility: repository.visibility,
+};
+
+const pullRequestValue = (number, updatedAt) => ({
+  base: { ref: "main", repo: rawRepository, sha: "a".repeat(40) },
+  body: null,
+  closed_at: null,
+  created_at: "2026-07-01T00:00:00Z",
+  draft: false,
+  head: {
+    ref: `feature/${String(number)}`,
+    repo: rawRepository,
+    sha: number.toString(16).padStart(40, "0"),
+  },
+  html_url: `https://github.com/${repository.fullName}/pull/${String(number)}`,
+  id: 1000 + number,
+  merged_at: null,
+  node_id: `PR_node_${String(number)}`,
+  number,
+  state: "open",
+  title: `Pull request ${String(number)}`,
+  updated_at: updatedAt,
+  user: { id: 900, login: "other-maintainer" },
+});
+
+const authoredPullRequestNode = (
+  number,
+  {
+    nodeId = `PR_authored_${String(number)}`,
+    repositoryId = 5000 + number,
+    repositoryName = `external-org/repository-${String(number)}`,
+  } = {}
+) => ({
+  author: { login: "f0rr0" },
+  id: nodeId,
+  number,
+  repository: {
+    databaseId: repositoryId,
+    nameWithOwner: repositoryName,
+  },
+  updatedAt: "2026-08-29T12:00:00Z",
+  url: `https://github.com/${repositoryName}/pull/${String(number)}`,
+});
+
+const authoredPullRequestPage = ({
+  endCursor = null,
+  hasNextPage,
+  nodes,
+  totalCount,
+}) => ({
+  data: {
+    user: {
+      login: "f0rr0",
+      pullRequests: {
+        nodes,
+        pageInfo: { endCursor, hasNextPage },
+        totalCount,
+      },
+    },
+  },
+});
+
+describe("GitHub pull request historical backfill", () => {
+  test("does not rewrite complete membership on an unchanged PR rerun", async () => {
+    let persistenceCalls = 0;
+    const result = await persistGitHubPullRequestBackfillMembership({
+      commitShas: ["a".repeat(40)],
+      headSha: "a".repeat(40),
+      membershipComplete: true,
+      persist: async () => {
+        persistenceCalls += 1;
+        return true;
+      },
+      stored: {
+        baseRepositoryId: "123",
+        commitRepositoryId: "123",
+        membershipRefreshRequired: false,
+        pullRequestNodeId: "PR_unchanged",
+        retryLifecycleReset: false,
+        versionId: "version-1",
+      },
+    });
+
+    expect(result).toEqual({ complete: true, refreshed: false });
+    expect(persistenceCalls).toBe(0);
+  });
+
+  test("walks the authored PR connection beyond 100 pages", async () => {
+    const totalCount = 101;
+    let requests = 0;
+    globalThis.fetch = async (_input, options) => {
+      const body = JSON.parse(options.body);
+      const page = requests;
+      expect(body.variables.cursor).toBe(
+        page === 0 ? null : `authored-cursor-${String(page)}`
+      );
+      expect(body.variables.login).toBe("f0rr0");
+      expect(body.variables.pageSize).toBe(100);
+      expect(body.query).toContain("user(login: $login)");
+      requests += 1;
+      return Response.json(
+        authoredPullRequestPage({
+          endCursor:
+            page + 1 < totalCount
+              ? `authored-cursor-${String(page + 1)}`
+              : null,
+          hasNextPage: page + 1 < totalCount,
+          nodes: [authoredPullRequestNode(page + 1)],
+          totalCount,
+        })
+      );
+    };
+
+    const result = await collectGitHubAuthoredPullRequestBackfillCandidates({
+      account: "f0rr0",
+      deadlineAt: Date.now() + 120_000,
+      token: "test-token",
+    });
+
+    expect(result.pages).toBe(101);
+    expect(result.totalCount).toBe(totalCount);
+    expect(result.pullRequests).toHaveLength(totalCount);
+    expect(requests).toBe(101);
+  });
+
+  test("rejects a cyclic authored PR cursor", async () => {
+    let page = 0;
+    globalThis.fetch = async () => {
+      page += 1;
+      return Response.json(
+        authoredPullRequestPage({
+          endCursor: "repeated-cursor",
+          hasNextPage: true,
+          nodes: [authoredPullRequestNode(page)],
+          totalCount: 2,
+        })
+      );
+    };
+
+    await expect(
+      collectGitHubAuthoredPullRequestBackfillCandidates({
+        account: "f0rr0",
+        deadlineAt: Date.now() + 120_000,
+        token: "test-token",
+      })
+    ).rejects.toThrow("invalid authored pull request pagination");
+  });
+
+  test("rejects authored PR pagination without unique progress", async () => {
+    let page = 0;
+    globalThis.fetch = async () => {
+      page += 1;
+      return Response.json(
+        authoredPullRequestPage({
+          endCursor: `cursor-${String(page)}`,
+          hasNextPage: true,
+          nodes: [authoredPullRequestNode(1)],
+          totalCount: 2,
+        })
+      );
+    };
+
+    await expect(
+      collectGitHubAuthoredPullRequestBackfillCandidates({
+        account: "f0rr0",
+        deadlineAt: Date.now() + 120_000,
+        token: "test-token",
+      })
+    ).rejects.toThrow("invalid authored pull request pagination");
+  });
+
+  test("rejects a changing authored PR total count", async () => {
+    let page = 0;
+    globalThis.fetch = async () => {
+      page += 1;
+      return Response.json(
+        authoredPullRequestPage({
+          endCursor: page === 1 ? "page-two" : null,
+          hasNextPage: page === 1,
+          nodes: [authoredPullRequestNode(page)],
+          totalCount: page === 1 ? 2 : 3,
+        })
+      );
+    };
+
+    await expect(
+      collectGitHubAuthoredPullRequestBackfillCandidates({
+        account: "f0rr0",
+        deadlineAt: Date.now() + 120_000,
+        token: "test-token",
+      })
+    ).rejects.toThrow("invalid authored pull request connection");
+  });
+
+  test("rejects conflicting authored PR identities", async () => {
+    let page = 0;
+    globalThis.fetch = async () => {
+      page += 1;
+      return Response.json(
+        authoredPullRequestPage({
+          endCursor: page === 1 ? "page-two" : null,
+          hasNextPage: page === 1,
+          nodes: [
+            authoredPullRequestNode(page, {
+              nodeId: "PR_conflicting",
+              repositoryId: 6000 + page,
+              repositoryName: `external-org/conflict-${String(page)}`,
+            }),
+          ],
+          totalCount: 2,
+        })
+      );
+    };
+
+    await expect(
+      collectGitHubAuthoredPullRequestBackfillCandidates({
+        account: "f0rr0",
+        deadlineAt: Date.now() + 120_000,
+        token: "test-token",
+      })
+    ).rejects.toThrow("conflicting pull requests");
+  });
+
+  test("discovers an authored PR in an unaffiliated external repository", async () => {
+    globalThis.fetch = async () =>
+      Response.json(
+        authoredPullRequestPage({
+          hasNextPage: false,
+          nodes: [
+            authoredPullRequestNode(7, {
+              repositoryId: 7000,
+              repositoryName: "unaffiliated/example",
+            }),
+          ],
+          totalCount: 1,
+        })
+      );
+
+    const result = await collectGitHubAuthoredPullRequestBackfillCandidates({
+      account: "f0rr0",
+      deadlineAt: Date.now() + 120_000,
+      token: "test-token",
+    });
+    expect(result.pullRequests).toEqual([
+      expect.objectContaining({
+        nodeId: "PR_authored_7",
+        repository: "unaffiliated/example",
+        repositoryId: "7000",
+      }),
+    ]);
+  });
+
+  test("processes unshardable external authored PRs before affiliated repositories", async () => {
+    const requestedPaths = [];
+    globalThis.fetch = async (input) => {
+      const url = new URL(input instanceof Request ? input.url : input);
+      requestedPaths.push(url.pathname);
+      if (url.pathname === "/user/repos") {
+        return Response.json([rawRepository]);
+      }
+      if (url.pathname === "/graphql") {
+        return Response.json(
+          authoredPullRequestPage({
+            hasNextPage: false,
+            nodes: [
+              authoredPullRequestNode(7, {
+                repositoryId: 7000,
+                repositoryName: "unaffiliated/example",
+              }),
+            ],
+            totalCount: 1,
+          })
+        );
+      }
+      if (url.pathname === "/repos/unaffiliated/example/pulls/7") {
+        return Response.json({ message: "Not Found" }, { status: 404 });
+      }
+      throw new Error(`Unexpected GitHub request: ${url.href}`);
+    };
+
+    expect(
+      await backfillGitHubPullRequests({
+        account: "f0rr0",
+        deadlineAt: Date.now() + 120_000,
+        repositoryId: null,
+        sinceAt: new Date("2026-08-01T00:00:00.000Z"),
+        token: "test-token",
+        untilAt: new Date("2026-08-31T23:59:59.999Z"),
+      })
+    ).toMatchObject({
+      complete: false,
+      repositories: 1,
+      scannedPullRequests: 1,
+      stopReason: "provider_retry",
+    });
+    expect(requestedPaths).toEqual([
+      "/user/repos",
+      "/graphql",
+      "/repos/unaffiliated/example/pulls/7",
+    ]);
+  });
+
+  test("walks every all-state PR despite adversarially old update times", async () => {
+    const requests = [];
+    globalThis.fetch = async (input) => {
+      const url = new URL(input instanceof Request ? input.url : input);
+      requests.push(url);
+      if (url.searchParams.get("page") === "2") {
+        return Response.json([pullRequestValue(3, "2026-07-31T23:59:59Z")]);
+      }
+      const next = new URL(url);
+      next.searchParams.set("page", "2");
+      return Response.json(
+        [
+          // Updated after the commit window still matters: the PR may have
+          // retained an in-window commit only after that window closed.
+          pullRequestValue(1, "2026-09-10T00:00:00Z"),
+          pullRequestValue(2, "2026-08-01T00:00:00Z"),
+        ],
+        { headers: { link: `<${next.href}>; rel="next"` } }
+      );
+    };
+
+    const result = await collectGitHubPullRequestBackfillCandidates({
+      account: "f0rr0",
+      deadlineAt: Date.now() + 120_000,
+      repository,
+      token: "test-token",
+    });
+
+    expect(result.complete).toBe(true);
+    expect(result.pullRequests.map(({ nodeId }) => nodeId)).toEqual([
+      "PR_node_1",
+      "PR_node_2",
+      "PR_node_3",
+    ]);
+    expect(requests).toHaveLength(2);
+    for (const url of requests) {
+      expect(url.pathname).toBe("/repos/example-org/example-repo/pulls");
+      expect(url.searchParams.get("direction")).toBe("desc");
+      expect(url.searchParams.get("page")).toBe(
+        String(requests.indexOf(url) + 1)
+      );
+      expect(url.searchParams.get("per_page")).toBe("100");
+      expect(url.searchParams.get("sort")).toBe("updated");
+      expect(url.searchParams.get("state")).toBe("all");
+    }
+  });
+
+  test("rejects pagination that drops an inventory constraint", async () => {
+    globalThis.fetch = async (input) => {
+      const url = new URL(input instanceof Request ? input.url : input);
+      const next = new URL(url);
+      next.searchParams.set("page", "2");
+      next.searchParams.delete("state");
+      return Response.json([pullRequestValue(1, "2026-08-01T00:00:00Z")], {
+        headers: { link: `<${next.href}>; rel="next"` },
+      });
+    };
+
+    await expect(
+      collectGitHubPullRequestBackfillCandidates({
+        account: "f0rr0",
+        deadlineAt: Date.now() + 120_000,
+        repository,
+        token: "test-token",
+      })
+    ).rejects.toThrow("invalid pull request pagination");
+  });
+
+  test("rejects pages that violate the documented descending order", async () => {
+    globalThis.fetch = async () =>
+      Response.json([
+        pullRequestValue(1, "2026-08-01T00:00:00Z"),
+        pullRequestValue(2, "2026-08-02T00:00:00Z"),
+      ]);
+
+    await expect(
+      collectGitHubPullRequestBackfillCandidates({
+        account: "f0rr0",
+        deadlineAt: Date.now() + 120_000,
+        repository,
+        token: "test-token",
+      })
+    ).rejects.toThrow("outside descending updated order");
+  });
+
+  test("fails incomplete when a listed pull request becomes inaccessible", async () => {
+    globalThis.fetch = async (input) => {
+      const url = new URL(input instanceof Request ? input.url : input);
+      if (url.pathname === "/user/repos") {
+        return Response.json([rawRepository]);
+      }
+      if (url.pathname === "/repos/example-org/example-repo/pulls") {
+        return Response.json([pullRequestValue(1, "2026-08-01T00:00:00Z")]);
+      }
+      if (url.pathname === "/graphql") {
+        return Response.json(
+          authoredPullRequestPage({
+            hasNextPage: false,
+            nodes: [],
+            totalCount: 0,
+          })
+        );
+      }
+      if (url.pathname === "/repos/example-org/example-repo/pulls/1") {
+        return Response.json({ message: "Not Found" }, { status: 404 });
+      }
+      throw new Error(`Unexpected GitHub request: ${url.href}`);
+    };
+
+    expect(
+      await backfillGitHubPullRequests({
+        account: "f0rr0",
+        deadlineAt: Date.now() + 120_000,
+        repositoryId: null,
+        sinceAt: new Date("2026-08-01T00:00:00.000Z"),
+        token: "test-token",
+        untilAt: new Date("2026-08-31T23:59:59.999Z"),
+      })
+    ).toMatchObject({
+      complete: false,
+      scannedPullRequests: 1,
+      skippedPullRequests: 0,
+      stopReason: "provider_retry",
+    });
+  });
+
+  test("includes only an in-window tracked commit or merged PR milestone", () => {
+    const sinceAt = new Date("2026-08-01T00:00:00.000Z");
+    const untilAt = new Date("2026-08-31T23:59:59.999Z");
+    const commit = (committedAt) => ({
+      author: "f0rr0",
+      committedAt,
+      message: "feat: retained work",
+      repository: repository.fullName,
+      repositoryId: repository.id,
+      sha: "f".repeat(40),
+      url: `https://github.com/${repository.fullName}/commit/${"f".repeat(40)}`,
+    });
+    const belongs = (input) =>
+      githubPullRequestBelongsInBackfillWindow({
+        account: "f0rr0",
+        commits: [],
+        sinceAt,
+        untilAt,
+        ...input,
+      });
+
+    expect(
+      belongs({
+        commits: [commit(sinceAt.toISOString())],
+        pullRequest: { authorAccount: null, mergedAt: null },
+      })
+    ).toBe(true);
+    expect(
+      belongs({
+        commits: [commit(untilAt.toISOString())],
+        pullRequest: { authorAccount: null, mergedAt: null },
+      })
+    ).toBe(true);
+    expect(
+      belongs({
+        pullRequest: {
+          authorAccount: "f0rr0",
+          mergedAt: "2026-08-15T00:00:00.000Z",
+        },
+      })
+    ).toBe(true);
+    expect(
+      belongs({
+        pullRequest: {
+          authorAccount: "f0rr0",
+          mergedAt: "2026-09-01T00:00:00.000Z",
+        },
+      })
+    ).toBe(false);
+    expect(
+      belongs({
+        pullRequest: { authorAccount: "f0rr0", mergedAt: null },
+      })
+    ).toBe(false);
+  });
+});

--- a/tests/github-reconciliation.test.mjs
+++ b/tests/github-reconciliation.test.mjs
@@ -3,7 +3,6 @@ import { afterEach, describe, expect, test } from "bun:test";
 import {
   collectAccessibleGitHubRepositories,
   collectGitHubRepositoryRefs,
-  hydrateSparseGitHubPullRequestEvents,
 } from "../src/lib/github-reconciliation.ts";
 
 const originalFetch = globalThis.fetch;
@@ -69,35 +68,29 @@ describe("GitHub repository reconciliation", () => {
     ]);
   });
 
-  test("enumerates heads and peels annotated tags to commit SHAs", async () => {
+  test("uses branch and repository-tag commit targets without tag peeling", async () => {
     const headSha = "a".repeat(40);
-    const tagSha = "b".repeat(40);
     const taggedCommitSha = "c".repeat(40);
     const paths = [];
     globalThis.fetch = async (input) => {
       const url =
         input instanceof Request ? new URL(input.url) : new URL(input);
-      paths.push(url.pathname);
-      if (url.pathname.endsWith("/git/matching-refs/heads/")) {
+      paths.push(`${url.pathname}?${url.searchParams.toString()}`);
+      if (url.pathname.endsWith("/branches")) {
         return Response.json([
           {
-            object: { sha: headSha, type: "commit" },
-            ref: "refs/heads/main",
+            commit: { sha: headSha },
+            name: "main",
           },
         ]);
       }
-      if (url.pathname.endsWith("/git/matching-refs/tags/")) {
+      if (url.pathname.endsWith("/tags")) {
         return Response.json([
           {
-            object: { sha: tagSha, type: "tag" },
-            ref: "refs/tags/v1.0.0",
+            commit: { sha: taggedCommitSha },
+            name: "v1.0.0",
           },
         ]);
-      }
-      if (url.pathname.endsWith(`/git/tags/${tagSha}`)) {
-        return Response.json({
-          object: { sha: taggedCommitSha, type: "commit" },
-        });
       }
       throw new Error(`Unexpected GitHub path: ${url.pathname}`);
     };
@@ -113,75 +106,45 @@ describe("GitHub repository reconciliation", () => {
       ]
     );
     expect(paths).toEqual([
-      "/repos/example-org/example-repo/git/matching-refs/heads/",
-      "/repos/example-org/example-repo/git/matching-refs/tags/",
-      `/repos/example-org/example-repo/git/tags/${tagSha}`,
+      "/repos/example-org/example-repo/branches?per_page=100&page=1",
+      "/repos/example-org/example-repo/tags?per_page=100&page=1",
     ]);
   });
-});
 
-describe("sparse PullRequestEvent hydration", () => {
-  const event = {
-    id: "123456789",
-    issue: null,
-    occurredAt: "2026-08-29T10:00:00.000Z",
-    pullRequest: null,
-    pullRequestSignal: {
-      action: "opened",
-      number: 7,
-      repository: {
-        fullName: repositoryFacts.fullName,
-        id: repositoryFacts.id,
-      },
-    },
-    push: null,
-  };
-
-  test("hydrates an unknown sparse event before its checkpoint advances", async () => {
-    const headSha = "d".repeat(40);
-    const baseSha = "e".repeat(40);
+  test("follows every branch page without imposing a completeness cap", async () => {
+    const firstSha = "d".repeat(40);
+    const secondSha = "e".repeat(40);
+    const pages = [];
     globalThis.fetch = async (input) => {
       const url =
         input instanceof Request ? new URL(input.url) : new URL(input);
-      expect(url.pathname).toBe("/repos/example-org/example-repo/pulls/7");
-      return Response.json({
-        base: { ref: "main", repo: repository, sha: baseSha },
-        body: "Adds credit billing.",
-        closed_at: null,
-        created_at: "2026-08-29T09:00:00Z",
-        draft: false,
-        head: { ref: "credit-billing", repo: repository, sha: headSha },
-        html_url: "https://github.com/example-org/example-repo/pull/7",
-        id: 789,
-        merge_commit_sha: null,
-        merged: false,
-        merged_at: null,
-        node_id: "PR_example",
-        number: 7,
-        state: "open",
-        title: "Add credit billing",
-        updated_at: "2026-08-29T10:00:00Z",
-        user: { id: 101, login: "f0rr0" },
-      });
+      pages.push(`${url.pathname}:${url.searchParams.get("page")}`);
+      if (
+        url.pathname.endsWith("/branches") &&
+        url.searchParams.get("page") === "1"
+      ) {
+        return Response.json([{ commit: { sha: firstSha }, name: "first" }], {
+          headers: {
+            link: `<https://api.github.com/repos/example-org/example-repo/branches?per_page=100&page=2>; rel="next"`,
+          },
+        });
+      }
+      if (url.pathname.endsWith("/branches")) {
+        return Response.json([{ commit: { sha: secondSha }, name: "second" }]);
+      }
+      return Response.json([]);
     };
 
-    const [hydrated] = await hydrateSparseGitHubPullRequestEvents(
-      [event],
-      "token"
+    expect(await collectGitHubRepositoryRefs(repositoryFacts, "token")).toEqual(
+      [
+        { headSha: firstSha, kind: "head", refName: "refs/heads/first" },
+        { headSha: secondSha, kind: "head", refName: "refs/heads/second" },
+      ]
     );
-    expect(hydrated.pullRequest).toMatchObject({
-      authorAccount: "f0rr0",
-      nodeId: "PR_example",
-      number: 7,
-      title: "Add credit billing",
-    });
-    expect(hydrated.pullRequestSignal).toBeUndefined();
-  });
-
-  test("retains an inaccessible signal so known-PR reconciliation can still run", async () => {
-    globalThis.fetch = async () => new Response(null, { status: 404 });
-    expect(
-      await hydrateSparseGitHubPullRequestEvents([event], "token")
-    ).toEqual([event]);
+    expect(pages).toEqual([
+      "/repos/example-org/example-repo/branches:1",
+      "/repos/example-org/example-repo/branches:2",
+      "/repos/example-org/example-repo/tags:1",
+    ]);
   });
 });

--- a/tests/production-database-migration.test.mjs
+++ b/tests/production-database-migration.test.mjs
@@ -1,6 +1,11 @@
 import { describe, expect, test } from "bun:test";
 
 import {
+  shouldConfigureSupabaseCronForProduction,
+  supabaseCronSiteUrlFrom,
+  supabaseCronUrlsFrom,
+} from "../scripts/configure-supabase-cron.ts";
+import {
   ProductionMigrationConfigurationError,
   productionMigrationDatabaseUrl,
   shouldApplyProductionMigrations,
@@ -21,6 +26,42 @@ describe("production migration environment", () => {
         VERCEL_ENV: "preview",
       })
     ).toBe(false);
+    expect(
+      shouldConfigureSupabaseCronForProduction({
+        VERCEL: "1",
+        VERCEL_ENV: "production",
+      })
+    ).toBe(true);
+    expect(
+      shouldConfigureSupabaseCronForProduction({
+        VERCEL: "1",
+        VERCEL_ENV: "preview",
+      })
+    ).toBe(false);
+  });
+});
+
+describe("production Supabase cron URLs", () => {
+  test("uses Vercel's production hostname without a managed site URL", () => {
+    expect(
+      supabaseCronSiteUrlFrom({
+        VERCEL_PROJECT_PRODUCTION_URL: "f0rr0.dev",
+      })
+    ).toBe("https://f0rr0.dev");
+    expect(supabaseCronSiteUrlFrom({})).toBe("https://f0rr0.dev");
+  });
+
+  test("builds every bounded production endpoint from the site URL", () => {
+    expect(supabaseCronUrlsFrom("https://f0rr0.dev")).toEqual({
+      events: "https://f0rr0.dev/api/cron/github-sync",
+      headRefs:
+        "https://f0rr0.dev/api/cron/github-refs?kind=head&repositories=8",
+      tagRefs: "https://f0rr0.dev/api/cron/github-refs?kind=tag&repositories=8",
+      worker: "https://f0rr0.dev/api/cron/github-worker",
+    });
+    expect(() => supabaseCronUrlsFrom("http://localhost:3000")).toThrow(
+      "HTTPS"
+    );
   });
 });
 

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "regions": ["hnd1"]
+}


### PR DESCRIPTION
## Summary

- Add durable five-minute Events intake, staggered branch/tag reconciliation, sparse PR signals, and bounded restart-safe workers.
- Replace lossy historical queueing with direct current-ref and retained-PR backfill, including authored PRs in unaffiliated repositories, GraphQL membership beyond REST caps, and authoritative merge evidence.
- Make aliases causal and reversible, harden webhook/provider validation, retry and deadline behavior, and preserve private repository grouping without revealing identity.
- Apply migrations and transactionally reconcile Supabase Cron on any Vercel production build; retain an auditable evidence-recovery workflow.

## Correctness guarantees

- Every inventory token is verified against `/user` before scanning.
- Backfill reports incomplete rather than claiming success on deadlines, provider gaps, pagination drift, or lost access.
- Current refs and complete PR memberships deduplicate by repository ID and SHA; unchanged memberships are not rewritten.
- Only explicit PR-version, parent, or cherry-pick evidence can hide a duplicate commit.

## Validation

- `bun run lint`
- `bun run typecheck`
- `bun test` — 190 tests, 1,247 assertions
- PostgreSQL race and evidence-recovery tests
- `bun run db:generate` — no schema drift, 14 tables
- `bun run build`
- `actionlint .github/workflows/*.yml`
- tracked-source credential scan

## Rollout

After merge, the Vercel production build applies migration `0011`, installs the four Supabase jobs, and the first authenticated worker completes the one-time evidence repair. Then dispatch **Backfill GitHub activity** for the required inclusive UTC range; reruns are idempotent and repository IDs can shard large inventories.