### PR TITLE
fix(github): backfill large pull requests

### DIFF
--- a/docs/github-commits.md
+++ b/docs/github-commits.md
@@ -219,10 +219,13 @@ source evidence but is not substituted for the public timestamp.
 PR membership comes from GitHub, not from an LLM. For each enriched commit the
 worker first uses GitHub's associated-PR endpoint. Each PR is stored by stable
 node ID with a current mutable snapshot and immutable head-SHA versions. The
-commit list is fetched for a new head SHA; REST is used first and GraphQL
-pagination covers PRs beyond the REST commit-list cap. An incomplete membership
-is never accepted as complete evidence. Association is not filtered by PR
-author, so a foreign-authored PR can still organize a tracked commit. Only a
+commit list is fetched for a new head SHA. GitHub's PR-commit endpoint serves
+memberships through its 250-commit limit; larger or otherwise incomplete
+responses fall back to the paginated `base SHA...head SHA` comparison on the
+base repository. The comparison must report the snapshot's exact commit count,
+terminate cleanly, and end at the snapshot head. An incomplete membership is
+never accepted as complete evidence. Association is not filtered by PR author,
+so a foreign-authored PR can still organize a tracked commit. Only a
 tracked-authored merged PR becomes the separate public merge milestone.
 
 When a commit appears in more than one current complete PR membership, the
@@ -545,13 +548,15 @@ selected Action time budget is the operational bound. Pull requests run first
 because the all-repository authored-PR stream cannot be repository-sharded:
 
 1. Enumerate every all-state pull request in each affiliated repository in
-   descending `updated_at` order; no timestamp cutoff is safe because Git commit
-   timestamps are author-controlled. An all-repository run independently walks
-   the tracked user's unbounded GraphQL `pullRequests` connection as well, so an
-   authored PR remains discoverable when its base is an unaffiliated external
-   repository. The author stream validates the returned user and PR author,
-   repository database ID/name, PR identity/link, total count, unique progress,
-   and every cursor before merging by PR node ID with the affiliated inventory.
+   ascending creation order. Creation order is stable while a mutable
+   `updated_at` ordering can move PRs between pages; no timestamp cutoff is safe
+   because Git commit timestamps are author-controlled. An all-repository run
+   independently walks the tracked user's unbounded GraphQL `pullRequests`
+   connection as well, so an authored PR remains discoverable when its base is
+   an unaffiliated external repository. The author stream validates the
+   returned user and PR author, repository database ID/name, PR identity/link,
+   total count, unique progress, and every cursor before merging by PR node ID
+   with the affiliated inventory.
    A repository-targeted run stays scoped to that numeric repository ID and does
    not invoke the author stream. Fetch complete membership, retain a PR when it
    contains a tracked commit in the interval or is a tracked-authored merge in

--- a/src/lib/github-activity-processor.ts
+++ b/src/lib/github-activity-processor.ts
@@ -40,7 +40,7 @@ export const GITHUB_ACTIVITY_FALLBACK_SUMMARY_RECIPE =
   "commit-message-summary-v1";
 const GITHUB_FILE_PAGE_SIZE = 100;
 const MAXIMUM_GITHUB_FILE_PAGES = 30;
-const MAXIMUM_GITHUB_PULL_REQUEST_COMMIT_PAGES = 3;
+const GITHUB_PULL_REQUEST_COMMIT_LIMIT = 250;
 const GITHUB_GRAPHQL_NODE_BATCH_SIZE = 100;
 const GITHUB_GRAPHQL_SECONDARY_LIMIT_WAIT_MS = 60_000;
 const ZERO_SHA = "0".repeat(40);
@@ -896,24 +896,66 @@ export const fetchGitHubActivityCommitSource = async (
     async (token) => await fetchCommitSourceWithToken(row, token, options)
   );
 
-const compareCommitValuesWithToken = async (
-  row: GitHubActivityPushObservationReference,
+interface GitHubCommitComparisonReference {
+  baseSha: string;
+  expectedCommitCount: number | null;
+  headSha: string;
+  repository: GitHubRepository;
+}
+
+const commitComparisonPath = (
+  comparison: GitHubCommitComparisonReference,
+  repositoryPath: string
+) =>
+  `${repositoryPath}/compare/${encodeURIComponent(
+    comparison.baseSha
+  )}...${encodeURIComponent(comparison.headSha)}`;
+
+const validateNextCommitComparisonPage = (
+  next: URL,
+  currentPage: number,
+  comparison: GitHubCommitComparisonReference
+) => {
+  const namedPath = commitComparisonPath(
+    comparison,
+    repositoryApiPath(comparison.repository.fullName, "")
+  );
+  const numericPath = commitComparisonPath(
+    comparison,
+    `/repositories/${encodeURIComponent(comparison.repository.id)}`
+  );
+  if (
+    (next.pathname !== namedPath && next.pathname !== numericPath) ||
+    next.searchParams.get("page") !== String(currentPage + 1) ||
+    next.searchParams.get("per_page") !== "100" ||
+    next.searchParams.size !== 2
+  ) {
+    throw new ActivityProcessingError(
+      "source_invalid",
+      "GitHub returned invalid commit comparison pagination."
+    );
+  }
+};
+
+// oxlint-disable-next-line eslint/complexity -- Every comparison pagination invariant is validated fail-closed.
+const commitComparisonValuesWithToken = async (
+  comparison: GitHubCommitComparisonReference,
   token: string,
   options: GitHubProviderRequestOptions = {}
 ) => {
-  const repository = repositoryReferenceFrom(row);
   const values: unknown[] = [];
   let url: URL | null = githubApiUrl(
-    repositoryApiPath(
-      repository.fullName,
-      `/compare/${encodeURIComponent(row.beforeSha)}...${encodeURIComponent(
-        row.afterSha
-      )}`
+    commitComparisonPath(
+      comparison,
+      repositoryApiPath(comparison.repository.fullName, "")
     )
   );
   url.searchParams.set("per_page", "100");
   const visited = new Set<string>();
+  const seenShas = new Set<string>();
   let aheadBy: number | null = null;
+  let page = 1;
+  let totalCommits: number | null = null;
   while (url !== null) {
     if (visited.has(url.href)) {
       throw new ActivityProcessingError(
@@ -927,43 +969,91 @@ const compareCommitValuesWithToken = async (
     const pageAheadBy = isObject(result.payload)
       ? requiredInteger(result.payload.ahead_by, "compare ahead count")
       : null;
+    const pageTotalCommits = isObject(result.payload)
+      ? requiredInteger(result.payload.total_commits, "compare commit count")
+      : null;
     if (
       !Array.isArray(pageValues) ||
       pageAheadBy === null ||
-      (aheadBy !== null && aheadBy !== pageAheadBy)
+      pageTotalCommits === null ||
+      (aheadBy !== null && aheadBy !== pageAheadBy) ||
+      (totalCommits !== null && totalCommits !== pageTotalCommits) ||
+      pageAheadBy !== pageTotalCommits
     ) {
       throw new ActivityProcessingError(
         "source_invalid",
-        "GitHub returned invalid push commit evidence."
+        "GitHub returned invalid commit comparison evidence."
       );
     }
     aheadBy = pageAheadBy;
+    totalCommits = pageTotalCommits;
+    const previousSize = seenShas.size;
+    for (const value of pageValues) {
+      const sha = isObject(value) ? commitShaFrom(value.sha) : null;
+      if (sha === null || seenShas.has(sha)) {
+        throw new ActivityProcessingError(
+          "source_invalid",
+          "GitHub returned invalid commit comparison members."
+        );
+      }
+      seenShas.add(sha);
+    }
     values.push(...pageValues);
-    url = nextGitHubPage(result.response);
+    const next = nextGitHubPage(result.response);
+    if (next !== null) {
+      validateNextCommitComparisonPage(next, page, comparison);
+      if (seenShas.size === previousSize || values.length >= pageTotalCommits) {
+        throw new ActivityProcessingError(
+          "source_invalid",
+          "GitHub returned inconsistent commit comparison pagination."
+        );
+      }
+      page += 1;
+    }
+    url = next;
     if (
-      row.expectedCommitCount !== null &&
-      values.length > row.expectedCommitCount
+      values.length > pageTotalCommits ||
+      (comparison.expectedCommitCount !== null &&
+        values.length > comparison.expectedCommitCount)
     ) {
       throw new ActivityProcessingError(
         "source_incomplete",
-        "GitHub returned more commits than the durable push observation recorded."
+        "GitHub returned more commits than the expected comparison recorded."
       );
     }
   }
 
   if (
     aheadBy === null ||
+    totalCommits === null ||
     values.length !== aheadBy ||
-    (row.expectedCommitCount !== null &&
-      values.length !== row.expectedCommitCount)
+    values.length !== totalCommits ||
+    (comparison.expectedCommitCount !== null &&
+      values.length !== comparison.expectedCommitCount)
   ) {
     throw new ActivityProcessingError(
       "source_incomplete",
-      "GitHub did not return the complete pushed commit set."
+      "GitHub did not return the complete commit comparison."
     );
   }
   return values;
 };
+
+const compareCommitValuesWithToken = async (
+  row: GitHubActivityPushObservationReference,
+  token: string,
+  options: GitHubProviderRequestOptions = {}
+) =>
+  await commitComparisonValuesWithToken(
+    {
+      baseSha: row.beforeSha,
+      expectedCommitCount: row.expectedCommitCount,
+      headSha: row.afterSha,
+      repository: repositoryReferenceFrom(row),
+    },
+    token,
+    options
+  );
 
 // GitHub cannot compare the all-zero SHA used for a new branch. GraphQL's
 // cursor lets us request exactly the observed number of commits when legacy
@@ -1479,149 +1569,82 @@ const fetchPullRequestSnapshotWithToken = async (
   };
 };
 
-// oxlint-disable-next-line complexity -- Every GraphQL pagination invariant is validated fail-closed.
-const pullRequestMembershipFromGraphQl = async (
-  row: GitHubActivityPullRequestReference,
+const pullRequestMembershipFromValues = (
+  values: readonly unknown[],
   expectedCommitCount: number,
-  token: string,
   commitRepository: GitHubRepository,
   expectedHeadSha: string | null,
-  deadlineAt: number | undefined
-) => {
-  const [owner, name] = row.repository.split("/");
-  if (owner === undefined || name === undefined) {
-    throw new ActivityProcessingError(
-      "source_invalid",
-      "The stored GitHub repository reference is invalid."
-    );
-  }
-  const query = `query PullRequestCommits($owner: String!, $name: String!, $number: Int!, $cursor: String) {
-    repository(owner: $owner, name: $name) {
-      pullRequest(number: $number) {
-        commits(first: 100, after: $cursor) {
-          totalCount
-          nodes {
-            commit {
-              oid
-              message
-              committedDate
-              author { user { login } }
-            }
-          }
-          pageInfo { hasNextPage endCursor }
-        }
-      }
-    }
-  }`;
+  paginationComplete = true
+): GitHubActivityPullRequestMembershipSource => {
   const commitShas: string[] = [];
   const commits: GitHubCommit[] = [];
   const seen = new Set<string>();
-  const seenCursors = new Set<string>();
-  let cursor: string | null = null;
-  let hasNextPage = true;
-  while (hasNextPage) {
-    const response = await fetchGitHub(githubApiUrl("/graphql"), {
-      body: JSON.stringify({
-        query,
-        variables: { cursor, name, number: row.number, owner },
-      }),
-      deadlineAt,
-      method: "POST",
-      token,
-    });
-    const payload = await githubGraphQlPayloadFrom(response);
-    const repository = isObject(payload.data) ? payload.data.repository : null;
-    const pullRequest = isObject(repository) ? repository.pullRequest : null;
-    const connection = isObject(pullRequest) ? pullRequest.commits : null;
-    if (
-      !isObject(connection) ||
-      !Array.isArray(connection.nodes) ||
-      !isObject(connection.pageInfo) ||
-      requiredInteger(connection.totalCount, "pull request commit count") !==
-        expectedCommitCount ||
-      typeof connection.pageInfo.hasNextPage !== "boolean"
-    ) {
+  for (const value of values) {
+    const sha = isObject(value) ? commitShaFrom(value.sha) : null;
+    if (sha === null) {
       throw new ActivityProcessingError(
         "source_invalid",
-        "GitHub returned invalid GraphQL pull request membership."
+        "GitHub returned an invalid pull request commit."
       );
     }
-    const commitsBeforePage = commitShas.length;
-    for (const node of connection.nodes) {
-      const sha =
-        isObject(node) && isObject(node.commit)
-          ? commitShaFrom(node.commit.oid)
-          : null;
-      if (sha === null) {
-        throw new ActivityProcessingError(
-          "source_invalid",
-          "GitHub returned an invalid pull request commit."
-        );
-      }
-      if (!seen.has(sha)) {
-        seen.add(sha);
-        commitShas.push(sha);
-        const commitValue = isObject(node) ? node.commit : null;
-        const user =
-          isObject(commitValue) && isObject(commitValue.author)
-            ? commitValue.author.user
-            : null;
-        const commit = trackedCommitFromPushValue(
-          {
-            author: isObject(user) ? { login: user.login } : null,
-            commit: {
-              committer: {
-                date: isObject(commitValue) ? commitValue.committedDate : null,
-              },
-              message: isObject(commitValue) ? commitValue.message : null,
-            },
-            sha,
-          },
-          sha,
-          commitRepository
-        );
-        if (commit !== null) {
-          commits.push(commit);
-        }
-      }
+    if (seen.has(sha)) {
+      continue;
     }
-    ({ hasNextPage } = connection.pageInfo);
-    if (
-      commitShas.length > expectedCommitCount ||
-      (hasNextPage && commitShas.length === commitsBeforePage)
-    ) {
-      throw new ActivityProcessingError(
-        "source_invalid",
-        "GitHub returned inconsistent GraphQL pull request membership."
-      );
+    seen.add(sha);
+    commitShas.push(sha);
+    const commit = trackedCommitFromPullRequestValue(
+      value,
+      sha,
+      commitRepository
+    );
+    if (commit !== null) {
+      commits.push(commit);
     }
-    const nextCursor = connection.pageInfo.endCursor;
-    if (
-      hasNextPage &&
-      (typeof nextCursor !== "string" ||
-        nextCursor.length === 0 ||
-        seenCursors.has(nextCursor))
-    ) {
-      throw new ActivityProcessingError(
-        "source_invalid",
-        "GitHub returned an invalid pull request membership cursor."
-      );
-    }
-    if (typeof nextCursor === "string") {
-      seenCursors.add(nextCursor);
-    }
-    cursor = typeof nextCursor === "string" ? nextCursor : null;
   }
   return {
     commitShas,
     commits,
     membershipComplete:
-      !hasNextPage &&
+      paginationComplete &&
       commitShas.length === expectedCommitCount &&
       (expectedHeadSha === null ||
         expectedCommitCount === 0 ||
         commitShas.at(-1) === expectedHeadSha),
   };
+};
+
+const pullRequestMembershipFromComparison = async (
+  row: GitHubActivityPullRequestReference,
+  expectedCommitCount: number,
+  token: string,
+  commitRepository: GitHubRepository,
+  expectedBaseSha: string,
+  expectedHeadSha: string,
+  options: GitHubProviderRequestOptions
+) => {
+  const values = await commitComparisonValuesWithToken(
+    {
+      baseSha: expectedBaseSha,
+      expectedCommitCount,
+      headSha: expectedHeadSha,
+      repository: repositoryReferenceFrom(row),
+    },
+    token,
+    options
+  );
+  const membership = pullRequestMembershipFromValues(
+    values,
+    expectedCommitCount,
+    commitRepository,
+    expectedHeadSha
+  );
+  if (!membership.membershipComplete) {
+    throw new ActivityProcessingError(
+      "source_incomplete",
+      "GitHub returned ambiguous pull request comparison evidence."
+    );
+  }
+  return membership;
 };
 
 export const fetchGitHubPullRequestMembershipWithToken = async (
@@ -1631,19 +1654,48 @@ export const fetchGitHubPullRequestMembershipWithToken = async (
   options: {
     commitRepository?: GitHubRepository;
     deadlineAt?: number;
+    expectedBaseSha?: string;
     expectedHeadSha?: string;
   } = {}
 ): Promise<GitHubActivityPullRequestMembershipSource> => {
   const repository = repositoryReferenceFrom(row);
   const commitRepository = options.commitRepository ?? repository;
+  if (!Number.isSafeInteger(expectedCommitCount) || expectedCommitCount < 0) {
+    throw new ActivityProcessingError(
+      "source_invalid",
+      "The expected GitHub pull request commit count is invalid."
+    );
+  }
+  const expectedBaseSha =
+    options.expectedBaseSha === undefined
+      ? null
+      : commitShaFrom(options.expectedBaseSha);
   const expectedHeadSha =
     options.expectedHeadSha === undefined
       ? null
       : commitShaFrom(options.expectedHeadSha);
-  if (options.expectedHeadSha !== undefined && expectedHeadSha === null) {
+  if (
+    (options.expectedBaseSha !== undefined && expectedBaseSha === null) ||
+    (options.expectedHeadSha !== undefined && expectedHeadSha === null)
+  ) {
     throw new ActivityProcessingError(
       "source_invalid",
-      "The expected GitHub pull request head is invalid."
+      "The expected GitHub pull request comparison is invalid."
+    );
+  }
+  if (
+    expectedCommitCount > GITHUB_PULL_REQUEST_COMMIT_LIMIT &&
+    expectedBaseSha !== null &&
+    expectedHeadSha !== null
+  ) {
+    return await pullRequestMembershipFromComparison(
+      row,
+      expectedCommitCount,
+      token,
+      commitRepository,
+      expectedBaseSha,
+      expectedHeadSha,
+      options
     );
   }
   const pullRequestPath = repositoryApiPath(
@@ -1652,13 +1704,11 @@ export const fetchGitHubPullRequestMembershipWithToken = async (
   );
   let url: URL | null = githubApiUrl(`${pullRequestPath}/commits`);
   url.searchParams.set("per_page", "100");
-  const commitShas: string[] = [];
-  const commits: GitHubCommit[] = [];
-  const seen = new Set<string>();
+  const values: unknown[] = [];
 
   for (
     let page = 0;
-    url !== null && page < MAXIMUM_GITHUB_PULL_REQUEST_COMMIT_PAGES;
+    url !== null && page < Math.ceil(GITHUB_PULL_REQUEST_COMMIT_LIMIT / 100);
     page += 1
   ) {
     const result = await fetchJsonWithResponse(url, token, options);
@@ -1668,45 +1718,29 @@ export const fetchGitHubPullRequestMembershipWithToken = async (
         "GitHub returned invalid pull request commits."
       );
     }
-    for (const value of result.payload) {
-      const sha = isObject(value) ? commitShaFrom(value.sha) : null;
-      if (sha === null) {
-        throw new ActivityProcessingError(
-          "source_invalid",
-          "GitHub returned an invalid pull request commit."
-        );
-      }
-      if (!seen.has(sha)) {
-        seen.add(sha);
-        commitShas.push(sha);
-        const commit = trackedCommitFromPullRequestValue(
-          value,
-          sha,
-          commitRepository
-        );
-        if (commit !== null) {
-          commits.push(commit);
-        }
-      }
-    }
+    values.push(...result.payload);
     url = nextGitHubPage(result.response);
   }
 
-  const membershipComplete =
-    url === null &&
-    commitShas.length === expectedCommitCount &&
-    (expectedHeadSha === null ||
-      expectedCommitCount === 0 ||
-      commitShas.at(-1) === expectedHeadSha);
-  return membershipComplete
-    ? { commitShas, commits, membershipComplete }
-    : await pullRequestMembershipFromGraphQl(
+  const membership = pullRequestMembershipFromValues(
+    values,
+    expectedCommitCount,
+    commitRepository,
+    expectedHeadSha,
+    url === null
+  );
+  return membership.membershipComplete ||
+    expectedBaseSha === null ||
+    expectedHeadSha === null
+    ? membership
+    : await pullRequestMembershipFromComparison(
         row,
         expectedCommitCount,
         token,
         commitRepository,
+        expectedBaseSha,
         expectedHeadSha,
-        options.deadlineAt
+        options
       );
 };
 
@@ -1726,6 +1760,7 @@ export const fetchGitHubPullRequestMembership = async (
   options: {
     commitRepository?: GitHubRepository;
     deadlineAt?: number;
+    expectedBaseSha?: string;
     expectedHeadSha?: string;
   } = {}
 ) =>
@@ -1753,6 +1788,7 @@ export const fetchGitHubPullRequestSource = async (
         snapshot.pullRequest.headRepository ??
         snapshot.pullRequest.baseRepository,
       deadlineAt: options.deadlineAt,
+      expectedBaseSha: snapshot.pullRequest.baseSha,
       expectedHeadSha: snapshot.pullRequest.headSha,
     }
   );

--- a/src/lib/github-activity-worker.ts
+++ b/src/lib/github-activity-worker.ts
@@ -382,6 +382,7 @@ const reconcilePullRequest = async (
           snapshot.pullRequest.headRepository ??
           snapshot.pullRequest.baseRepository,
         deadlineAt: context.deadlineAt,
+        expectedBaseSha: snapshot.pullRequest.baseSha,
         expectedHeadSha: snapshot.pullRequest.headSha,
       }
     );

--- a/src/lib/github-pull-request-backfill.ts
+++ b/src/lib/github-pull-request-backfill.ts
@@ -348,11 +348,16 @@ const pullRequestCandidateFromListValue = (
   }
   const root = value as Record<string, unknown>;
   const {
+    created_at: providerCreatedAt,
     html_url: htmlUrl,
     node_id: nodeId,
     number,
     updated_at: providerUpdatedAt,
   } = root;
+  const createdAt =
+    typeof providerCreatedAt === "string"
+      ? new Date(providerCreatedAt)
+      : new Date(Number.NaN);
   const updatedAt =
     typeof providerUpdatedAt === "string"
       ? new Date(providerUpdatedAt)
@@ -363,6 +368,7 @@ const pullRequestCandidateFromListValue = (
     typeof nodeId !== "string" ||
     nodeId.length === 0 ||
     nodeId.length > 100 ||
+    Number.isNaN(createdAt.getTime()) ||
     Number.isNaN(updatedAt.getTime()) ||
     htmlUrl !==
       `https://github.com/${input.repository.fullName}/pull/${String(number)}`
@@ -370,13 +376,16 @@ const pullRequestCandidateFromListValue = (
     return null;
   }
   return {
-    account: input.account,
-    nodeId,
-    number: Number(number),
-    providerUpdatedAt: updatedAt.toISOString(),
-    repository: input.repository.fullName,
-    repositoryId: input.repository.id,
-  } satisfies GitHubPullRequestBackfillCandidate;
+    candidate: {
+      account: input.account,
+      nodeId,
+      number: Number(number),
+      providerUpdatedAt: updatedAt.toISOString(),
+      repository: input.repository.fullName,
+      repositoryId: input.repository.id,
+    } satisfies GitHubPullRequestBackfillCandidate,
+    createdAt: createdAt.toISOString(),
+  };
 };
 
 const validateNextPullRequestPage = (
@@ -384,13 +393,16 @@ const validateNextPullRequestPage = (
   currentPage: number,
   repository: GitHubRepositoryFacts
 ) => {
+  const namedPath = repositoryApiPath(repository.fullName, "/pulls");
+  const numericPath = `/repositories/${encodeURIComponent(repository.id)}/pulls`;
   if (
-    next.pathname !== repositoryApiPath(repository.fullName, "/pulls") ||
-    next.searchParams.get("direction") !== "desc" ||
+    (next.pathname !== namedPath && next.pathname !== numericPath) ||
+    next.searchParams.get("direction") !== "asc" ||
     next.searchParams.get("page") !== String(currentPage + 1) ||
     next.searchParams.get("per_page") !== String(GITHUB_PAGE_SIZE) ||
-    next.searchParams.get("sort") !== "updated" ||
-    next.searchParams.get("state") !== "all"
+    next.searchParams.get("sort") !== "created" ||
+    next.searchParams.get("state") !== "all" ||
+    next.searchParams.size !== 5
   ) {
     throw new TypeError("GitHub returned invalid pull request pagination.");
   }
@@ -407,14 +419,14 @@ export const collectGitHubPullRequestBackfillCandidates = async (input: {
   let url: URL | null = githubApiUrl(
     repositoryApiPath(input.repository.fullName, "/pulls")
   );
-  url.searchParams.set("direction", "desc");
+  url.searchParams.set("direction", "asc");
   url.searchParams.set("page", "1");
   url.searchParams.set("per_page", String(GITHUB_PAGE_SIZE));
-  url.searchParams.set("sort", "updated");
+  url.searchParams.set("sort", "created");
   url.searchParams.set("state", "all");
   const pullRequests = new Map<string, GitHubPullRequestBackfillCandidate>();
   const visited = new Set<string>();
-  let previousUpdatedAt = Number.POSITIVE_INFINITY;
+  let previousCreatedAt = Number.NEGATIVE_INFINITY;
   let page = 1;
 
   while (url !== null) {
@@ -440,17 +452,18 @@ export const collectGitHubPullRequestBackfillCandidates = async (input: {
     }
 
     for (const value of payload) {
-      const candidate = pullRequestCandidateFromListValue(value, input);
-      if (candidate === null) {
+      const parsed = pullRequestCandidateFromListValue(value, input);
+      if (parsed === null) {
         throw new TypeError("GitHub returned an invalid pull request page.");
       }
-      const updatedAt = new Date(candidate.providerUpdatedAt).getTime();
-      if (updatedAt > previousUpdatedAt) {
+      const createdAt = new Date(parsed.createdAt).getTime();
+      if (createdAt < previousCreatedAt) {
         throw new TypeError(
-          "GitHub returned pull requests outside descending updated order."
+          "GitHub returned pull requests outside ascending created order."
         );
       }
-      previousUpdatedAt = updatedAt;
+      previousCreatedAt = createdAt;
+      const { candidate } = parsed;
       const existing = pullRequests.get(candidate.nodeId);
       if (
         existing !== undefined &&
@@ -667,6 +680,7 @@ const preparePullRequest = async (input: {
     {
       commitRepository,
       deadlineAt: input.deadlineAt,
+      expectedBaseSha: snapshot.pullRequest.baseSha,
       expectedHeadSha: snapshot.pullRequest.headSha,
     }
   );

--- a/tests/github-activity-feed-postgres.test.mjs
+++ b/tests/github-activity-feed-postgres.test.mjs
@@ -668,8 +668,12 @@ describe.skipIf(!dockerAvailable)(
         on conflict (account) do nothing
       `;
       await admin`
-        insert into github_repositories (full_name, id)
-        values ('f0rr0/deadline-release', ${repositoryId})
+        insert into github_repositories (
+          first_observed_at, full_name, id, last_observed_at
+        ) values (
+          '2018-01-01T00:00:00.000Z', 'f0rr0/deadline-release',
+          ${repositoryId}, '2018-01-01T00:00:00.000Z'
+        )
       `;
       await admin`
         insert into github_push_observations (

--- a/tests/github-activity-processor.test.mjs
+++ b/tests/github-activity-processor.test.mjs
@@ -286,6 +286,7 @@ describe("GitHub activity commit acquisition", () => {
       );
       return Response.json({
         ahead_by: 2,
+        total_commits: 2,
         commits: [
           pushCommitValue(trackedSha, "f0rr0", 100),
           pushCommitValue(foreignSha, "octocat", 200),
@@ -318,6 +319,7 @@ describe("GitHub activity commit acquisition", () => {
     globalThis.fetch = async () =>
       Response.json({
         ahead_by: 3,
+        total_commits: 3,
         commits: [
           pushCommitValue(firstSha, "f0rr0", 100),
           pushCommitValue(surplusSha, "octocat", 200),
@@ -348,6 +350,7 @@ describe("GitHub activity commit acquisition", () => {
     globalThis.fetch = async () =>
       Response.json({
         ahead_by: 2,
+        total_commits: 2,
         commits: [
           pushCommitValue(firstSha, "f0rr0", 100),
           pushCommitValue(afterSha, "f0rr0", 100),
@@ -377,6 +380,7 @@ describe("GitHub activity commit acquisition", () => {
     globalThis.fetch = async () =>
       Response.json({
         ahead_by: 2,
+        total_commits: 2,
         commits: [
           { author: { login: "octocat" }, commit: null, sha: foreignSha },
           {
@@ -419,6 +423,7 @@ describe("GitHub activity commit acquisition", () => {
     globalThis.fetch = async () =>
       Response.json({
         ahead_by: 1,
+        total_commits: 1,
         commits: [
           {
             author: { login: "f0rr0" },
@@ -447,7 +452,8 @@ describe("GitHub activity commit acquisition", () => {
     const beforeSha = "1".repeat(40);
     const afterSha = "2".repeat(40);
     env.GITHUB_F0RR0_TOKEN = "test-token";
-    globalThis.fetch = async () => Response.json({ ahead_by: 0, commits: [] });
+    globalThis.fetch = async () =>
+      Response.json({ ahead_by: 0, commits: [], total_commits: 0 });
 
     const source = await fetchGitHubPushObservationSource({
       account: "f0rr0",
@@ -1119,6 +1125,34 @@ describe("GitHub pull request acquisition", () => {
     });
   });
 
+  test("does not accept PR membership before pagination terminates", async () => {
+    let calls = 0;
+    globalThis.fetch = async (input) => {
+      calls += 1;
+      const url = new URL(input instanceof Request ? input.url : input);
+      const next = new URL(url);
+      next.searchParams.set("page", String(calls + 1));
+      return Response.json([pushCommitValue(headSha, "f0rr0", 100)], {
+        headers: { link: `<${next.href}>; rel="next"` },
+      });
+    };
+
+    const membership = await fetchGitHubPullRequestMembershipWithToken(
+      {
+        account: "f0rr0",
+        number: 7,
+        repository: repository.full_name,
+        repositoryId: String(repository.id),
+      },
+      1,
+      "test-token",
+      { expectedHeadSha: headSha }
+    );
+
+    expect(calls).toBe(3);
+    expect(membership.membershipComplete).toBe(false);
+  });
+
   test("accepts an upstream PR discovered from a fork commit", async () => {
     const commitSha = "9".repeat(40);
     const forkRepository = {
@@ -1239,72 +1273,88 @@ describe("GitHub pull request acquisition", () => {
     ]);
   });
 
-  test("fully paginates GraphQL membership beyond the REST cap", async () => {
+  test("recovers an incomplete bounded PR response from its pinned comparison", async () => {
+    const requestedPaths = [];
+    globalThis.fetch = async (input) => {
+      const url = new URL(input instanceof Request ? input.url : input);
+      requestedPaths.push(url.pathname);
+      if (url.pathname.endsWith("/pulls/7/commits")) {
+        return Response.json([{ sha: memberShas[0] }]);
+      }
+      if (
+        url.pathname ===
+        `/repos/${repository.full_name}/compare/${baseSha}...${headSha}`
+      ) {
+        return Response.json({
+          ahead_by: 2,
+          commits: memberShas.map((sha) => pushCommitValue(sha, "f0rr0", 100)),
+          total_commits: 2,
+        });
+      }
+      return Response.json({ message: "not found" }, { status: 404 });
+    };
+
+    const membership = await fetchGitHubPullRequestMembershipWithToken(
+      {
+        account: "f0rr0",
+        number: 7,
+        repository: repository.full_name,
+        repositoryId: String(repository.id),
+      },
+      memberShas.length,
+      "test-token",
+      { expectedBaseSha: baseSha, expectedHeadSha: headSha }
+    );
+
+    expect(membership.commitShas).toEqual(memberShas);
+    expect(membership.membershipComplete).toBe(true);
+    expect(requestedPaths).toEqual([
+      `/repos/${repository.full_name}/pulls/7/commits`,
+      `/repos/${repository.full_name}/compare/${baseSha}...${headSha}`,
+    ]);
+  });
+
+  test("uses a complete paginated comparison beyond the PR commit cap", async () => {
     env.GITHUB_F0RR0_TOKEN = "test-token";
-    const graphQlCursors = [];
-    globalThis.fetch = async (input, init) => {
+    const comparePages = [];
+    globalThis.fetch = async (input) => {
       const url =
         input instanceof Request ? new URL(input.url) : new URL(input);
       if (url.pathname.endsWith("/pulls/7")) {
-        return Response.json({ ...pullRequest, commits: 3051 });
+        return Response.json({ ...pullRequest, commits: 368 });
       }
-      if (url.pathname.endsWith("/pulls/7/commits")) {
+      if (
+        url.pathname ===
+          `/repos/${repository.full_name}/compare/${baseSha}...${headSha}` ||
+        url.pathname ===
+          `/repositories/${String(repository.id)}/compare/${baseSha}...${headSha}`
+      ) {
         const page = Number(url.searchParams.get("page") ?? "1");
-        const shas = Array.from({ length: page < 3 ? 100 : 50 }, (_, index) =>
-          (BigInt(page * 100 + index) + 1n).toString(16).padStart(40, "0")
+        comparePages.push(page);
+        const count = page < 4 ? 100 : 68;
+        const commits = Array.from({ length: count }, (_, index) =>
+          pushCommitValue(
+            (BigInt((page - 1) * 100 + index) + 10_000n)
+              .toString(16)
+              .padStart(40, "0"),
+            "f0rr0",
+            100
+          )
         );
+        if (page === 4) {
+          commits.at(-1).sha = headSha;
+        }
         return Response.json(
-          shas.map((sha) => ({ sha })),
+          { ahead_by: 368, commits, total_commits: 368 },
           {
             headers:
-              page < 3
+              page < 4
                 ? {
-                    link: `<https://api.github.com/repos/example-org/example-repo/pulls/7/commits?per_page=100&page=${String(page + 1)}>; rel="next"`,
+                    link: `<https://api.github.com/repositories/${String(repository.id)}/compare/${baseSha}...${headSha}?per_page=100&page=${String(page + 1)}>; rel="next"`,
                   }
                 : undefined,
           }
         );
-      }
-      if (url.pathname === "/graphql") {
-        expect(init?.method).toBe("POST");
-        const request = JSON.parse(init?.body);
-        const { cursor } = request.variables;
-        graphQlCursors.push(cursor);
-        const page = cursor === null ? 0 : Number(cursor.slice(7));
-        const count = page < 30 ? 100 : 51;
-        const nodes = Array.from({ length: count }, (_, index) => ({
-          commit: {
-            ...(page === 0 && index === 0
-              ? {
-                  author: { user: { login: "f0rr0" } },
-                  committedDate: "2026-08-02T12:00:00Z",
-                  message: "feat: GraphQL membership",
-                }
-              : {}),
-            oid: (BigInt(page * 100 + index) + 10_000n)
-              .toString(16)
-              .padStart(40, "0"),
-          },
-        }));
-        if (page === 30) {
-          nodes.at(-1).commit.oid = headSha;
-        }
-        return Response.json({
-          data: {
-            repository: {
-              pullRequest: {
-                commits: {
-                  nodes,
-                  pageInfo: {
-                    endCursor: page < 30 ? `cursor-${String(page + 1)}` : null,
-                    hasNextPage: page < 30,
-                  },
-                  totalCount: 3051,
-                },
-              },
-            },
-          },
-        });
       }
       return Response.json({ message: "not found" }, { status: 404 });
     };
@@ -1315,12 +1365,79 @@ describe("GitHub pull request acquisition", () => {
       repository: "example-org/example-repo",
       repositoryId: "123",
     });
-    expect(source.commitShas).toHaveLength(3051);
+    expect(source.commitShas).toHaveLength(368);
     expect(source.membershipComplete).toBe(true);
-    expect(source.commits[0]?.committedAt).toBe("2026-08-02T12:00:00.000Z");
-    expect(graphQlCursors).toHaveLength(31);
-    expect(graphQlCursors.at(0)).toBeNull();
-    expect(graphQlCursors.at(-1)).toBe("cursor-30");
+    expect(source.commitShas.at(-1)).toBe(headSha);
+    expect(source.commits[0]?.committedAt).toBe("2026-08-28T12:00:00.000Z");
+    expect(comparePages).toEqual([1, 2, 3, 4]);
+  });
+
+  test("rejects a truncated comparison instead of accepting partial membership", async () => {
+    const commits = Array.from({ length: 250 }, (_, index) =>
+      pushCommitValue(
+        (BigInt(index) + 20_000n).toString(16).padStart(40, "0"),
+        "f0rr0",
+        100
+      )
+    );
+    globalThis.fetch = async (input) => {
+      const url = new URL(input instanceof Request ? input.url : input);
+      expect(url.pathname).toBe(
+        `/repos/${repository.full_name}/compare/${baseSha}...${headSha}`
+      );
+      return Response.json({
+        ahead_by: 251,
+        commits,
+        total_commits: 251,
+      });
+    };
+
+    await expect(
+      fetchGitHubPullRequestMembershipWithToken(
+        {
+          account: "f0rr0",
+          number: 7,
+          repository: repository.full_name,
+          repositoryId: String(repository.id),
+        },
+        251,
+        "test-token",
+        { expectedBaseSha: baseSha, expectedHeadSha: headSha }
+      )
+    ).rejects.toMatchObject({ code: "source_incomplete" });
+  });
+
+  test("rejects comparison links that skip a page", async () => {
+    const commits = Array.from({ length: 100 }, (_, index) =>
+      pushCommitValue(
+        (BigInt(index) + 30_000n).toString(16).padStart(40, "0"),
+        "f0rr0",
+        100
+      )
+    );
+    globalThis.fetch = async () =>
+      Response.json(
+        { ahead_by: 251, commits, total_commits: 251 },
+        {
+          headers: {
+            link: `<https://api.github.com/repositories/${String(repository.id)}/compare/${baseSha}...${headSha}?per_page=100&page=3>; rel="next"`,
+          },
+        }
+      );
+
+    await expect(
+      fetchGitHubPullRequestMembershipWithToken(
+        {
+          account: "f0rr0",
+          number: 7,
+          repository: repository.full_name,
+          repositoryId: String(repository.id),
+        },
+        251,
+        "test-token",
+        { expectedBaseSha: baseSha, expectedHeadSha: headSha }
+      )
+    ).rejects.toMatchObject({ code: "source_invalid" });
   });
 });
 

--- a/tests/github-pull-request-backfill.test.mjs
+++ b/tests/github-pull-request-backfill.test.mjs
@@ -39,11 +39,15 @@ const rawRepository = {
   visibility: repository.visibility,
 };
 
-const pullRequestValue = (number, updatedAt) => ({
+const pullRequestValue = (
+  number,
+  updatedAt,
+  createdAt = "2026-07-01T00:00:00Z"
+) => ({
   base: { ref: "main", repo: rawRepository, sha: "a".repeat(40) },
   body: null,
   closed_at: null,
-  created_at: "2026-07-01T00:00:00Z",
+  created_at: createdAt,
   draft: false,
   head: {
     ref: `feature/${String(number)}`,
@@ -338,22 +342,25 @@ describe("GitHub pull request historical backfill", () => {
     ]);
   });
 
-  test("walks every all-state PR despite adversarially old update times", async () => {
+  test("walks stable created-order pages and accepts numeric pagination paths", async () => {
     const requests = [];
     globalThis.fetch = async (input) => {
       const url = new URL(input instanceof Request ? input.url : input);
       requests.push(url);
       if (url.searchParams.get("page") === "2") {
-        return Response.json([pullRequestValue(3, "2026-07-31T23:59:59Z")]);
+        return Response.json([
+          pullRequestValue(3, "2026-07-31T23:59:59Z", "2026-07-03T00:00:00Z"),
+        ]);
       }
       const next = new URL(url);
+      next.pathname = `/repositories/${repository.id}/pulls`;
       next.searchParams.set("page", "2");
       return Response.json(
         [
           // Updated after the commit window still matters: the PR may have
           // retained an in-window commit only after that window closed.
-          pullRequestValue(1, "2026-09-10T00:00:00Z"),
-          pullRequestValue(2, "2026-08-01T00:00:00Z"),
+          pullRequestValue(1, "2026-09-10T00:00:00Z", "2026-07-01T00:00:00Z"),
+          pullRequestValue(2, "2026-08-01T00:00:00Z", "2026-07-02T00:00:00Z"),
         ],
         { headers: { link: `<${next.href}>; rel="next"` } }
       );
@@ -373,14 +380,17 @@ describe("GitHub pull request historical backfill", () => {
       "PR_node_3",
     ]);
     expect(requests).toHaveLength(2);
+    expect(requests.map(({ pathname }) => pathname)).toEqual([
+      "/repos/example-org/example-repo/pulls",
+      "/repositories/123/pulls",
+    ]);
     for (const url of requests) {
-      expect(url.pathname).toBe("/repos/example-org/example-repo/pulls");
-      expect(url.searchParams.get("direction")).toBe("desc");
+      expect(url.searchParams.get("direction")).toBe("asc");
       expect(url.searchParams.get("page")).toBe(
         String(requests.indexOf(url) + 1)
       );
       expect(url.searchParams.get("per_page")).toBe("100");
-      expect(url.searchParams.get("sort")).toBe("updated");
+      expect(url.searchParams.get("sort")).toBe("created");
       expect(url.searchParams.get("state")).toBe("all");
     }
   });
@@ -406,11 +416,11 @@ describe("GitHub pull request historical backfill", () => {
     ).rejects.toThrow("invalid pull request pagination");
   });
 
-  test("rejects pages that violate the documented descending order", async () => {
+  test("rejects pages that violate the documented ascending created order", async () => {
     globalThis.fetch = async () =>
       Response.json([
-        pullRequestValue(1, "2026-08-01T00:00:00Z"),
-        pullRequestValue(2, "2026-08-02T00:00:00Z"),
+        pullRequestValue(1, "2026-08-01T00:00:00Z", "2026-07-02T00:00:00Z"),
+        pullRequestValue(2, "2026-08-02T00:00:00Z", "2026-07-01T00:00:00Z"),
       ]);
 
     await expect(
@@ -420,7 +430,7 @@ describe("GitHub pull request historical backfill", () => {
         repository,
         token: "test-token",
       })
-    ).rejects.toThrow("outside descending updated order");
+    ).rejects.toThrow("outside ascending created order");
   });
 
   test("fails incomplete when a listed pull request becomes inaccessible", async () => {


### PR DESCRIPTION
## Summary

- replace the capped GraphQL PR-membership fallback with a paginated, immutable `base...head` comparison
- validate comparison totals, unique progress, terminal head, page progression, and canonical numeric pagination links
- enumerate affiliated PRs in stable creation order while accepting GitHub’s canonical repository pagination path
- correct the historical-backfill documentation and the date-sensitive PostgreSQL fixture

## Verification

- live read-only verification recovered 368/368 commits from the PR that failed the Action and 308/308 from a merged oversized PR
- `bun test` (194 passed)
- `bun run lint`
- `bun run typecheck`
- `bun run build`
- `actionlint`
- `bun run db:generate` (no schema drift)