### PR TITLE
fix(github): bound historical activity backfills

### DIFF
--- a/.github/workflows/github-activity-backfill.yml
+++ b/.github/workflows/github-activity-backfill.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       start_date:
-        description: Start date — earliest UTC day included (YYYY-MM-DD)
+        description: Start UTC day; max 31 days, broad runs within 62 days (YYYY-MM-DD)
         required: true
         type: string
       end_date:
@@ -21,13 +21,13 @@ on:
           - yuppiestechdev
           - all
       repository_id:
-        description: Numeric repository ID to scan; blank scans every accessible repository
+        description: Numeric repository ID; blank scans repositories active in the window
         required: false
         type: string
       maximum_minutes:
-        description: Discovery/processing budget; durable work can continue (1-330 min)
+        description: Hard discovery/processing budget; incomplete work fails visibly (1-330 min)
         required: true
-        default: 300
+        default: 60
         type: number
 
 concurrency:
@@ -52,7 +52,7 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
-      - name: Discover history and process shared work
+      - name: Discover history and process work
         env:
           ACCOUNT: ${{ inputs.account }}
           DATABASE_URL: ${{ secrets.ACTIVITY_DATABASE_URL }}
@@ -60,7 +60,6 @@ jobs:
           GITHUB_F0RR0_TOKEN: ${{ secrets.ACTIVITY_F0RR0_TOKEN }}
           GITHUB_YUPPIESTECHDEV_TOKEN: ${{ secrets.ACTIVITY_YUPPIESTECHDEV_TOKEN }}
           MAXIMUM_MINUTES: ${{ inputs.maximum_minutes }}
-          OPENAI_API_KEY: ${{ secrets.ACTIVITY_OPENAI_API_KEY }}
           REPOSITORY_ID: ${{ inputs.repository_id }}
           START_DATE: ${{ inputs.start_date }}
         run: >-

--- a/docs/github-activity-public-commit-summaries.md
+++ b/docs/github-activity-public-commit-summaries.md
@@ -175,17 +175,20 @@ revision.
 Completed rows appear in pages of complete UTC days: five days by default, with
 a server maximum of 14. The opaque cursor carries the prior page's UTC-day
 boundary and original snapshot timestamp, so an older page cannot include work
-published after the first page. Pagination never splits one day across pages.
+published after the first page. Each page is read in one read-only repeatable-
+read transaction; later canonicalization can still remove or regroup work
+between cursor requests because historical projection versions are not stored.
+Pagination never splits one day across pages.
 
 Canonical commits with the same primary GitHub PR and UTC day render as one PR
 slice containing their individual headlines/disclosures. A PR spanning several
 days produces one slice per day. Each repository appears under one header per
 day, ordered by its newest visible activity, with its standalone commits, PR
 slices, and issues nested beneath it. Stored multi-parent merge commits are
-omitted from summary generation and the timeline. PR merge outcomes contribute
-to the daily totals without producing separate timeline entries. Daily totals
-include repositories, additions, deletions, merged PRs, and opened issues;
-proven aliases and omitted merge commits do not add duplicate churn.
+omitted from summary generation and the timeline. A PR merge is association and
+deduplication evidence, not a second unit of public work. Daily totals include
+repositories, additions, deletions, and opened issues; proven aliases and
+omitted merge commits do not add duplicate churn.
 
 Language logos use version-pinned Simple Icons SVGs from the npm distribution.
 Repository owner avatars and durable repository/PR display facts come from the

--- a/docs/github-commits.md
+++ b/docs/github-commits.md
@@ -39,7 +39,7 @@ Manual GitHub Actions backfill
   -> persist candidates directly and run the same durable worker
 
 Next.js server render / GET /api/github/activity
-  -> snapshot-stable pages of complete UTC days
+  -> atomically read, publication-watermarked pages of complete UTC days
 ```
 
 The webhook is the low-latency path for repositories where the GitHub App is
@@ -178,17 +178,21 @@ reconciliations, and summaries. Canonicalization remains capped at eight, and
 the pass has a 90-second internal deadline. Direct GitHub Actions backfill
 passes raise every provider-backed stage limit to eight and use a four-minute
 per-pass deadline. The Action runner uses its longer job lifetime through
-repeated durable passes rather than one unbounded operation. A pass that reaches
-its deadline releases unfinished claims at their previously eligible retry
-state; an invocation boundary does not spend a retry attempt or add backoff.
+repeated durable passes rather than one unbounded operation. When a scoped audit
+finds only retry-delayed work, the runner waits until its earliest durable retry
+only when that retry still fits inside the selected Action budget. A pass that
+reaches its deadline releases unfinished claims at their previously eligible
+retry state; an invocation boundary does not spend a retry attempt or add
+backoff.
 
 A commit with more than one parent is a regular merge commit. It remains fully
 stored for intake, ancestry, and alias evidence, but it is excluded from summary
 creation, summary claims, the public activity projection, pagination days, and
-daily LOC/repository totals. A merged pull request contributes to its day's
-aggregate total without producing a separate timeline entry. This intentionally
-omits even a merge commit with unique conflict-resolution changes: the public
-surface describes authored work and PR outcomes, not integration mechanics.
+daily LOC/repository totals. A merge event is evidence for associating and
+deduplicating authored commits; it is not public work by itself and contributes
+no timeline entry or aggregate count. This intentionally omits even a merge
+commit with unique conflict-resolution changes: the public surface describes
+authored work, not integration mechanics.
 
 An issue opened by a tracked account needs no enrichment or model call. Intake
 persists its stable node/repository IDs, original title/link snapshots, creation
@@ -197,10 +201,14 @@ an `issues` webhook converge on those same unique identities.
 
 Observation and commit fetches require GitHub's provider timestamp rather than
 substituting the poll time. They use retryable database states and honor GitHub
-rate-limit timing; permanent source failures become `unavailable`. Work is
-owned through conditional leases, so a timed-out Vercel invocation can be
-continued safely by a later worker. The worker stops starting expensive work
-before its internal deadline.
+rate-limit timing. Non-retryable REST `403`, `404`, `410`, and `422`,
+non-retryable GraphQL failures, and repeatedly unusable, incomplete,
+unavailable, or unauthorized source evidence become explicit terminal coverage
+gaps after three independent claims; rate limits and request deadlines never
+do. Terminal summary acquisition becomes `indeterminate`. Work is owned through
+conditional leases, so a timed-out Vercel invocation can be continued safely by
+a later worker. The worker stops starting expensive work before its internal
+deadline.
 
 Commit storage is sufficient to audit and re-fetch the source under the normal
 assumption that repository access and history remain available. It includes
@@ -246,15 +254,15 @@ base-only, title, or body edit does not fetch membership again or create a new
 commit-summary revision.
 
 Each routine worker pass claims at most four due PRs globally across active
-tracked accounts; the Action raises that global cap to eight. Claims rotate one
-account at a time so one account cannot consume the whole pass while another
-has eligible work. A known merged or closed PR receives one successful terminal
-refresh, then clears
+tracked accounts; the Action raises the cap to eight within its manual scope.
+Claims rotate one account at a time so one account cannot consume the whole pass
+while another has eligible work. A known merged or closed PR receives one
+successful terminal refresh, then clears
 `next_reconcile_at` and leaves the queue. Temporary failures use exponential
 backoff from 15 minutes through 24 hours instead of silently dropping that
-refresh. A GitHub `404` remains retryable because repository permissions can
-change; `410` and `422` become unavailable only after eight attempts.
-A proven repository/SHA provenance change remains immediately terminal.
+refresh. A deterministic provider failure is retried across three independent
+claims before becoming a visible coverage gap; a proven repository/SHA
+provenance change remains immediately terminal.
 
 ### Proven-copy canonicalization
 
@@ -328,19 +336,22 @@ Subsequent pages use
 Pagination is by complete UTC day, not by item. A page contains five days by
 default (the server accepts at most 14). Its opaque, versioned cursor contains a
 `beforeDay` boundary and the original `snapshotAt`, so loading older days cannot
-mix in activities published after the first page. A safety limit fails the read
-instead of returning a partial day.
+mix in activities published after the first page. Every page is projected in a
+single read-only repeatable-read transaction. Later canonicalization can still
+remove or regroup work between separate cursor requests; the database does not
+retain historical projection versions. A safety limit fails the read instead of
+returning a partial day.
 
 Each day shows totals for repositories, GitHub-reported additions/deletions,
-PRs merged, and issues opened. Every repository appears once per day, ordered by
-its newest visible activity, with standalone commits, PR slices, and issues
-nested beneath that header. A contracted commit is one line containing its
+and issues opened. Every repository appears once per day, ordered by its newest
+visible activity, with standalone commits, PR slices, and issues nested beneath
+that header. A contracted commit is one line containing its
 truncated headline, line-change count, and chevron; expansion leaves those
 elements in place and adds the muted description, languages, and file count
 below. PR commits are shown under deterministic per-day PR slices without a
-separate type label. PR merge outcomes contribute to the daily totals instead of
-rendering as separate timeline entries. Repository and owner display facts are
-served from persisted snapshots; the page does not refetch GitHub.
+separate type label. A PR merge is association and deduplication evidence, not a
+second unit of public work. Repository and owner display facts are served from
+persisted snapshots; the page does not refetch GitHub.
 Timestamps hydrate to the viewer's local time without a timezone suffix; UTC is
 used only for stable day grouping and pagination.
 
@@ -522,7 +533,12 @@ The `Backfill GitHub activity` workflow is manually dispatched from GitHub
 Actions after its workflow file is present on the default branch. `start_date`
 is the earliest UTC calendar day included and `end_date` is the latest; both
 days are inclusive, the start must not follow the end, and the end cannot be in
-the future. Before inventory starts, the Action runs the same locked evidence
+the future. One invocation spans at most 31 days. A broad all-repository run
+must start within the last 62 inclusive UTC days; older recovery requires an
+explicit numeric `repository_id`, so mutable current `pushed_at`/`updated_at`
+timestamps cannot turn an old month into a near-lifetime scan. Longer history
+must be dispatched as separate repository-scoped month-sized runs. Before
+inventory starts, the Action runs the same locked evidence
 integrity preflight as the scheduled worker, so a backfill cannot process rows
 under the transitional migration invariant. The workflow also accepts one
 tracked account or both, an optional
@@ -539,69 +555,106 @@ ACTIVITY_F0RR0_TOKEN
 ACTIVITY_YUPPIESTECHDEV_TOKEN
 ```
 
-Only the token for each selected account is required. The optional
-`ACTIVITY_OPENAI_API_KEY` enables richer public-repository summaries; omitting
-it selects the deterministic fallback and does not reduce discovery coverage.
+Only the token for each selected account is required. The Action deliberately
+does not receive an OpenAI key; its worker passes use the deterministic summary
+fallback so historical completion is not coupled to a model provider.
 
 For each selected account, the runner first verifies that `/user` matches the
 selected tracked account, then performs two independent discovery passes over
-the requested inclusive UTC interval. There is no arbitrary day-count cap; the
-selected Action time budget is the operational bound. Pull requests run first
+the requested inclusive UTC interval. Pull requests run first
 because the all-repository authored-PR stream cannot be repository-sharded:
 
-1. Enumerate every all-state pull request in each affiliated repository in
-   ascending creation order. Creation order is stable while a mutable
-   `updated_at` ordering can move PRs between pages; no timestamp cutoff is safe
-   because Git commit timestamps are author-controlled. An all-repository run
-   independently walks the tracked user's unbounded GraphQL `pullRequests`
-   connection as well, so an authored PR remains discoverable when its base is
-   an unaffiliated external repository. The author stream validates the
-   returned user and PR author, repository database ID/name, PR identity/link,
-   total count, unique progress, and every cursor before merging by PR node ID
-   with the affiliated inventory.
+1. Enumerate repositories whose current `pushed_at` is on or after the window
+   start. Within them, read all-state PRs in descending `updated_at` order and
+   stop below the same boundary. An all-repository run independently reads the
+   tracked user's GraphQL `pullRequests` connection in descending `UPDATED_AT`
+   order and stops at the boundary, so a recently changed authored PR remains
+   discoverable when its base is an unaffiliated external repository. The
+   author stream validates the returned user and PR author, repository database
+   ID/name, PR identity/link, total count, monotonic ordering, unique progress,
+   and every traversed cursor before merging by PR node ID with the affiliated
+   inventory. Logs report both the lifetime total and the smaller selected
+   window count.
    A repository-targeted run stays scoped to that numeric repository ID and does
    not invoke the author stream. Fetch complete membership, retain a PR when it
-   contains a tracked commit in the interval or is a tracked-authored merge in
-   the interval, and resolve merged PR evidence through GraphQL. A verified null
-   merge commit is retained as the valid result of a rebase merge.
-2. Enumerate every accessible repository and its current branches and tags,
-   order branches before tags, and collapse refs that share a commit target.
-   For each distinct target, paginate GitHub's commit list with that SHA,
-   tracked author, `since`, and `until`, then persist candidates directly using
-   repository ID plus commit SHA as their identity.
+   contains a tracked-authored commit in the interval, and resolve merge
+   evidence through GraphQL only for internal association and deduplication. A
+   PR merge without such a commit is not retained as public work.
+2. Enumerate the same recently pushed repository set and its current branches
+   and tags, order branches before tags, and collapse refs that share a commit
+   target. For each distinct target, paginate GitHub's commit list with that
+   SHA, tracked author, `since`, and `until`, then persist candidates directly
+   using repository ID plus commit SHA as their identity.
 
-The commit and merge date filters remain inclusive at both ends. When `all` is
+The commit date filter remains inclusive at both ends. When `all` is
 selected, the two account inventories run concurrently with a maximum
 concurrency of two; each account still uses its own token and author filter.
 
-Together, the passes deterministically cover tracked-author commits in the date
-range that are reachable from a current ref or retained by an eligible PR when
-the Action runs. They cannot discover a commit that was force-pushed away or
+Together, the passes cover tracked-author commits in the date range that are
+reachable from a current ref or retained by an eligible PR when the Action runs,
+provided repository/PR update timestamps reflect the push that exposed the
+commit. The `pushed_at` and `updated_at` cutoffs are practical provider bounds,
+not a proof for deliberately forged future Git timestamps. The passes cannot
+discover a commit that was force-pushed away or
 whose only branch, tag, and PR were deleted before any webhook, Event, prior
 backfill, or surviving ref exposed its SHA. They also cannot inspect a
 repository the selected token cannot access, and GitHub must associate the
 commit author with the tracked account.
 
 GitHub primary-rate-limit responses are waited out when the reset still fits
-inside the selected budget. A deadline or provider delay that cannot fit marks
-the inventory incomplete and fails the job explicitly. Repeating the same
-inputs is safe: commit, PR, and membership identities deduplicate in the
-database, and a complete current membership is not rewritten or invalidated on
-an unchanged PR version. Provider discovery still restarts from the
-deterministic beginning rather than storing an Action-only cursor. If an
-all-repository scan repeatedly exceeds 330 minutes, dispatch the same range once
-per numeric `repository_id` to shard the affiliated inventory; those scoped runs
-intentionally do not replace the all-repository authored-PR pass.
+inside the selected budget. The workflow defaults to a 60-minute budget, which
+starts before the locked evidence-integrity preflight and covers discovery,
+worker drains, retry waits, and the final audit. The preflight applies matching
+PostgreSQL lock and statement timeouts, provider calls carry the same absolute
+deadline, and worker passes plus the final audit are deadline-raced. A deadline
+or retryable provider delay that cannot fit marks the run incomplete and fails
+it explicitly.
+Repeating the same inputs is safe: commit, PR, and membership identities
+deduplicate in the database, and a complete current membership is not rewritten
+or invalidated on an unchanged PR version. Provider discovery still restarts
+from the deterministic beginning rather than storing an Action-only cursor. If
+an individual recently active repository dominates a run, dispatch the same
+range for its numeric `repository_id`; those scoped runs intentionally do not
+replace the all-repository authored-PR pass.
 
 After discovery, direct worker passes request at most eight items from every
-configurable stage. They process the shared global queue, which can include work
-unrelated to the selected backfill. The final JSON contains per-account
+configurable stage. The manual worker admits only the selected accounts and
+commit timestamps. A repository-targeted run additionally admits direct work in
+that repository and commits retained by its current complete PR memberships;
+scheduled workers remain global. The final JSON contains per-account
 `inventories` with `direct` and `pullRequests` results, the aggregate
-`inventoryComplete` flag, and global `processing` outcomes. A complete inventory
-proves that both discovery passes reached their ends; it does not prove the
-shared worker queue is empty. Likewise, a worker pass that claims zero items
-does not prove retry-delayed work is absent. Normal five-minute Vercel worker
-runs continue durable work after the Action stops.
+`boundedDiscoveryComplete` flag, `discoveryCoverage`, scoped `processing`
+outcomes, per-account scoped `audits`, explicit `coverageGaps`, and separate
+`pipelineSettled`, `complete`, and `outcome` fields. The Action exits
+successfully only when bounded traversal finishes and every scoped audit reports
+`stored_projection_verified`. Its outcome is `complete` with no gaps,
+`completed_with_gaps` when terminal provider or pipeline evidence is enumerated,
+or `incomplete` while retryable work remains. One inaccessible repository or PR
+therefore cannot starve later candidates or make every rerun fail forever, but
+the missing evidence is never silently counted as verified coverage. A
+repository-targeted run audits only that repository plus commits retained by its
+current PR memberships, so unrelated work in the same account and window cannot
+fail the run. The audit covers scoped push observations, PR signals,
+memberships, reconciliation, commit enrichment, PR discovery, summaries, and
+the exact public projection. Inbox scope uses provider event time (falling back
+to local observation time for pushes), so delayed delivery is included without
+a historical week draining unrelated later events.
+`pipeline.earliestRetryAt` drives bounded retry waiting. This completion
+contract does not claim provider completeness or recover Git objects that no
+current ref or retained PR exposes.
+
+Run the read-only projection and pipeline audit against any inclusive window of
+at most 31 days:
+
+```sh
+bun run github:audit --account f0rr0 --start-date 2026-08-01 --end-date 2026-08-30
+```
+
+The command exits zero only when the stored pipeline is settled and every
+eligible stored source agrees exactly with the rendered projection, daily
+totals, and repository grouping. It reports `providerCompleteness` as
+`not_assessed`: current GitHub APIs cannot retrospectively prove commits that
+were deleted or force-pushed away before any durable observation.
 
 Use an opaque numeric ID when targeting one repository so a private repository
 name does not appear in public workflow inputs. Resolve it locally with:

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "db:migrate": "drizzle-kit migrate",
     "db:studio": "drizzle-kit studio",
     "github:sync": "bun scripts/sync-github-commits.ts",
+    "github:audit": "bun scripts/audit-github-activity.ts",
     "supabase:cron": "bun scripts/configure-supabase-cron.ts"
   },
   "dependencies": {

--- a/scripts/audit-github-activity.ts
+++ b/scripts/audit-github-activity.ts
@@ -1,0 +1,91 @@
+import { closeDatabase } from "../src/db/client";
+import { env } from "../src/env";
+import {
+  githubActivityAuditRequestFrom,
+  runGitHubActivityAudit,
+} from "../src/lib/github-activity-audit";
+import type { GitHubActivityAuditStatus } from "../src/lib/github-activity-audit";
+
+interface GitHubActivityAuditArguments {
+  account: string;
+  endDate: string;
+  startDate: string;
+}
+
+export const githubActivityAuditArgumentsFrom = (
+  arguments_: readonly string[]
+): GitHubActivityAuditArguments => {
+  const allowed = new Set(["--account", "--end-date", "--start-date"]);
+  const values = new Map<string, string>();
+  for (let index = 0; index < arguments_.length; index += 2) {
+    const name = arguments_[index];
+    const value = arguments_[index + 1];
+    if (
+      name === undefined ||
+      value === undefined ||
+      !allowed.has(name) ||
+      values.has(name)
+    ) {
+      throw new TypeError("The GitHub activity audit arguments are invalid.");
+    }
+    values.set(name, value.trim());
+  }
+  const account = values.get("--account");
+  const endDate = values.get("--end-date");
+  const startDate = values.get("--start-date");
+  if (
+    account === undefined ||
+    account.length === 0 ||
+    endDate === undefined ||
+    endDate.length === 0 ||
+    startDate === undefined ||
+    startDate.length === 0
+  ) {
+    throw new TypeError(
+      "--account, --start-date, and --end-date are required."
+    );
+  }
+  return { account, endDate, startDate };
+};
+
+export const githubActivityAuditExitCodeFromStatus = (
+  status: GitHubActivityAuditStatus
+) => {
+  if (status === "stored_projection_verified") {
+    return 0;
+  }
+  return status === "inconclusive" ? 2 : 1;
+};
+
+const main = async () => {
+  if (env.DATABASE_URL === undefined) {
+    throw new Error("DATABASE_URL is not configured.");
+  }
+  const input = githubActivityAuditArgumentsFrom(process.argv.slice(2));
+  const request = githubActivityAuditRequestFrom(input);
+  if (request === null) {
+    throw new TypeError(
+      "The audit range must use valid inclusive UTC dates, end today or earlier, span at most 31 days, and name a tracked account."
+    );
+  }
+  try {
+    const report = await runGitHubActivityAudit(request);
+    process.stdout.write(`${JSON.stringify(report)}\n`);
+    const exitCode = githubActivityAuditExitCodeFromStatus(report.status);
+    if (exitCode !== 0) {
+      process.exitCode = exitCode;
+    }
+  } finally {
+    await closeDatabase();
+  }
+};
+
+if (import.meta.main) {
+  try {
+    await main();
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Unknown error";
+    process.stderr.write(`${message}\n`);
+    process.exitCode = 2;
+  }
+}

--- a/scripts/backfill-github-activity.ts
+++ b/scripts/backfill-github-activity.ts
@@ -1,13 +1,29 @@
+import { setTimeout as delay } from "node:timers/promises";
+
 import { closeDatabase } from "../src/db/client";
 import { env } from "../src/env";
+import {
+  githubActivityAuditRequestFrom,
+  runGitHubActivityAudit,
+} from "../src/lib/github-activity-audit";
+import type { GitHubActivityAuditReport } from "../src/lib/github-activity-audit";
 import { runGitHubActivityWorker } from "../src/lib/github-activity-worker";
 import { ensureGitHubEvidenceIntegrity } from "../src/lib/github-activity-worker-store";
+import { GitHubRequestDeadlineError } from "../src/lib/github-api";
 import {
   GITHUB_BACKFILL_WORKER_BATCH_SIZE,
+  githubBackfillCompletionFrom,
+  githubBackfillDiscoveryCompleteFrom,
+  githubBackfillExitCodeFrom,
+  githubBackfillOutcomeFrom,
   githubBackfillProcessingCountsFrom,
+  githubBackfillProcessingMadeProgress,
   githubBackfillRequestFrom,
 } from "../src/lib/github-backfill-core";
-import type { GitHubBackfillProcessingCounts } from "../src/lib/github-backfill-core";
+import type {
+  GitHubBackfillProcessingCounts,
+  GitHubBackfillRequest,
+} from "../src/lib/github-backfill-core";
 import { assertGitHubTokenIdentity } from "../src/lib/github-commits";
 import type { TrackedGitHubAccount } from "../src/lib/github-commits-core";
 import { backfillGitHubCommitsFromCurrentRefs } from "../src/lib/github-direct-backfill";
@@ -115,7 +131,12 @@ const requestValue = (input: BackfillArguments) => ({
 
 interface BackfillProcessingTotals extends GitHubBackfillProcessingCounts {
   passes: number;
-  stopReason: "no_immediately_claimable_work" | "time_budget";
+  stopReason:
+    | "audit_failed"
+    | "no_immediately_claimable_work"
+    | "pipeline_stalled"
+    | "retry_outside_budget"
+    | "time_budget";
 }
 
 const emptyProcessingCounts = (): GitHubBackfillProcessingCounts => ({
@@ -139,8 +160,38 @@ const addProcessingCounts = (
   totals.unavailable += counts.unavailable;
 };
 
-const processQueue = async (
+const deadlineErrorAfter = async (
+  milliseconds: number,
+  signal: AbortSignal
+): Promise<never> => {
+  await delay(milliseconds, undefined, { signal });
+  throw new GitHubRequestDeadlineError();
+};
+
+export const runBeforeDeadline = async <Value>(
+  operation: Promise<Value>,
   deadlineAt: number
+): Promise<Value> => {
+  const remainingMilliseconds = Math.floor(deadlineAt - Date.now());
+  if (remainingMilliseconds < 1) {
+    throw new GitHubRequestDeadlineError();
+  }
+  const abortController = new AbortController();
+  const timeout = deadlineErrorAfter(
+    remainingMilliseconds,
+    abortController.signal
+  );
+  try {
+    return await Promise.race([operation, timeout]);
+  } finally {
+    abortController.abort();
+  }
+};
+
+const processQueue = async (
+  deadlineAt: number,
+  request: GitHubBackfillRequest,
+  completedPasses = 0
 ): Promise<BackfillProcessingTotals> => {
   let passes = 0;
   const totals = emptyProcessingCounts();
@@ -152,22 +203,31 @@ const processQueue = async (
     if (maximumDurationMs < 1) {
       break;
     }
-    const result = await runGitHubActivityWorker({
-      commitLimit: GITHUB_BACKFILL_WORKER_BATCH_SIZE,
-      maximumDurationMs,
-      observationLimit: GITHUB_BACKFILL_WORKER_BATCH_SIZE,
-      pullRequestDiscoveryLimit: GITHUB_BACKFILL_WORKER_BATCH_SIZE,
-      pullRequestLimit: GITHUB_BACKFILL_WORKER_BATCH_SIZE,
-      pullRequestSignalLimit: GITHUB_BACKFILL_WORKER_BATCH_SIZE,
-      summaryLimit: GITHUB_BACKFILL_WORKER_BATCH_SIZE,
-    });
+    const result = await runBeforeDeadline(
+      runGitHubActivityWorker({
+        accounts: request.accounts,
+        commitLimit: GITHUB_BACKFILL_WORKER_BATCH_SIZE,
+        maximumDurationMs,
+        observationLimit: GITHUB_BACKFILL_WORKER_BATCH_SIZE,
+        pullRequestDiscoveryLimit: GITHUB_BACKFILL_WORKER_BATCH_SIZE,
+        pullRequestLimit: GITHUB_BACKFILL_WORKER_BATCH_SIZE,
+        pullRequestSignalLimit: GITHUB_BACKFILL_WORKER_BATCH_SIZE,
+        scope: {
+          repositoryId: request.repositoryId,
+          sinceAt: request.sinceAt,
+          untilAt: request.untilAt,
+        },
+        summaryLimit: GITHUB_BACKFILL_WORKER_BATCH_SIZE,
+      }),
+      deadlineAt
+    );
     const counts = githubBackfillProcessingCountsFrom(result);
     passes += 1;
     addProcessingCounts(totals, counts);
     process.stdout.write(
-      `Worker pass ${String(passes)}: claimed ${String(counts.claimed)}, processed ${String(counts.processed)}, deferred ${String(counts.deferred)}, unavailable ${String(counts.unavailable)}, failed ${String(counts.failed)}, aliases ${String(counts.aliases)}.\n`
+      `Worker pass ${String(completedPasses + passes)}: claimed ${String(counts.claimed)}, processed ${String(counts.processed)}, deferred ${String(counts.deferred)}, unavailable ${String(counts.unavailable)}, failed ${String(counts.failed)}, aliases ${String(counts.aliases)}.\n`
     );
-    if (counts.claimed === 0) {
+    if (!githubBackfillProcessingMadeProgress(counts)) {
       return {
         ...totals,
         passes,
@@ -176,6 +236,50 @@ const processQueue = async (
     }
   }
   return { ...totals, passes, stopReason: "time_budget" };
+};
+
+const combineProcessingTotals = (
+  total: BackfillProcessingTotals,
+  next: BackfillProcessingTotals
+): BackfillProcessingTotals => {
+  addProcessingCounts(total, next);
+  total.passes += next.passes;
+  total.stopReason = next.stopReason;
+  return total;
+};
+
+export const backfillRetryWaitMillisecondsFrom = (
+  audits: readonly Pick<GitHubActivityAuditReport, "pipeline" | "status">[],
+  deadlineAt: number,
+  now = Date.now()
+) => {
+  if (
+    audits.length === 0 ||
+    audits.some(
+      ({ status }) =>
+        status !== "pipeline_incomplete" &&
+        status !== "stored_projection_verified"
+    )
+  ) {
+    return null;
+  }
+  const retryTimes = audits.flatMap(({ pipeline, status }) => {
+    if (status !== "pipeline_incomplete" || pipeline.earliestRetryAt === null) {
+      return [];
+    }
+    const timestamp = new Date(pipeline.earliestRetryAt).getTime();
+    if (!Number.isFinite(timestamp)) {
+      throw new TypeError("The GitHub audit retry timestamp is invalid.");
+    }
+    return [timestamp];
+  });
+  if (retryTimes.length === 0) {
+    return null;
+  }
+  const waitMilliseconds = Math.max(1000, Math.min(...retryTimes) - now);
+  return now + waitMilliseconds + WORKER_CLEANUP_MARGIN_MS < deadlineAt
+    ? waitMilliseconds
+    : null;
 };
 
 const tokenFor = (account: TrackedGitHubAccount) => {
@@ -193,89 +297,202 @@ const logAccount = (account: TrackedGitHubAccount, message: string) => {
   process.stdout.write(`[${account}] ${message}\n`);
 };
 
+const runScopedAudits = async (
+  request: GitHubBackfillRequest,
+  deadlineAt: number
+) => {
+  const auditNow = new Date();
+  return await runBeforeDeadline(
+    Promise.all(
+      request.accounts.map(async (account) => {
+        const auditRequest = githubActivityAuditRequestFrom(
+          {
+            account,
+            endDate: request.endDate,
+            repositoryId: request.repositoryId,
+            startDate: request.startDate,
+          },
+          auditNow
+        );
+        if (auditRequest === null) {
+          throw new Error("The completed backfill audit scope is invalid.");
+        }
+        return await runGitHubActivityAudit(auditRequest);
+      })
+    ),
+    deadlineAt
+  );
+};
+
 const main = async () => {
   const input = backfillArgumentsFrom(process.argv.slice(2));
   requireEnvironment(input);
   const request = githubBackfillRequestFrom(requestValue(input));
   if (request === null) {
     throw new TypeError(
-      "The backfill input is invalid: --start-date is the earliest included UTC day and must not follow --end-date, the latest included UTC day. Dates must use YYYY-MM-DD, the end cannot be in the future, and the account and repository ID must be valid."
+      "The backfill input is invalid: use an inclusive UTC range of at most 31 days, with YYYY-MM-DD dates ending today or earlier and a tracked account. Broad runs must start within the last 62 UTC days; use a numeric repository ID for older recovery."
     );
   }
   const { sinceAt, untilAt } = request;
+  const deadlineAt = Date.now() + input.maximumMinutes * 60_000;
   try {
-    const evidenceRecovery = await ensureGitHubEvidenceIntegrity();
-    const deadlineAt = Date.now() + input.maximumMinutes * 60_000;
-    const inventories = await Promise.all(
-      request.accounts.map(async (account) => {
-        const token = tokenFor(account);
-        await assertGitHubTokenIdentity(account, token, { deadlineAt });
-        logAccount(account, "authenticated token identity");
-        const pullRequests = await backfillGitHubPullRequests({
-          account,
-          deadlineAt,
-          onRateLimitWait: (retryAt) => {
-            logAccount(
-              account,
-              `PR rate limit resets at ${retryAt.toISOString()}; waiting within budget`
-            );
-          },
-          repositoryId: request.repositoryId,
-          sinceAt,
-          token,
-          untilAt,
-        });
-        logAccount(
-          account,
-          `pull requests: ${String(pullRequests.pullRequests)} persisted after ${String(pullRequests.scannedPullRequests)} candidates (${pullRequests.stopReason})`
-        );
-        if (Date.now() + WORKER_CLEANUP_MARGIN_MS >= deadlineAt) {
-          return { account, direct: null, pullRequests };
+    const evidenceRecovery = await runBeforeDeadline(
+      ensureGitHubEvidenceIntegrity(new Date(), { deadlineAt }),
+      deadlineAt
+    );
+    const inventories = await runBeforeDeadline(
+      Promise.all(
+        request.accounts.map(async (account) => {
+          const token = tokenFor(account);
+          await assertGitHubTokenIdentity(account, token, { deadlineAt });
+          logAccount(account, "authenticated token identity");
+          const pullRequests = await backfillGitHubPullRequests({
+            account,
+            deadlineAt,
+            onRateLimitWait: (retryAt) => {
+              logAccount(
+                account,
+                `PR rate limit resets at ${retryAt.toISOString()}; waiting within budget`
+              );
+            },
+            repositoryId: request.repositoryId,
+            sinceAt,
+            token,
+            untilAt,
+          });
+          logAccount(
+            account,
+            `authored pull requests: selected ${String(pullRequests.selectedAuthoredPullRequests)} updated in the window from ${String(pullRequests.authoredPullRequestsLifetime)} lifetime rows across ${String(pullRequests.authoredPullRequestPages)} pages`
+          );
+          logAccount(
+            account,
+            `pull requests: ${String(pullRequests.pullRequests)} persisted, ${String(pullRequests.skippedPullRequests)} outside the work window, ${String(pullRequests.unavailablePullRequests)} unavailable PRs and ${String(pullRequests.unavailableRepositories)} unavailable repositories after ${String(pullRequests.scannedPullRequests)} candidates (${pullRequests.stopReason})`
+          );
+          if (Date.now() + WORKER_CLEANUP_MARGIN_MS >= deadlineAt) {
+            return { account, direct: null, pullRequests };
+          }
+          const direct = await backfillGitHubCommitsFromCurrentRefs({
+            account,
+            deadlineAt,
+            onRateLimitWait: (retryAt) => {
+              logAccount(
+                account,
+                `current-ref rate limit resets at ${retryAt.toISOString()}; waiting within budget`
+              );
+            },
+            repositoryId: request.repositoryId,
+            sinceAt,
+            token,
+            untilAt,
+          });
+          logAccount(
+            account,
+            `current refs: ${String(direct.uniqueCommits)} unique commits from ${String(direct.heads)} distinct heads, ${String(direct.unavailableRepositories)} unavailable repositories (${direct.stopReason})`
+          );
+          return { account, direct, pullRequests };
+        })
+      ),
+      deadlineAt
+    );
+    const boundedDiscoveryComplete =
+      githubBackfillDiscoveryCompleteFrom(inventories);
+    const worker: BackfillProcessingTotals = {
+      ...emptyProcessingCounts(),
+      passes: 0,
+      stopReason: "no_immediately_claimable_work",
+    };
+    let audits: readonly GitHubActivityAuditReport[] = [];
+    let completion = githubBackfillCompletionFrom({
+      auditStatuses: [],
+      boundedDiscoveryComplete,
+    });
+    while (true) {
+      const pass = await processQueue(deadlineAt, request, worker.passes);
+      combineProcessingTotals(worker, pass);
+      audits = await runScopedAudits(request, deadlineAt);
+      completion = githubBackfillCompletionFrom({
+        auditStatuses: audits.map(({ status }) => status),
+        boundedDiscoveryComplete,
+      });
+      if (completion.complete || !boundedDiscoveryComplete) {
+        break;
+      }
+      if (pass.stopReason === "time_budget") {
+        worker.stopReason = "time_budget";
+        break;
+      }
+      const retryWait = backfillRetryWaitMillisecondsFrom(audits, deadlineAt);
+      if (retryWait === null) {
+        if (
+          audits.some(
+            ({ status }) => status === "inconclusive" || status === "mismatch"
+          )
+        ) {
+          worker.stopReason = "audit_failed";
+        } else if (
+          audits.some(({ pipeline }) => pipeline.earliestRetryAt !== null)
+        ) {
+          worker.stopReason = "retry_outside_budget";
+        } else {
+          worker.stopReason = "pipeline_stalled";
         }
-        const direct = await backfillGitHubCommitsFromCurrentRefs({
-          account,
-          deadlineAt,
-          onRateLimitWait: (retryAt) => {
-            logAccount(
-              account,
-              `current-ref rate limit resets at ${retryAt.toISOString()}; waiting within budget`
-            );
-          },
-          repositoryId: request.repositoryId,
-          sinceAt,
-          token,
-          untilAt,
-        });
-        logAccount(
-          account,
-          `current refs: ${String(direct.uniqueCommits)} unique commits from ${String(direct.heads)} distinct heads (${direct.stopReason})`
-        );
-        return { account, direct, pullRequests };
-      })
-    );
-    const inventoryComplete = inventories.every(
-      ({ direct, pullRequests }) =>
-        direct?.complete === true && pullRequests.complete
-    );
-    const worker = await processQueue(deadlineAt);
-    process.stdout.write(
-      `${JSON.stringify({ evidenceRecovery: evidenceRecovery.status, inventories, inventoryComplete, processing: worker })}\n`
-    );
-    process.stdout.write(
-      "Processing totals cover the shared global queue; inventoryComplete proves only that this invocation finished both selected discovery passes.\n"
-    );
-    if (worker.stopReason === "time_budget") {
+        break;
+      }
       process.stdout.write(
-        "The Action time budget ended; durable or retry-delayed work may remain, and Supabase Cron will continue it.\n"
+        `No scoped work is claimable; waiting ${String(Math.ceil(retryWait / 1000))} seconds for the next durable retry within the Action budget.\n`
       );
-    } else {
+      await delay(retryWait);
+    }
+    const coverageGaps = {
+      providerPullRequests: inventories.reduce(
+        (total, { pullRequests }) =>
+          total + pullRequests.unavailablePullRequests,
+        0
+      ),
+      providerRepositories: inventories.reduce(
+        (total, { direct, pullRequests }) =>
+          total +
+          (direct?.unavailableRepositories ?? 0) +
+          pullRequests.unavailableRepositories,
+        0
+      ),
+      storedPipeline: audits.reduce(
+        (total, audit) => total + audit.coverage.gaps.total,
+        0
+      ),
+    };
+    const totalCoverageGaps =
+      coverageGaps.providerPullRequests +
+      coverageGaps.providerRepositories +
+      coverageGaps.storedPipeline;
+    const outcome = githubBackfillOutcomeFrom(completion, totalCoverageGaps);
+    process.stdout.write(
+      `${JSON.stringify({ audits, boundedDiscoveryComplete, complete: completion.complete, coverageGaps: { ...coverageGaps, total: totalCoverageGaps }, discoveryCoverage: request.repositoryId === null ? "repositories_pushed_and_pull_requests_updated_since_window_start" : "explicit_repository", evidenceRecovery: evidenceRecovery.status, inventories, outcome, pipelineSettled: completion.pipelineSettled, processing: worker })}\n`
+    );
+    process.stdout.write(
+      "Processing totals cover the requested account, date window, and optional repository scope; boundedDiscoveryComplete reports discovery and pipelineSettled reports scoped stored projection readiness.\n"
+    );
+    if (completion.complete && totalCoverageGaps > 0) {
       process.stdout.write(
-        "No work was immediately claimable; durable retry-delayed work may still remain for Supabase Cron.\n"
+        `The bounded backfill completed with ${String(totalCoverageGaps)} explicit coverage gaps; inspect coverageGaps and audit coverage before interpreting totals.\n`
+      );
+    } else if (worker.stopReason === "time_budget") {
+      process.stdout.write(
+        "The Action time budget ended with scoped work still unsettled.\n"
+      );
+    } else if (!completion.complete) {
+      process.stdout.write(
+        `The scoped pipeline stopped as ${worker.stopReason}; its audit and earliestRetryAt fields describe the remaining work.\n`
       );
     }
-    if (!inventoryComplete) {
+    if (githubBackfillExitCodeFrom(completion) !== 0) {
+      if (boundedDiscoveryComplete) {
+        throw new Error(
+          `The bounded discovery finished, but the stored pipeline/projection is not settled for every requested scope (${audits.map(({ scope, status }) => `${scope.account}:${status}`).join(", ")}; stop reason: ${worker.stopReason}). Durable evidence is safe; inspect each audit's earliestRetryAt and failed checks before rerunning.`
+        );
+      }
       throw new Error(
-        "The GitHub inventory did not finish within the provider/time budget. Persisted evidence is safe; rerun the same inputs idempotently. If an all-repository scan repeatedly exceeds 330 minutes, dispatch one numeric --repository-id at a time to shard the inventory."
+        "The bounded GitHub discovery did not finish within the provider/time budget. Persisted evidence is safe; rerun the same inputs idempotently. If one recently active repository dominates the run, dispatch its numeric --repository-id separately."
       );
     }
   } finally {

--- a/src/components/github-activity-days.tsx
+++ b/src/components/github-activity-days.tsx
@@ -477,16 +477,6 @@ function DayTotals({ day }: Readonly<{ day: PublicGitHubActivityDay }>) {
           value={`−${countFormatter.format(totals.deletions)}`}
         />
       )}
-      {totals.pullRequestsMerged === 0 ? null : (
-        <DayTotal
-          label={
-            totals.pullRequestsMerged === 1
-              ? "pull request merged"
-              : "pull requests merged"
-          }
-          value={countFormatter.format(totals.pullRequestsMerged)}
-        />
-      )}
       {totals.issuesOpened === 0 ? null : (
         <DayTotal
           label={totals.issuesOpened === 1 ? "issue opened" : "issues opened"}

--- a/src/lib/github-activity-alias-store.ts
+++ b/src/lib/github-activity-alias-store.ts
@@ -4,6 +4,8 @@ import type { getDatabase } from "@/db/client";
 import {
   githubCommits,
   githubPublicActivities,
+  githubPullRequestMemberships,
+  githubPullRequestVersions,
   githubSummaryAttempts,
 } from "@/db/schema";
 
@@ -18,20 +20,8 @@ type DatabaseTransaction = Parameters<
  */
 export const invalidateGitHubPullRequestDerivedAliases = async (
   transaction: DatabaseTransaction,
-  pullRequestNodeId: string,
-  repositoryIds: readonly (string | null | undefined)[]
+  pullRequestNodeId: string
 ) => {
-  const affectedRepositoryIds = [
-    ...new Set(
-      repositoryIds.filter(
-        (repositoryId): repositoryId is string =>
-          repositoryId !== null && repositoryId !== undefined
-      )
-    ),
-  ];
-  if (affectedRepositoryIds.length === 0) {
-    return 0;
-  }
   const resetActivities = await transaction
     .update(githubPublicActivities)
     .set({
@@ -44,7 +34,6 @@ export const invalidateGitHubPullRequestDerivedAliases = async (
     .where(
       and(
         eq(githubPublicActivities.kind, "commit"),
-        inArray(githubPublicActivities.repositoryId, affectedRepositoryIds),
         isNotNull(githubPublicActivities.canonicalPublicId),
         sql`${githubPublicActivities.aliasEvidence} ->> 'pullRequestNodeId' = ${pullRequestNodeId}`
       )
@@ -77,9 +66,27 @@ export const invalidateGitHubPullRequestDerivedAliases = async (
         )
       );
   }
-  await transaction
-    .update(githubCommits)
-    .set({ canonicalizedAt: null })
-    .where(inArray(githubCommits.repositoryId, affectedRepositoryIds));
+  if (resetActivities.length > 0) {
+    await transaction
+      .update(githubCommits)
+      .set({ canonicalizedAt: null })
+      .where(
+        inArray(
+          githubCommits.activityPublicId,
+          resetActivities.map(({ publicId }) => publicId)
+        )
+      );
+  }
+  await transaction.update(githubCommits).set({ canonicalizedAt: null })
+    .where(sql<boolean>`EXISTS (
+      SELECT 1
+      FROM ${githubPullRequestMemberships}
+      INNER JOIN ${githubPullRequestVersions}
+        ON ${githubPullRequestVersions.id} = ${githubPullRequestMemberships.versionId}
+      WHERE ${githubPullRequestVersions.pullRequestNodeId} = ${pullRequestNodeId}
+        AND ${githubPullRequestVersions.membershipComplete} = true
+        AND ${githubPullRequestMemberships.commitRepositoryId} = ${githubCommits.repositoryId}
+        AND ${githubPullRequestMemberships.commitSha} = ${githubCommits.sha}
+    )`);
   return resetActivities.length;
 };

--- a/src/lib/github-activity-audit.ts
+++ b/src/lib/github-activity-audit.ts
@@ -1,0 +1,1314 @@
+import {
+  and,
+  eq,
+  gte,
+  inArray,
+  isNotNull,
+  isNull,
+  lte,
+  sql,
+} from "drizzle-orm";
+
+import { getDatabase } from "@/db/client";
+import {
+  githubCommits,
+  githubIssues,
+  githubPublicActivities,
+  githubPullRequests,
+  githubPullRequestSignals,
+  githubPullRequestVersions,
+  githubPushObservations,
+  githubSummaryAttempts,
+} from "@/db/schema";
+import type { GitHubActivityCursor } from "@/lib/github-activity-cursor";
+import { readPublicGitHubActivityPage } from "@/lib/github-activity-store";
+import type {
+  PublicGitHubActivityDay,
+  PublicGitHubActivityItem,
+} from "@/lib/github-activity-types";
+import {
+  githubCommitInWorkerScope,
+  githubPullRequestInWorkerScope,
+  githubPullRequestSignalInWorkerScope,
+  githubPushObservationInWorkerScope,
+} from "@/lib/github-activity-worker-store";
+import {
+  repositoryIdFrom,
+  trackedGitHubAccountFrom,
+} from "@/lib/github-commits-core";
+import type { TrackedGitHubAccount } from "@/lib/github-commits-core";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+export const MAXIMUM_GITHUB_ACTIVITY_AUDIT_DAYS = 31;
+
+export interface GitHubActivityAuditRequest {
+  account: TrackedGitHubAccount;
+  endDate: string;
+  repositoryId: string | null;
+  sinceAt: Date;
+  snapshotAt: Date;
+  startDate: string;
+  untilAt: Date;
+}
+
+const utcDayFrom = (value: unknown) => {
+  if (typeof value !== "string" || !DATE_PATTERN.test(value)) {
+    return null;
+  }
+  const date = new Date(`${value}T00:00:00.000Z`);
+  return !Number.isNaN(date.getTime()) &&
+    date.toISOString().slice(0, 10) === value
+    ? date
+    : null;
+};
+
+export const githubActivityAuditRequestFrom = (
+  value: unknown,
+  now = new Date()
+): GitHubActivityAuditRequest | null => {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return null;
+  }
+  const input = value as Record<string, unknown>;
+  const account = trackedGitHubAccountFrom(input.account);
+  const rawRepositoryId =
+    typeof input.repositoryId === "string" ? input.repositoryId.trim() : "";
+  const repositoryId =
+    rawRepositoryId.length === 0 ? null : repositoryIdFrom(rawRepositoryId);
+  const sinceAt = utcDayFrom(input.startDate);
+  const endDay = utcDayFrom(input.endDate);
+  const today = new Date(
+    Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate())
+  );
+  if (
+    account === null ||
+    sinceAt === null ||
+    endDay === null ||
+    sinceAt > endDay ||
+    endDay > today ||
+    (rawRepositoryId.length > 0 && repositoryId === null)
+  ) {
+    return null;
+  }
+  const days = Math.floor((endDay.getTime() - sinceAt.getTime()) / DAY_MS) + 1;
+  if (days > MAXIMUM_GITHUB_ACTIVITY_AUDIT_DAYS) {
+    return null;
+  }
+  return {
+    account,
+    endDate: endDay.toISOString().slice(0, 10),
+    repositoryId,
+    sinceAt,
+    snapshotAt: new Date(now),
+    startDate: sinceAt.toISOString().slice(0, 10),
+    untilAt: new Date(endDay.getTime() + DAY_MS - 1),
+  };
+};
+
+export interface GitHubActivityProjectionCheck {
+  id: string;
+  ok: boolean;
+  violations: number;
+}
+
+interface FlattenedPublicItem {
+  additions: number;
+  deletions: number;
+  id: string;
+  issue: boolean;
+  repositoryKey: string;
+}
+
+const flattenedPublicItems = (
+  item: PublicGitHubActivityItem
+): readonly FlattenedPublicItem[] => {
+  if (item.kind === "commit") {
+    return [
+      {
+        additions: item.commit.additions,
+        deletions: item.commit.deletions,
+        id: item.commit.id,
+        issue: false,
+        repositoryKey: item.repository.key,
+      },
+    ];
+  }
+  if (item.kind === "pull-request-commits") {
+    return item.commits.map((commit) => ({
+      additions: commit.additions,
+      deletions: commit.deletions,
+      id: commit.id,
+      issue: false,
+      repositoryKey: item.repository.key,
+    }));
+  }
+  return [
+    {
+      additions: 0,
+      deletions: 0,
+      id: item.id,
+      issue: true,
+      repositoryKey: item.repository.key,
+    },
+  ];
+};
+
+export const auditPublicGitHubActivityDays = (
+  days: readonly PublicGitHubActivityDay[]
+): readonly GitHubActivityProjectionCheck[] => {
+  let additionTotalViolations = 0;
+  let deletionTotalViolations = 0;
+  let duplicateDayViolations = 0;
+  let duplicateSourceViolations = 0;
+  let issueTotalViolations = 0;
+  let mergeMilestoneViolations = 0;
+  let invalidKindViolations = 0;
+  let repositoryTotalViolations = 0;
+  const seenDays = new Set<string>();
+  const seenSources = new Set<string>();
+
+  for (const day of days) {
+    if (seenDays.has(day.day)) {
+      duplicateDayViolations += 1;
+    }
+    seenDays.add(day.day);
+    const flattened: FlattenedPublicItem[] = [];
+    for (const item of day.items) {
+      const { kind } = item as { kind?: unknown };
+      if (
+        kind === "pull_request" ||
+        kind === "pull-request" ||
+        kind === "pull-request-merged"
+      ) {
+        mergeMilestoneViolations += 1;
+        continue;
+      }
+      if (
+        kind !== "commit" &&
+        kind !== "pull-request-commits" &&
+        kind !== "issue-opened"
+      ) {
+        invalidKindViolations += 1;
+        continue;
+      }
+      flattened.push(...flattenedPublicItems(item));
+    }
+    for (const item of flattened) {
+      if (seenSources.has(item.id)) {
+        duplicateSourceViolations += 1;
+      }
+      seenSources.add(item.id);
+    }
+    const additions = flattened.reduce(
+      (total, item) => total + item.additions,
+      0
+    );
+    const deletions = flattened.reduce(
+      (total, item) => total + item.deletions,
+      0
+    );
+    const issues = flattened.filter((item) => item.issue).length;
+    const repositories = new Set(flattened.map((item) => item.repositoryKey))
+      .size;
+    additionTotalViolations += Number(additions !== day.totals.additions);
+    deletionTotalViolations += Number(deletions !== day.totals.deletions);
+    issueTotalViolations += Number(issues !== day.totals.issuesOpened);
+    repositoryTotalViolations += Number(
+      repositories !== day.totals.repositories
+    );
+  }
+
+  return [
+    {
+      id: "no_pull_request_merge_milestones",
+      ok: mergeMilestoneViolations === 0,
+      violations: mergeMilestoneViolations,
+    },
+    {
+      id: "allowed_activity_kinds",
+      ok: invalidKindViolations === 0,
+      violations: invalidKindViolations,
+    },
+    {
+      id: "unique_days",
+      ok: duplicateDayViolations === 0,
+      violations: duplicateDayViolations,
+    },
+    {
+      id: "unique_work_sources",
+      ok: duplicateSourceViolations === 0,
+      violations: duplicateSourceViolations,
+    },
+    {
+      id: "day_addition_totals",
+      ok: additionTotalViolations === 0,
+      violations: additionTotalViolations,
+    },
+    {
+      id: "day_deletion_totals",
+      ok: deletionTotalViolations === 0,
+      violations: deletionTotalViolations,
+    },
+    {
+      id: "day_issue_totals",
+      ok: issueTotalViolations === 0,
+      violations: issueTotalViolations,
+    },
+    {
+      id: "day_repository_totals",
+      ok: repositoryTotalViolations === 0,
+      violations: repositoryTotalViolations,
+    },
+  ];
+};
+
+interface StoredCommitAuditRow {
+  activityPublicId: string | null;
+  additions: number | null;
+  canonicalPublicId: string | null;
+  canonicalizedAt: Date | null;
+  changedFiles: number | null;
+  deletions: number | null;
+  enrichmentState: string;
+  enrichmentRetryAt?: Date | null;
+  hiddenAt: Date | null;
+  parentShas: readonly string[] | null;
+  publishedAt: Date | null;
+  pullRequestDiscoveryState: string;
+  pullRequestDiscoveryRetryAt?: Date | null;
+  substantiveLoc: number | null;
+  summaryAttemptExists?: boolean;
+  summaryComplete: boolean;
+  summaryUnavailable?: boolean;
+}
+
+interface StoredIssueAuditRow {
+  activityPublicId: string | null;
+  canonicalPublicId: string | null;
+  hiddenAt: Date | null;
+  publishedAt: Date | null;
+}
+
+export interface GitHubActivityAuditEvidence {
+  commits: readonly StoredCommitAuditRow[];
+  globalProjectionSourceIds: readonly string[];
+  issues: readonly StoredIssueAuditRow[];
+  legacyPullRequestMilestones: number;
+  pipelineEvidence?: GitHubActivityAuditPipelineEvidence;
+  projectionDays: readonly PublicGitHubActivityDay[];
+  projectionError: string | null;
+}
+
+export interface GitHubActivityAuditPipelineEvidence {
+  earliestRetryAt: Date | null;
+  pullRequestMembershipsPending: number;
+  pullRequestMembershipsUnavailable: number;
+  pullRequestReconciliationsPending: number;
+  pullRequestReconciliationsUnavailable: number;
+  pullRequestSignalsPending: number;
+  pullRequestSignalsUnavailable: number;
+  pushObservationsPending: number;
+  pushObservationsUnavailable: number;
+  summaryAttemptsPending: number;
+  summaryAttemptsUnavailable: number;
+}
+
+const emptyPipelineEvidence = (): GitHubActivityAuditPipelineEvidence => ({
+  earliestRetryAt: null,
+  pullRequestMembershipsPending: 0,
+  pullRequestMembershipsUnavailable: 0,
+  pullRequestReconciliationsPending: 0,
+  pullRequestReconciliationsUnavailable: 0,
+  pullRequestSignalsPending: 0,
+  pullRequestSignalsUnavailable: 0,
+  pushObservationsPending: 0,
+  pushObservationsUnavailable: 0,
+  summaryAttemptsPending: 0,
+  summaryAttemptsUnavailable: 0,
+});
+
+const publishedWithinSnapshot = (publishedAt: Date | null, snapshotAt: Date) =>
+  publishedAt !== null && publishedAt <= snapshotAt;
+
+const commitPassesCanonicalGate = (
+  commit: StoredCommitAuditRow,
+  snapshotAt: Date
+) =>
+  commit.activityPublicId !== null &&
+  publishedWithinSnapshot(commit.publishedAt, snapshotAt) &&
+  commit.hiddenAt === null &&
+  commit.canonicalPublicId === null &&
+  commit.canonicalizedAt !== null &&
+  commit.canonicalizedAt <= snapshotAt &&
+  commit.parentShas !== null &&
+  commit.parentShas.length <= 1;
+
+const issuePassesPublicGate = (issue: StoredIssueAuditRow, snapshotAt: Date) =>
+  issue.activityPublicId !== null &&
+  publishedWithinSnapshot(issue.publishedAt, snapshotAt) &&
+  issue.hiddenAt === null &&
+  issue.canonicalPublicId === null;
+
+const commitSourceComplete = (commit: StoredCommitAuditRow) =>
+  commit.additions !== null &&
+  commit.changedFiles !== null &&
+  commit.deletions !== null &&
+  commit.substantiveLoc !== null &&
+  commit.summaryComplete;
+
+const publicSourceIds = (days: readonly PublicGitHubActivityDay[]) =>
+  days.flatMap((day) =>
+    day.items.flatMap((item) => flattenedPublicItems(item).map(({ id }) => id))
+  );
+
+export const scopePublicGitHubActivityDays = (
+  days: readonly PublicGitHubActivityDay[],
+  sourceIds: ReadonlySet<string>
+) =>
+  days.flatMap((day) => {
+    const items: PublicGitHubActivityItem[] = [];
+    for (const item of day.items) {
+      if (item.kind === "commit") {
+        if (sourceIds.has(item.commit.id)) {
+          items.push(item);
+        }
+        continue;
+      }
+      if (item.kind === "pull-request-commits") {
+        const commits = item.commits.filter((commit) =>
+          sourceIds.has(commit.id)
+        );
+        if (commits.length > 0) {
+          items.push({ ...item, commits });
+        }
+        continue;
+      }
+      if (sourceIds.has(item.id)) {
+        items.push(item);
+      }
+    }
+    if (items.length === 0) {
+      return [];
+    }
+    const flattened = items.flatMap((item) => flattenedPublicItems(item));
+    return [
+      {
+        ...day,
+        items,
+        totals: {
+          additions: flattened.reduce(
+            (total, item) => total + item.additions,
+            0
+          ),
+          deletions: flattened.reduce(
+            (total, item) => total + item.deletions,
+            0
+          ),
+          issuesOpened: flattened.filter((item) => item.issue).length,
+          repositories: new Set(flattened.map((item) => item.repositoryKey))
+            .size,
+        },
+      },
+    ];
+  });
+
+const setDifferenceSize = (
+  left: ReadonlySet<string>,
+  right: ReadonlySet<string>
+) => [...left].filter((value) => !right.has(value)).length;
+
+export interface GitHubActivityAuditReport {
+  checks: readonly GitHubActivityProjectionCheck[];
+  coverage: {
+    evidence: "stored_postgresql_rows";
+    gaps: {
+      commitEnrichmentUnavailable: number;
+      pullRequestDiscoveryUnavailable: number;
+      pullRequestMembershipsUnavailable: number;
+      pullRequestReconciliationsUnavailable: number;
+      pullRequestSignalsUnavailable: number;
+      pushObservationsUnavailable: number;
+      summaryAttemptsUnavailable: number;
+      total: number;
+    };
+    providerCompleteness: "not_assessed";
+    statement: string;
+  };
+  inventory: {
+    commitsObserved: number;
+    issuesObserved: number;
+    legacyPullRequestMilestonesExcluded: number;
+  };
+  pipeline: {
+    aliasesExcluded: number;
+    canonicalizationPending: number;
+    earliestRetryAt: string | null;
+    enrichmentIncomplete: number;
+    integrationCommitsExcluded: number;
+    projectionReadyButUnpublished: number;
+    publishedButGated: number;
+    pullRequestDiscoveryIncomplete: number;
+    pullRequestMembershipsPending: number;
+    pullRequestReconciliationsPending: number;
+    pullRequestSignalsPending: number;
+    pushObservationsPending: number;
+    summaryIncomplete: number;
+    summaryAttemptsPending: number;
+    unsettledCommits: number;
+    unsettledIssues: number;
+  };
+  projection: {
+    days: number;
+    expectedActivitySources: number;
+    renderedActivitySources: number;
+  };
+  scope: {
+    account: TrackedGitHubAccount;
+    endDate: string;
+    repositoryId: string | null;
+    snapshotAt: string;
+    startDate: string;
+  };
+  status: GitHubActivityAuditStatus;
+  version: 1;
+}
+
+export type GitHubActivityAuditStatus =
+  | "inconclusive"
+  | "mismatch"
+  | "pipeline_incomplete"
+  | "stored_projection_verified";
+
+export const buildGitHubActivityAuditReport = (
+  request: GitHubActivityAuditRequest,
+  evidence: GitHubActivityAuditEvidence
+): GitHubActivityAuditReport => {
+  const { snapshotAt } = request;
+  const pipelineEvidence = evidence.pipelineEvidence ?? emptyPipelineEvidence();
+  const stableCommits = evidence.commits.filter((commit) =>
+    commitPassesCanonicalGate(commit, snapshotAt)
+  );
+  const expectedIds = new Set(evidence.globalProjectionSourceIds);
+  const renderedIds = new Set(publicSourceIds(evidence.projectionDays));
+  const sourceCompletenessViolations = stableCommits.filter(
+    (commit) => !commitSourceComplete(commit)
+  ).length;
+  const exactProjectionViolations =
+    setDifferenceSize(expectedIds, renderedIds) +
+    setDifferenceSize(renderedIds, expectedIds);
+  const canonicalGateViolations = evidence.commits.filter(
+    (commit) =>
+      commit.activityPublicId !== null &&
+      renderedIds.has(commit.activityPublicId) &&
+      !commitPassesCanonicalGate(commit, snapshotAt)
+  ).length;
+  const integrationCommitViolations = evidence.commits.filter(
+    (commit) =>
+      commit.activityPublicId !== null &&
+      renderedIds.has(commit.activityPublicId) &&
+      commit.parentShas !== null &&
+      commit.parentShas.length > 1
+  ).length;
+  const checks = [
+    {
+      id: "public_projection_readable",
+      ok: evidence.projectionError === null,
+      violations: evidence.projectionError === null ? 0 : 1,
+    },
+    ...auditPublicGitHubActivityDays(evidence.projectionDays),
+    {
+      id: "exact_stored_activity_sources",
+      ok: exactProjectionViolations === 0,
+      violations: exactProjectionViolations,
+    },
+    {
+      id: "canonical_commit_gate",
+      ok: canonicalGateViolations === 0,
+      violations: canonicalGateViolations,
+    },
+    {
+      id: "no_integration_commits",
+      ok: integrationCommitViolations === 0,
+      violations: integrationCommitViolations,
+    },
+    {
+      id: "complete_published_commit_sources",
+      ok: sourceCompletenessViolations === 0,
+      violations: sourceCompletenessViolations,
+    },
+  ] satisfies readonly GitHubActivityProjectionCheck[];
+  const projectionReadyButUnpublished = evidence.commits.filter(
+    (commit) =>
+      commit.activityPublicId !== null &&
+      commit.publishedAt === null &&
+      commit.hiddenAt === null &&
+      commit.canonicalPublicId === null &&
+      commit.canonicalizedAt !== null &&
+      commit.canonicalizedAt <= snapshotAt &&
+      commit.parentShas !== null &&
+      commit.parentShas.length <= 1 &&
+      commitSourceComplete(commit)
+  ).length;
+  const publishedButGated = evidence.commits.filter(
+    (commit) =>
+      publishedWithinSnapshot(commit.publishedAt, snapshotAt) &&
+      !commitPassesCanonicalGate(commit, snapshotAt)
+  ).length;
+  const unsettledCommits = evidence.commits.filter((commit) => {
+    if (commit.enrichmentState === "unavailable") {
+      return false;
+    }
+    if (commit.enrichmentState !== "complete" || commit.parentShas === null) {
+      return true;
+    }
+    if (
+      commit.parentShas.length > 1 ||
+      commit.canonicalPublicId !== null ||
+      commit.hiddenAt !== null
+    ) {
+      return false;
+    }
+    if (
+      commit.pullRequestDiscoveryState !== "complete" &&
+      commit.pullRequestDiscoveryState !== "unavailable"
+    ) {
+      return true;
+    }
+    if (commit.summaryUnavailable === true) {
+      return false;
+    }
+    return !(
+      commitPassesCanonicalGate(commit, snapshotAt) &&
+      commitSourceComplete(commit)
+    );
+  }).length;
+  const unsettledIssues = evidence.issues.filter(
+    (issue) =>
+      issue.canonicalPublicId === null &&
+      issue.hiddenAt === null &&
+      !issuePassesPublicGate(issue, snapshotAt)
+  ).length;
+  const retryableQueueItems =
+    pipelineEvidence.pullRequestMembershipsPending +
+    pipelineEvidence.pullRequestReconciliationsPending +
+    pipelineEvidence.pullRequestSignalsPending +
+    pipelineEvidence.pushObservationsPending +
+    pipelineEvidence.summaryAttemptsPending;
+  const gaps = {
+    commitEnrichmentUnavailable: evidence.commits.filter(
+      (commit) => commit.enrichmentState === "unavailable"
+    ).length,
+    pullRequestDiscoveryUnavailable: evidence.commits.filter(
+      (commit) => commit.pullRequestDiscoveryState === "unavailable"
+    ).length,
+    pullRequestMembershipsUnavailable:
+      pipelineEvidence.pullRequestMembershipsUnavailable,
+    pullRequestReconciliationsUnavailable:
+      pipelineEvidence.pullRequestReconciliationsUnavailable,
+    pullRequestSignalsUnavailable:
+      pipelineEvidence.pullRequestSignalsUnavailable,
+    pushObservationsUnavailable: pipelineEvidence.pushObservationsUnavailable,
+    summaryAttemptsUnavailable: pipelineEvidence.summaryAttemptsUnavailable,
+  };
+  const totalGaps =
+    gaps.commitEnrichmentUnavailable +
+    gaps.pullRequestDiscoveryUnavailable +
+    gaps.pullRequestMembershipsUnavailable +
+    gaps.pullRequestReconciliationsUnavailable +
+    gaps.pullRequestSignalsUnavailable +
+    gaps.pushObservationsUnavailable +
+    gaps.summaryAttemptsUnavailable;
+  const projectionMatches = checks.every((check) => check.ok);
+  let status: GitHubActivityAuditStatus = "inconclusive";
+  if (evidence.projectionError === null) {
+    status = "mismatch";
+    if (projectionMatches) {
+      status =
+        unsettledCommits + unsettledIssues + retryableQueueItems === 0
+          ? "stored_projection_verified"
+          : "pipeline_incomplete";
+    }
+  }
+
+  return {
+    checks,
+    coverage: {
+      evidence: "stored_postgresql_rows",
+      gaps: { ...gaps, total: totalGaps },
+      providerCompleteness: "not_assessed",
+      statement:
+        request.repositoryId === null
+          ? "Provider completeness is not assessed. The projection comparison is global while pipeline inventory is scoped to the requested account. This audit only verifies evidence already stored in PostgreSQL; deleted or rewritten refs and events never observed by this system can be absent."
+          : "Provider completeness is not assessed. Projection and pipeline evidence are scoped to the requested account, repository, and window. This audit only verifies evidence already stored in PostgreSQL; deleted or rewritten refs and events never observed by this system can be absent.",
+    },
+    inventory: {
+      commitsObserved: evidence.commits.length,
+      issuesObserved: evidence.issues.length,
+      legacyPullRequestMilestonesExcluded: evidence.legacyPullRequestMilestones,
+    },
+    pipeline: {
+      aliasesExcluded: evidence.commits.filter(
+        (commit) => commit.canonicalPublicId !== null
+      ).length,
+      canonicalizationPending: evidence.commits.filter(
+        (commit) =>
+          commit.canonicalizedAt === null &&
+          commit.canonicalPublicId === null &&
+          commit.hiddenAt === null &&
+          commit.parentShas !== null &&
+          commit.parentShas.length <= 1
+      ).length,
+      earliestRetryAt: pipelineEvidence.earliestRetryAt?.toISOString() ?? null,
+      enrichmentIncomplete: evidence.commits.filter(
+        (commit) =>
+          commit.enrichmentState === "pending" ||
+          commit.enrichmentState === "processing"
+      ).length,
+      integrationCommitsExcluded: evidence.commits.filter(
+        (commit) => commit.parentShas !== null && commit.parentShas.length > 1
+      ).length,
+      projectionReadyButUnpublished,
+      publishedButGated,
+      pullRequestDiscoveryIncomplete: evidence.commits.filter(
+        (commit) =>
+          commit.pullRequestDiscoveryState === "pending" ||
+          commit.pullRequestDiscoveryState === "processing"
+      ).length,
+      pullRequestMembershipsPending:
+        pipelineEvidence.pullRequestMembershipsPending,
+      pullRequestReconciliationsPending:
+        pipelineEvidence.pullRequestReconciliationsPending,
+      pullRequestSignalsPending: pipelineEvidence.pullRequestSignalsPending,
+      pushObservationsPending: pipelineEvidence.pushObservationsPending,
+      summaryIncomplete: evidence.commits.filter(
+        (commit) =>
+          !commit.summaryComplete && commit.summaryUnavailable !== true
+      ).length,
+      summaryAttemptsPending: pipelineEvidence.summaryAttemptsPending,
+      unsettledCommits,
+      unsettledIssues,
+    },
+    projection: {
+      days: evidence.projectionDays.length,
+      expectedActivitySources: expectedIds.size,
+      renderedActivitySources: renderedIds.size,
+    },
+    scope: {
+      account: request.account,
+      endDate: request.endDate,
+      repositoryId: request.repositoryId,
+      snapshotAt: snapshotAt.toISOString(),
+      startDate: request.startDate,
+    },
+    status,
+    version: 1,
+  };
+};
+
+const commitActivityIdentity = and(
+  eq(githubPublicActivities.kind, "commit"),
+  eq(githubPublicActivities.repositoryId, githubCommits.repositoryId),
+  eq(githubPublicActivities.sourceNodeId, githubCommits.sha)
+);
+
+const issueActivityIdentity = and(
+  eq(githubPublicActivities.kind, "issue"),
+  eq(githubPublicActivities.repositoryId, githubIssues.repositoryId),
+  eq(githubPublicActivities.sourceNodeId, githubIssues.nodeId)
+);
+
+interface AuditRetryRow {
+  retryAt: Date | null;
+  state: string;
+}
+
+interface AuditPullRequestPipelineRow {
+  lastReconciledAt: Date | null;
+  membershipComplete: boolean | null;
+  nextReconcileAt: Date | null;
+  reconcileError: string | null;
+  versionObservedAt: Date | null;
+}
+
+const commitHasRetryablePullRequestDiscovery = (commit: StoredCommitAuditRow) =>
+  commit.enrichmentState === "complete" &&
+  (commit.parentShas === null || commit.parentShas.length <= 1) &&
+  (commit.pullRequestDiscoveryState === "pending" ||
+    commit.pullRequestDiscoveryState === "processing");
+
+const commitNeedsImmediatePipelineWork = (commit: StoredCommitAuditRow) =>
+  commit.enrichmentState === "complete" &&
+  commit.parentShas !== null &&
+  commit.parentShas.length <= 1 &&
+  commit.canonicalPublicId === null &&
+  commit.hiddenAt === null &&
+  (commit.pullRequestDiscoveryState === "complete" ||
+    commit.pullRequestDiscoveryState === "unavailable") &&
+  (commit.canonicalizedAt === null ||
+    (!commit.summaryComplete &&
+      commit.summaryUnavailable !== true &&
+      commit.summaryAttemptExists !== true));
+
+const commitRetryDatesFrom = (
+  commits: readonly StoredCommitAuditRow[],
+  snapshotAt: Date
+) => {
+  const retryDates: Date[] = [];
+  for (const commit of commits) {
+    if (
+      commit.enrichmentState === "pending" ||
+      commit.enrichmentState === "processing"
+    ) {
+      retryDates.push(commit.enrichmentRetryAt ?? snapshotAt);
+      continue;
+    }
+    if (commitHasRetryablePullRequestDiscovery(commit)) {
+      retryDates.push(commit.pullRequestDiscoveryRetryAt ?? snapshotAt);
+      continue;
+    }
+    if (commitNeedsImmediatePipelineWork(commit)) {
+      retryDates.push(snapshotAt);
+    }
+  }
+  return retryDates;
+};
+
+const retryQueueEvidenceFrom = (
+  rows: readonly AuditRetryRow[],
+  snapshotAt: Date
+) => {
+  const pending = rows.filter(({ state }) =>
+    ["pending", "processing", "deferred"].includes(state)
+  );
+  return {
+    pending: pending.length,
+    retryDates: pending.map(({ retryAt }) => retryAt ?? snapshotAt),
+    unavailable: rows.length - pending.length,
+  };
+};
+
+const pullRequestPipelineEvidenceFrom = (
+  rows: readonly AuditPullRequestPipelineRow[],
+  snapshotAt: Date
+) => {
+  let pullRequestMembershipsPending = 0;
+  let pullRequestMembershipsUnavailable = 0;
+  let pullRequestReconciliationsPending = 0;
+  let pullRequestReconciliationsUnavailable = 0;
+  const retryDates: Date[] = [];
+  for (const pullRequest of rows) {
+    const membershipIncomplete = pullRequest.membershipComplete !== true;
+    if (membershipIncomplete) {
+      if (pullRequest.nextReconcileAt === null) {
+        pullRequestMembershipsUnavailable += 1;
+      } else {
+        pullRequestMembershipsPending += 1;
+      }
+    }
+    const observedAfterReconciliation =
+      pullRequest.versionObservedAt !== null &&
+      (pullRequest.lastReconciledAt === null ||
+        pullRequest.versionObservedAt > pullRequest.lastReconciledAt);
+    const reconciliationPending =
+      pullRequest.nextReconcileAt !== null &&
+      (pullRequest.reconcileError !== null ||
+        pullRequest.nextReconcileAt <= snapshotAt ||
+        membershipIncomplete ||
+        observedAfterReconciliation);
+    if (reconciliationPending) {
+      pullRequestReconciliationsPending += 1;
+      retryDates.push(pullRequest.nextReconcileAt ?? snapshotAt);
+    } else if (
+      pullRequest.nextReconcileAt === null &&
+      pullRequest.reconcileError !== null
+    ) {
+      pullRequestReconciliationsUnavailable += 1;
+    }
+  }
+  return {
+    pullRequestMembershipsPending,
+    pullRequestMembershipsUnavailable,
+    pullRequestReconciliationsPending,
+    pullRequestReconciliationsUnavailable,
+    retryDates,
+  };
+};
+
+const earliestDateFrom = (dates: readonly Date[]) => {
+  let earliest: Date | null = null;
+  for (const date of dates) {
+    if (earliest === null || date < earliest) {
+      earliest = date;
+    }
+  }
+  return earliest;
+};
+
+const pipelineEvidenceFrom = (
+  commits: readonly StoredCommitAuditRow[],
+  pushObservationRows: readonly AuditRetryRow[],
+  pullRequestSignalRows: readonly AuditRetryRow[],
+  pullRequestRows: readonly AuditPullRequestPipelineRow[],
+  summaryAttemptRows: readonly AuditRetryRow[],
+  snapshotAt: Date
+): GitHubActivityAuditPipelineEvidence => {
+  const pushObservations = retryQueueEvidenceFrom(
+    pushObservationRows,
+    snapshotAt
+  );
+  const pullRequestSignals = retryQueueEvidenceFrom(
+    pullRequestSignalRows,
+    snapshotAt
+  );
+  const pullRequests = pullRequestPipelineEvidenceFrom(
+    pullRequestRows,
+    snapshotAt
+  );
+  const summaryAttempts = retryQueueEvidenceFrom(
+    summaryAttemptRows,
+    snapshotAt
+  );
+  return {
+    earliestRetryAt: earliestDateFrom([
+      ...commitRetryDatesFrom(commits, snapshotAt),
+      ...pushObservations.retryDates,
+      ...pullRequestSignals.retryDates,
+      ...pullRequests.retryDates,
+      ...summaryAttempts.retryDates,
+    ]),
+    pullRequestMembershipsPending: pullRequests.pullRequestMembershipsPending,
+    pullRequestMembershipsUnavailable:
+      pullRequests.pullRequestMembershipsUnavailable,
+    pullRequestReconciliationsPending:
+      pullRequests.pullRequestReconciliationsPending,
+    pullRequestReconciliationsUnavailable:
+      pullRequests.pullRequestReconciliationsUnavailable,
+    pullRequestSignalsPending: pullRequestSignals.pending,
+    pullRequestSignalsUnavailable: pullRequestSignals.unavailable,
+    pushObservationsPending: pushObservations.pending,
+    pushObservationsUnavailable: pushObservations.unavailable,
+    summaryAttemptsPending: summaryAttempts.pending,
+    summaryAttemptsUnavailable: summaryAttempts.unavailable,
+  };
+};
+
+const readStoredEvidence = async (
+  request: GitHubActivityAuditRequest
+): Promise<
+  Omit<GitHubActivityAuditEvidence, "projectionDays" | "projectionError">
+> => {
+  const database = getDatabase();
+  const summaryComplete = sql<boolean>`exists (
+    select 1
+    from ${githubSummaryAttempts}
+    where ${githubSummaryAttempts.activityPublicId} = ${githubPublicActivities.publicId}
+      and ${githubSummaryAttempts.revision} <= ${githubPublicActivities.revision}
+      and ${githubSummaryAttempts.state} = 'complete'
+      and ${githubSummaryAttempts.summaryHeadline} is not null
+      and ${githubSummaryAttempts.summaryShort} is not null
+  )`;
+  const summaryAttemptExists = sql<boolean>`exists (
+    select 1
+    from ${githubSummaryAttempts}
+    where ${githubSummaryAttempts.activityPublicId} = ${githubPublicActivities.publicId}
+      and ${githubSummaryAttempts.revision} = ${githubPublicActivities.revision}
+  )`;
+  const summaryUnavailable = sql<boolean>`exists (
+    select 1
+    from ${githubSummaryAttempts}
+    where ${githubSummaryAttempts.activityPublicId} = ${githubPublicActivities.publicId}
+      and ${githubSummaryAttempts.revision} = ${githubPublicActivities.revision}
+      and ${githubSummaryAttempts.state} in ('failed', 'indeterminate')
+  )`;
+  const workerScope = {
+    repositoryId: request.repositoryId,
+    sinceAt: request.sinceAt,
+    untilAt: request.untilAt,
+  };
+  const issueRepositoryScope =
+    request.repositoryId === null
+      ? undefined
+      : eq(githubIssues.repositoryId, request.repositoryId);
+  const activityRepositoryScope =
+    request.repositoryId === null
+      ? undefined
+      : eq(githubPublicActivities.repositoryId, request.repositoryId);
+  const stableGlobalProjectionActivity = and(
+    inArray(githubPublicActivities.kind, ["commit", "issue"]),
+    isNotNull(githubPublicActivities.publishedAt),
+    lte(githubPublicActivities.publishedAt, request.snapshotAt),
+    isNull(githubPublicActivities.hiddenAt),
+    isNull(githubPublicActivities.canonicalPublicId),
+    gte(githubPublicActivities.occurredAt, request.sinceAt),
+    lte(githubPublicActivities.occurredAt, request.untilAt),
+    sql<boolean>`(
+      ${githubPublicActivities.kind} <> 'commit'
+      OR EXISTS (
+        SELECT 1
+        FROM ${githubCommits}
+        WHERE ${githubCommits.activityPublicId} = ${githubPublicActivities.publicId}
+          AND ${githubCommits.repositoryId} = ${githubPublicActivities.repositoryId}
+          AND ${githubCommits.sha} = ${githubPublicActivities.sourceNodeId}
+          AND ${githubCommits.canonicalizedAt} IS NOT NULL
+          AND ${githubCommits.canonicalizedAt} <= ${request.snapshotAt.toISOString()}::timestamptz
+          AND ${githubCommits.parentShas} IS NOT NULL
+          AND jsonb_array_length(${githubCommits.parentShas}) <= 1
+      )
+    )`
+  );
+  const [
+    commits,
+    issues,
+    legacyPullRequestRows,
+    globalProjectionRows,
+    pushObservationRows,
+    pullRequestSignalRows,
+    pullRequestRows,
+    summaryAttemptRows,
+  ] = await Promise.all([
+    database
+      .select({
+        activityPublicId: githubPublicActivities.publicId,
+        additions: githubCommits.additions,
+        canonicalPublicId: githubPublicActivities.canonicalPublicId,
+        canonicalizedAt: githubCommits.canonicalizedAt,
+        changedFiles: githubCommits.changedFiles,
+        deletions: githubCommits.deletions,
+        enrichmentState: githubCommits.enrichmentState,
+        enrichmentRetryAt: githubCommits.enrichmentLeaseUntil,
+        hiddenAt: githubPublicActivities.hiddenAt,
+        parentShas: githubCommits.parentShas,
+        publishedAt: githubPublicActivities.publishedAt,
+        pullRequestDiscoveryState: githubCommits.pullRequestDiscoveryState,
+        pullRequestDiscoveryRetryAt:
+          githubCommits.pullRequestDiscoveryLeaseUntil,
+        substantiveLoc: githubCommits.substantiveLoc,
+        summaryAttemptExists,
+        summaryComplete,
+        summaryUnavailable,
+      })
+      .from(githubCommits)
+      .leftJoin(githubPublicActivities, commitActivityIdentity)
+      .where(
+        and(
+          eq(githubCommits.author, request.account),
+          githubCommitInWorkerScope(workerScope)
+        )
+      ),
+    database
+      .select({
+        activityPublicId: githubPublicActivities.publicId,
+        canonicalPublicId: githubPublicActivities.canonicalPublicId,
+        hiddenAt: githubPublicActivities.hiddenAt,
+        publishedAt: githubPublicActivities.publishedAt,
+      })
+      .from(githubIssues)
+      .leftJoin(githubPublicActivities, issueActivityIdentity)
+      .where(
+        and(
+          eq(githubIssues.account, request.account),
+          issueRepositoryScope,
+          gte(githubIssues.createdAt, request.sinceAt),
+          lte(githubIssues.createdAt, request.untilAt)
+        )
+      ),
+    database
+      .select({ publicId: githubPublicActivities.publicId })
+      .from(githubPublicActivities)
+      .innerJoin(
+        githubPullRequests,
+        and(
+          eq(githubPublicActivities.kind, "pull_request"),
+          eq(
+            githubPublicActivities.repositoryId,
+            githubPullRequests.repositoryId
+          ),
+          eq(githubPublicActivities.sourceNodeId, githubPullRequests.nodeId)
+        )
+      )
+      .where(
+        and(
+          eq(githubPullRequests.account, request.account),
+          activityRepositoryScope,
+          gte(githubPublicActivities.occurredAt, request.sinceAt),
+          lte(githubPublicActivities.occurredAt, request.untilAt),
+          lte(githubPublicActivities.publishedAt, request.snapshotAt),
+          isNull(githubPublicActivities.hiddenAt),
+          isNull(githubPublicActivities.canonicalPublicId)
+        )
+      ),
+    request.repositoryId === null
+      ? database
+          .select({ publicId: githubPublicActivities.publicId })
+          .from(githubPublicActivities)
+          .where(stableGlobalProjectionActivity)
+      : Promise.resolve([]),
+    database
+      .select({
+        retryAt: githubPushObservations.leaseUntil,
+        state: githubPushObservations.state,
+      })
+      .from(githubPushObservations)
+      .where(
+        and(
+          eq(githubPushObservations.account, request.account),
+          githubPushObservationInWorkerScope(workerScope),
+          inArray(githubPushObservations.state, [
+            "pending",
+            "processing",
+            "deferred",
+            "unavailable",
+          ])
+        )
+      ),
+    database
+      .select({
+        retryAt: githubPullRequestSignals.leaseUntil,
+        state: githubPullRequestSignals.state,
+      })
+      .from(githubPullRequestSignals)
+      .where(
+        and(
+          eq(githubPullRequestSignals.account, request.account),
+          githubPullRequestSignalInWorkerScope(workerScope),
+          inArray(githubPullRequestSignals.state, [
+            "pending",
+            "processing",
+            "unavailable",
+          ])
+        )
+      ),
+    database
+      .select({
+        lastReconciledAt: githubPullRequests.lastReconciledAt,
+        membershipComplete: githubPullRequestVersions.membershipComplete,
+        nextReconcileAt: githubPullRequests.nextReconcileAt,
+        reconcileError: githubPullRequests.reconcileError,
+        versionObservedAt: githubPullRequestVersions.observedAt,
+      })
+      .from(githubPullRequests)
+      .leftJoin(
+        githubPullRequestVersions,
+        and(
+          eq(
+            githubPullRequestVersions.pullRequestNodeId,
+            githubPullRequests.nodeId
+          ),
+          eq(githubPullRequestVersions.isCurrent, true)
+        )
+      )
+      .where(
+        and(
+          eq(githubPullRequests.account, request.account),
+          githubPullRequestInWorkerScope(workerScope)
+        )
+      ),
+    database
+      .select({
+        retryAt: githubSummaryAttempts.leaseUntil,
+        state: githubSummaryAttempts.state,
+      })
+      .from(githubSummaryAttempts)
+      .innerJoin(
+        githubPublicActivities,
+        and(
+          eq(
+            githubPublicActivities.publicId,
+            githubSummaryAttempts.activityPublicId
+          ),
+          eq(githubPublicActivities.revision, githubSummaryAttempts.revision)
+        )
+      )
+      .innerJoin(githubCommits, commitActivityIdentity)
+      .where(
+        and(
+          eq(githubCommits.author, request.account),
+          githubCommitInWorkerScope(workerScope),
+          inArray(githubSummaryAttempts.state, [
+            "pending",
+            "processing",
+            "failed",
+            "indeterminate",
+          ]),
+          eq(githubPublicActivities.kind, "commit"),
+          isNull(githubPublicActivities.canonicalPublicId),
+          isNull(githubPublicActivities.hiddenAt),
+          eq(githubCommits.enrichmentState, "complete"),
+          isNotNull(githubCommits.canonicalizedAt),
+          sql<boolean>`${githubCommits.parentShas} IS NOT NULL
+              AND jsonb_array_length(${githubCommits.parentShas}) <= 1`
+        )
+      ),
+  ]);
+  const scopedProjectionSourceIds = [
+    ...commits
+      .filter((commit) => commitPassesCanonicalGate(commit, request.snapshotAt))
+      .map((commit) => commit.activityPublicId),
+    ...issues
+      .filter((issue) => issuePassesPublicGate(issue, request.snapshotAt))
+      .map((issue) => issue.activityPublicId),
+  ].filter((publicId): publicId is string => publicId !== null);
+  const pipelineEvidence = pipelineEvidenceFrom(
+    commits,
+    pushObservationRows,
+    pullRequestSignalRows,
+    pullRequestRows,
+    summaryAttemptRows,
+    request.snapshotAt
+  );
+  return {
+    commits,
+    globalProjectionSourceIds:
+      request.repositoryId === null
+        ? globalProjectionRows.map(({ publicId }) => publicId)
+        : scopedProjectionSourceIds,
+    issues,
+    legacyPullRequestMilestones: legacyPullRequestRows.length,
+    pipelineEvidence,
+  };
+};
+
+const readProjectionDays = async (
+  request: GitHubActivityAuditRequest,
+  sourceIds: ReadonlySet<string> | null
+) => {
+  const snapshotAt = request.snapshotAt.toISOString();
+  let beforeDay = new Date(request.untilAt.getTime() + 1)
+    .toISOString()
+    .slice(0, 10);
+  const days = new Map<string, PublicGitHubActivityDay>();
+  const maximumPages = Math.ceil(MAXIMUM_GITHUB_ACTIVITY_AUDIT_DAYS / 14) + 1;
+  for (let pageNumber = 0; pageNumber < maximumPages; pageNumber += 1) {
+    const cursor: GitHubActivityCursor = {
+      beforeDay,
+      snapshotAt,
+      version: 1,
+    };
+    const page = await readPublicGitHubActivityPage(cursor, 14);
+    if (page.days.length === 0) {
+      break;
+    }
+    for (const day of page.days) {
+      if (day.day >= request.startDate && day.day <= request.endDate) {
+        days.set(day.day, day);
+      }
+    }
+    const oldestDay = page.days.at(-1)?.day;
+    if (oldestDay === undefined || oldestDay <= request.startDate) {
+      break;
+    }
+    beforeDay = oldestDay;
+  }
+  const projectionDays = [...days.values()].toSorted((left, right) =>
+    right.day.localeCompare(left.day)
+  );
+  return sourceIds === null
+    ? projectionDays
+    : scopePublicGitHubActivityDays(projectionDays, sourceIds);
+};
+
+type StoredGitHubActivityAuditEvidence = Omit<
+  GitHubActivityAuditEvidence,
+  "projectionDays" | "projectionError"
+>;
+
+const scopedProjectionSourceIds = (
+  evidence: StoredGitHubActivityAuditEvidence
+) =>
+  new Set(
+    [...evidence.commits, ...evidence.issues]
+      .map(({ activityPublicId }) => activityPublicId)
+      .filter((publicId): publicId is string => publicId !== null)
+  );
+
+const serializedDate = (value: Date | null) => value?.toISOString() ?? null;
+
+export const githubActivityAuditEvidenceFingerprint = (
+  evidence: StoredGitHubActivityAuditEvidence
+) =>
+  JSON.stringify({
+    commits: evidence.commits
+      .map((commit) =>
+        JSON.stringify({
+          activityPublicId: commit.activityPublicId,
+          additions: commit.additions,
+          canonicalPublicId: commit.canonicalPublicId,
+          canonicalizedAt: serializedDate(commit.canonicalizedAt),
+          changedFiles: commit.changedFiles,
+          deletions: commit.deletions,
+          enrichmentState: commit.enrichmentState,
+          enrichmentRetryAt: serializedDate(commit.enrichmentRetryAt ?? null),
+          hiddenAt: serializedDate(commit.hiddenAt),
+          parentShas: commit.parentShas,
+          publishedAt: serializedDate(commit.publishedAt),
+          pullRequestDiscoveryState: commit.pullRequestDiscoveryState,
+          pullRequestDiscoveryRetryAt: serializedDate(
+            commit.pullRequestDiscoveryRetryAt ?? null
+          ),
+          substantiveLoc: commit.substantiveLoc,
+          summaryAttemptExists: commit.summaryAttemptExists ?? false,
+          summaryComplete: commit.summaryComplete,
+          summaryUnavailable: commit.summaryUnavailable ?? false,
+        })
+      )
+      .toSorted(),
+    issues: evidence.issues
+      .map((issue) =>
+        JSON.stringify({
+          activityPublicId: issue.activityPublicId,
+          canonicalPublicId: issue.canonicalPublicId,
+          hiddenAt: serializedDate(issue.hiddenAt),
+          publishedAt: serializedDate(issue.publishedAt),
+        })
+      )
+      .toSorted(),
+    globalProjectionSourceIds: evidence.globalProjectionSourceIds.toSorted(),
+    legacyPullRequestMilestones: evidence.legacyPullRequestMilestones,
+    pipelineEvidence: {
+      ...(evidence.pipelineEvidence ?? emptyPipelineEvidence()),
+      earliestRetryAt: serializedDate(
+        evidence.pipelineEvidence?.earliestRetryAt ?? null
+      ),
+    },
+  });
+
+export const runGitHubActivityAudit = async (
+  request: GitHubActivityAuditRequest
+): Promise<GitHubActivityAuditReport> => {
+  let lastStored = await readStoredEvidence(request);
+  let lastProjectionDays: readonly PublicGitHubActivityDay[] = [];
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    const before = lastStored;
+    try {
+      lastProjectionDays = await readProjectionDays(
+        request,
+        request.repositoryId === null ? null : scopedProjectionSourceIds(before)
+      );
+    } catch (error) {
+      return buildGitHubActivityAuditReport(request, {
+        ...before,
+        projectionDays: [],
+        projectionError:
+          error instanceof Error ? error.name : "UnknownProjectionError",
+      });
+    }
+    const after = await readStoredEvidence(request);
+    lastStored = after;
+    if (
+      githubActivityAuditEvidenceFingerprint(before) ===
+      githubActivityAuditEvidenceFingerprint(after)
+    ) {
+      return buildGitHubActivityAuditReport(request, {
+        ...after,
+        projectionDays: lastProjectionDays,
+        projectionError: null,
+      });
+    }
+  }
+  return buildGitHubActivityAuditReport(request, {
+    ...lastStored,
+    projectionDays: lastProjectionDays,
+    projectionError: "ConcurrentStoredEvidenceChange",
+  });
+};

--- a/src/lib/github-activity-feed.ts
+++ b/src/lib/github-activity-feed.ts
@@ -16,12 +16,12 @@ const emptyPage = (): PublicGitHubActivityPage => ({
 });
 
 const readCachedActivity = unstable_cache(
-  async (cursor: GitHubActivityCursor | null) =>
+  async (cursor: GitHubActivityCursor) =>
     await readPublicGitHubActivityPage(
       cursor,
       PUBLIC_GITHUB_ACTIVITY_DAY_PAGE_SIZE
     ),
-  ["public-github-activity-v12"],
+  ["public-github-activity-v13"],
   { revalidate: 900, tags: ["github-activity"] }
 );
 
@@ -29,7 +29,10 @@ export const getInitialGitHubActivity = async () => {
   if (!isDatabaseConfigured()) {
     return emptyPage();
   }
-  return await readCachedActivity(null);
+  return await readPublicGitHubActivityPage(
+    null,
+    PUBLIC_GITHUB_ACTIVITY_DAY_PAGE_SIZE
+  );
 };
 
 export const getGitHubActivityPage = async (cursor: GitHubActivityCursor) => {

--- a/src/lib/github-activity-store.ts
+++ b/src/lib/github-activity-store.ts
@@ -208,13 +208,6 @@ interface PullRequestAssociation {
   url: string;
 }
 
-interface PullRequestProjection {
-  mergedAt: Date | null;
-  nodeId: string;
-  repositoryId: string;
-  state: string;
-}
-
 interface IssueProjection {
   nodeId: string;
   repositoryId: string;
@@ -240,8 +233,6 @@ interface DayAccumulator {
   issuesOpened: number;
   items: PublicGitHubActivityItem[];
   pullRequestGroups: Map<string, PullRequestGroup>;
-  pullRequestsMerged: number;
-  repositories: Set<string>;
 }
 
 const emptyDay = (): DayAccumulator => ({
@@ -250,8 +241,6 @@ const emptyDay = (): DayAccumulator => ({
   issuesOpened: 0,
   items: [],
   pullRequestGroups: new Map(),
-  pullRequestsMerged: 0,
-  repositories: new Set(),
 });
 
 const orderedItems = (items: readonly PublicGitHubActivityItem[]) =>
@@ -260,10 +249,10 @@ const orderedItems = (items: readonly PublicGitHubActivityItem[]) =>
     return byTime === 0 ? right.id.localeCompare(left.id) : byTime;
   });
 
-type PublicActivityKind = "commit" | "issue" | "pull_request";
+type PublicActivityKind = "commit" | "issue";
 
 const isPublicActivityKind = (value: unknown): value is PublicActivityKind =>
-  value === "commit" || value === "issue" || value === "pull_request";
+  value === "commit" || value === "issue";
 
 interface CheckedActivityRow {
   kind: PublicActivityKind;
@@ -274,7 +263,9 @@ interface CheckedActivityRow {
   sourceNodeId: string;
 }
 
-type GitHubActivityDatabase = ReturnType<typeof getDatabase>;
+type GitHubActivityDatabase = Parameters<
+  Parameters<ReturnType<typeof getDatabase>["transaction"]>[0]
+>[0];
 
 const readCheckedActivityRows = async (
   database: GitHubActivityDatabase,
@@ -327,7 +318,6 @@ interface ActivityProjectionSources {
   commits: ReadonlyMap<string, CommitProjection>;
   issues: ReadonlyMap<string, IssueProjection>;
   primaryAssociations: ReadonlyMap<string, PullRequestAssociation>;
-  pullRequests: ReadonlyMap<string, PullRequestProjection>;
   repositories: ReadonlyMap<string, RepositoryProjection>;
   summaries: ReadonlyMap<string, CommitSummaryProjection>;
 }
@@ -353,7 +343,6 @@ const addCommitActivity = (
   );
   const association = sources.primaryAssociations.get(key);
   if (association === undefined) {
-    accumulator.repositories.add(activity.repositoryId);
     accumulator.items.push({
       commit: projected,
       id: activity.publicId,
@@ -366,7 +355,6 @@ const addCommitActivity = (
     });
     return;
   }
-  accumulator.repositories.add(association.repositoryId);
   const existing = accumulator.pullRequestGroups.get(association.nodeId);
   if (existing === undefined) {
     accumulator.pullRequestGroups.set(association.nodeId, {
@@ -388,23 +376,6 @@ const addCommitActivity = (
   }
 };
 
-const addPullRequestTotal = (
-  accumulator: DayAccumulator,
-  activity: CheckedActivityRow,
-  sources: ActivityProjectionSources
-) => {
-  const pullRequest = sources.pullRequests.get(activity.sourceNodeId);
-  if (
-    pullRequest === undefined ||
-    pullRequest.state !== "merged" ||
-    pullRequest.mergedAt === null
-  ) {
-    throw new Error("A published pull-request milestone is incomplete.");
-  }
-  accumulator.pullRequestsMerged += 1;
-  accumulator.repositories.add(pullRequest.repositoryId);
-};
-
 const addIssueActivity = (
   accumulator: DayAccumulator,
   activity: CheckedActivityRow,
@@ -415,7 +386,6 @@ const addIssueActivity = (
     throw new Error("A published issue milestone is incomplete.");
   }
   accumulator.issuesOpened += 1;
-  accumulator.repositories.add(issue.repositoryId);
   accumulator.items.push({
     id: activity.publicId,
     kind: "issue-opened",
@@ -443,8 +413,6 @@ const buildPublicActivityDays = (
     }
     if (activity.kind === "commit") {
       addCommitActivity(accumulator, activity, sources);
-    } else if (activity.kind === "pull_request") {
-      addPullRequestTotal(accumulator, activity, sources);
     } else {
       addIssueActivity(accumulator, activity, sources);
     }
@@ -476,15 +444,15 @@ const buildPublicActivityDays = (
         title: group.title,
       });
     }
+    const items = orderedItems(accumulator.items);
     return {
       day,
-      items: orderedItems(accumulator.items),
+      items,
       totals: {
         additions: accumulator.additions,
         deletions: accumulator.deletions,
         issuesOpened: accumulator.issuesOpened,
-        pullRequestsMerged: accumulator.pullRequestsMerged,
-        repositories: accumulator.repositories.size,
+        repositories: new Set(items.map((item) => item.repository.key)).size,
       },
     };
   });
@@ -493,7 +461,6 @@ const buildPublicActivityDays = (
 interface ActivitySourceIds {
   commitActivityPublicIds: readonly string[];
   issueNodeIds: readonly string[];
-  pullRequestNodeIds: readonly string[];
 }
 
 const readActivitySourceRows = async (
@@ -538,17 +505,6 @@ const readActivitySourceRows = async (
               ids.commitActivityPublicIds
             )
           ),
-    ids.pullRequestNodeIds.length === 0
-      ? Promise.resolve([])
-      : database
-          .select({
-            mergedAt: githubPullRequests.mergedAt,
-            nodeId: githubPullRequests.nodeId,
-            repositoryId: githubPullRequests.repositoryId,
-            state: githubPullRequests.state,
-          })
-          .from(githubPullRequests)
-          .where(inArray(githubPullRequests.nodeId, ids.pullRequestNodeIds)),
     ids.issueNodeIds.length === 0
       ? Promise.resolve([])
       : database
@@ -586,16 +542,17 @@ const readActivitySourceRows = async (
   ]);
 
 // oxlint-disable-next-line complexity -- Projection validation keeps every activity kind fail-closed.
-export const readPublicGitHubActivityPage = async (
+const readPublicGitHubActivityPageInTransaction = async (
+  database: GitHubActivityDatabase,
   cursor: GitHubActivityCursor | null,
-  limit = PUBLIC_GITHUB_ACTIVITY_DAY_PAGE_SIZE
+  pageSize: number
 ): Promise<PublicGitHubActivityPage> => {
-  const pageSize = checkedPageSize(limit);
   const snapshotAt = cursor?.snapshotAt ?? new Date().toISOString();
   const snapshotDate = new Date(snapshotAt);
   const beforeDate =
     cursor === null ? null : new Date(`${cursor.beforeDay}T00:00:00.000Z`);
   const stableActivity = and(
+    inArray(githubPublicActivities.kind, ["commit", "issue"]),
     isNotNull(githubPublicActivities.publishedAt),
     lte(githubPublicActivities.publishedAt, snapshotDate),
     isNull(githubPublicActivities.hiddenAt),
@@ -608,6 +565,8 @@ export const readPublicGitHubActivityPage = async (
         WHERE ${githubCommits.activityPublicId} = ${githubPublicActivities.publicId}
           AND ${githubCommits.repositoryId} = ${githubPublicActivities.repositoryId}
           AND ${githubCommits.sha} = ${githubPublicActivities.sourceNodeId}
+          AND ${githubCommits.canonicalizedAt} IS NOT NULL
+          AND ${githubCommits.canonicalizedAt} <= ${snapshotAt}
           AND ${githubCommits.parentShas} IS NOT NULL
           AND jsonb_array_length(${githubCommits.parentShas}) <= 1
       )
@@ -616,7 +575,6 @@ export const readPublicGitHubActivityPage = async (
       ? undefined
       : lt(githubPublicActivities.occurredAt, beforeDate)
   );
-  const database = getDatabase();
   const availableDays = await database
     .selectDistinct({ day: activityDay })
     .from(githubPublicActivities)
@@ -639,34 +597,26 @@ export const readPublicGitHubActivityPage = async (
   const commitActivityRows = activityRows.filter(
     (row) => row.kind === "commit"
   );
-  const pullRequestActivityRows = activityRows.filter(
-    (row) => row.kind === "pull_request"
-  );
   const issueActivityRows = activityRows.filter((row) => row.kind === "issue");
 
-  const pullRequestNodeIds = [
-    ...new Set(pullRequestActivityRows.map((row) => row.sourceNodeId)),
-  ];
   const issueNodeIds = [
     ...new Set(issueActivityRows.map((row) => row.sourceNodeId)),
   ];
   const commitActivityPublicIds = commitActivityRows.map((row) => row.publicId);
 
-  const [commitRows, pullRequestRows, issueRows, summaryRows] =
-    await readActivitySourceRows(database, {
+  const [commitRows, issueRows, summaryRows] = await readActivitySourceRows(
+    database,
+    {
       commitActivityPublicIds,
       issueNodeIds,
-      pullRequestNodeIds,
-    });
+    }
+  );
 
   const commits = new Map(
     commitRows.map((commit) => [
       commitKey(commit.repositoryId, commit.sha),
       commit,
     ])
-  );
-  const pullRequests = new Map(
-    pullRequestRows.map((pullRequest) => [pullRequest.nodeId, pullRequest])
   );
   const issues = new Map(issueRows.map((issue) => [issue.nodeId, issue]));
   const publishedRevisions = new Map(
@@ -820,7 +770,6 @@ export const readPublicGitHubActivityPage = async (
     commits,
     issues,
     primaryAssociations,
-    pullRequests,
     repositories,
     summaries,
   });
@@ -834,4 +783,20 @@ export const readPublicGitHubActivityPage = async (
         })
       : null;
   return { days, nextCursor, snapshotAt };
+};
+
+export const readPublicGitHubActivityPage = async (
+  cursor: GitHubActivityCursor | null,
+  limit = PUBLIC_GITHUB_ACTIVITY_DAY_PAGE_SIZE
+): Promise<PublicGitHubActivityPage> => {
+  const pageSize = checkedPageSize(limit);
+  return await getDatabase().transaction(
+    async (transaction) =>
+      await readPublicGitHubActivityPageInTransaction(
+        transaction,
+        cursor,
+        pageSize
+      ),
+    { accessMode: "read only", isolationLevel: "repeatable read" }
+  );
 };

--- a/src/lib/github-activity-types.ts
+++ b/src/lib/github-activity-types.ts
@@ -58,7 +58,6 @@ export interface PublicGitHubActivityDayTotals {
   additions: number;
   deletions: number;
   issuesOpened: number;
-  pullRequestsMerged: number;
   repositories: number;
 }
 

--- a/src/lib/github-activity-worker-store.ts
+++ b/src/lib/github-activity-worker-store.ts
@@ -50,7 +50,11 @@ import {
   nextGitHubPullRequestReconciliationAt,
 } from "@/lib/github-activity-worker-core";
 import type { GitHubExactDiffDigest } from "@/lib/github-activity-worker-core";
-import { trackedGitHubAccountFrom } from "@/lib/github-commits-core";
+import { GitHubRequestDeadlineError } from "@/lib/github-api";
+import {
+  TRACKED_GITHUB_ACCOUNTS,
+  trackedGitHubAccountFrom,
+} from "@/lib/github-commits-core";
 import type {
   GitHubPullRequest,
   GitHubRepositoryFacts,
@@ -235,13 +239,32 @@ export const inspectGitHubEvidenceRecovery = async () =>
  * workers rebuild the canonical/public projection from authoritative evidence.
  */
 export const ensureGitHubEvidenceIntegrity = async (
-  now = new Date()
+  now = new Date(),
+  options: { deadlineAt?: number } = {}
 ): Promise<GitHubEvidenceRecoveryResult> => {
   if (Number.isNaN(now.getTime())) {
     throw new TypeError("The GitHub evidence repair timestamp is invalid.");
   }
+  if (
+    options.deadlineAt !== undefined &&
+    (!Number.isFinite(options.deadlineAt) || options.deadlineAt <= Date.now())
+  ) {
+    throw new GitHubRequestDeadlineError();
+  }
 
   return await getDatabase().transaction(async (transaction) => {
+    if (options.deadlineAt !== undefined) {
+      const remainingMilliseconds = Math.floor(options.deadlineAt - Date.now());
+      if (remainingMilliseconds < 1) {
+        throw new GitHubRequestDeadlineError();
+      }
+      const timeout = `${String(remainingMilliseconds)}ms`;
+      await transaction.execute(sql`
+        SELECT
+          set_config('lock_timeout', ${timeout}, true),
+          set_config('statement_timeout', ${timeout}, true)
+      `);
+    }
     await transaction.execute(
       sql`SELECT pg_advisory_xact_lock(hashtextextended(${GITHUB_EVIDENCE_RECOVERY_LOCK}, 0))`
     );
@@ -424,6 +447,109 @@ export interface ClaimedGitHubPullRequestSignal {
   repositoryId: string;
 }
 
+export interface GitHubActivityWorkerScope {
+  repositoryId: string | null;
+  sinceAt: Date;
+  untilAt: Date;
+}
+
+export const githubCommitInWorkerScope = (
+  scope: GitHubActivityWorkerScope | undefined
+) => {
+  if (scope === undefined) {
+    return sql<boolean>`true`;
+  }
+  const occurredAt = sql<Date>`coalesce(
+    ${githubCommits.committerAt},
+    ${githubCommits.committedAt}
+  )`;
+  const repositoryScope =
+    scope.repositoryId === null
+      ? undefined
+      : sql<boolean>`(
+          ${githubCommits.repositoryId} = ${scope.repositoryId}
+          OR EXISTS (
+            SELECT 1
+            FROM ${githubPullRequestMemberships}
+            INNER JOIN ${githubPullRequestVersions}
+              ON ${githubPullRequestVersions.id} = ${githubPullRequestMemberships.versionId}
+            INNER JOIN ${githubPullRequests}
+              ON ${githubPullRequests.nodeId} = ${githubPullRequestVersions.pullRequestNodeId}
+            WHERE ${githubPullRequestVersions.isCurrent} = true
+              AND ${githubPullRequestVersions.membershipComplete} = true
+              AND ${githubPullRequests.repositoryId} = ${scope.repositoryId}
+              AND ${githubPullRequestMemberships.commitRepositoryId} = ${githubCommits.repositoryId}
+              AND ${githubPullRequestMemberships.commitSha} = ${githubCommits.sha}
+          )
+        )`;
+  return and(
+    sql<boolean>`${occurredAt} >= ${scope.sinceAt.toISOString()}::timestamptz`,
+    sql<boolean>`${occurredAt} <= ${scope.untilAt.toISOString()}::timestamptz`,
+    repositoryScope
+  );
+};
+
+// Intake can be stored after the provider event happened. Scope inboxes by the
+// provider timestamp when it exists, falling back to the local observation
+// timestamp, so a historical run neither misses delayed evidence nor drains
+// unrelated later inbox rows.
+export const githubPushObservationInWorkerScope = (
+  scope: GitHubActivityWorkerScope | undefined
+) =>
+  scope === undefined
+    ? undefined
+    : and(
+        sql<boolean>`coalesce(
+          ${githubPushObservations.providerCreatedAt},
+          ${githubPushObservations.observedAt}
+        ) >= ${scope.sinceAt.toISOString()}::timestamptz`,
+        sql<boolean>`coalesce(
+          ${githubPushObservations.providerCreatedAt},
+          ${githubPushObservations.observedAt}
+        ) <= ${scope.untilAt.toISOString()}::timestamptz`,
+        scope.repositoryId === null
+          ? undefined
+          : eq(githubPushObservations.repositoryId, scope.repositoryId)
+      );
+
+export const githubPullRequestSignalInWorkerScope = (
+  scope: GitHubActivityWorkerScope | undefined
+) =>
+  scope === undefined
+    ? undefined
+    : and(
+        gte(githubPullRequestSignals.occurredAt, scope.sinceAt),
+        lte(githubPullRequestSignals.occurredAt, scope.untilAt),
+        scope.repositoryId === null
+          ? undefined
+          : eq(githubPullRequestSignals.repositoryId, scope.repositoryId)
+      );
+
+export const githubPullRequestInWorkerScope = (
+  scope: GitHubActivityWorkerScope | undefined
+) =>
+  scope === undefined
+    ? undefined
+    : and(
+        gte(githubPullRequests.providerUpdatedAt, scope.sinceAt),
+        scope.repositoryId === null
+          ? undefined
+          : sql<boolean>`(
+              ${githubPullRequests.repositoryId} = ${scope.repositoryId}
+              OR ${githubPullRequests.headRepositoryId} = ${scope.repositoryId}
+              OR EXISTS (
+                SELECT 1
+                FROM ${githubPullRequestMemberships}
+                INNER JOIN ${githubPullRequestVersions}
+                  ON ${githubPullRequestVersions.id} = ${githubPullRequestMemberships.versionId}
+                WHERE ${githubPullRequestVersions.pullRequestNodeId} = ${githubPullRequests.nodeId}
+                  AND ${githubPullRequestVersions.isCurrent} = true
+                  AND ${githubPullRequestVersions.membershipComplete} = true
+                  AND ${githubPullRequestMemberships.commitRepositoryId} = ${scope.repositoryId}
+              )
+            )`
+      );
+
 const isActiveAccount = (
   account: string,
   activeAccounts: readonly TrackedGitHubAccount[]
@@ -433,7 +559,8 @@ const isActiveAccount = (
 export const claimGitHubPushObservations = async (
   limit: number,
   activeAccounts: readonly TrackedGitHubAccount[],
-  now = new Date()
+  now = new Date(),
+  scope?: GitHubActivityWorkerScope
 ): Promise<readonly ClaimedGitHubPushObservation[]> => {
   if (!Number.isSafeInteger(limit) || limit < 1 || limit > 8) {
     throw new RangeError("The GitHub observation claim limit is invalid.");
@@ -468,6 +595,7 @@ export const claimGitHubPushObservations = async (
       .where(
         and(
           inArray(githubPushObservations.account, [...activeAccounts]),
+          githubPushObservationInWorkerScope(scope),
           or(
             and(
               inArray(githubPushObservations.state, ["pending", "deferred"]),
@@ -709,7 +837,8 @@ export const markGitHubPushObservationUnavailable = async (
 export const claimGitHubCommitsForEnrichment = async (
   limit: number,
   activeAccounts: readonly TrackedGitHubAccount[],
-  now = new Date()
+  now = new Date(),
+  scope?: GitHubActivityWorkerScope
 ): Promise<readonly ClaimedGitHubCommit[]> => {
   if (!Number.isSafeInteger(limit) || limit < 1 || limit > 8) {
     throw new RangeError("The GitHub commit claim limit is invalid.");
@@ -735,6 +864,7 @@ export const claimGitHubCommitsForEnrichment = async (
       .where(
         and(
           inArray(githubCommits.author, [...activeAccounts]),
+          githubCommitInWorkerScope(scope),
           or(
             and(
               eq(githubCommits.enrichmentState, "pending"),
@@ -1018,7 +1148,8 @@ export const markGitHubCommitUnavailable = async (
 export const claimGitHubCommitsForPullRequestDiscovery = async (
   limit: number,
   activeAccounts: readonly TrackedGitHubAccount[],
-  now = new Date()
+  now = new Date(),
+  scope?: GitHubActivityWorkerScope
 ): Promise<readonly ClaimedGitHubPullRequestDiscovery[]> => {
   if (!Number.isSafeInteger(limit) || limit < 1 || limit > 8) {
     throw new RangeError("The GitHub PR discovery claim limit is invalid.");
@@ -1044,6 +1175,7 @@ export const claimGitHubCommitsForPullRequestDiscovery = async (
       .where(
         and(
           inArray(githubCommits.author, [...activeAccounts]),
+          githubCommitInWorkerScope(scope),
           eq(githubCommits.enrichmentState, "complete"),
           or(
             and(
@@ -1179,7 +1311,8 @@ export const markGitHubPullRequestDiscoveryUnavailable = async (
 export const claimGitHubPullRequestSignals = async (
   limit: number,
   activeAccounts: readonly TrackedGitHubAccount[],
-  now = new Date()
+  now = new Date(),
+  scope?: GitHubActivityWorkerScope
 ): Promise<readonly ClaimedGitHubPullRequestSignal[]> => {
   if (!Number.isSafeInteger(limit) || limit < 1 || limit > 8) {
     throw new RangeError("The GitHub PR signal claim limit is invalid.");
@@ -1205,6 +1338,7 @@ export const claimGitHubPullRequestSignals = async (
       .where(
         and(
           inArray(githubPullRequestSignals.account, [...activeAccounts]),
+          githubPullRequestSignalInWorkerScope(scope),
           or(
             and(
               eq(githubPullRequestSignals.state, "pending"),
@@ -1490,14 +1624,7 @@ const persistPullRequestSnapshotInTransaction = async (
   if (canonicalEvidenceChanged) {
     await invalidateGitHubPullRequestDerivedAliases(
       transaction,
-      pullRequest.nodeId,
-      [
-        existing.repositoryId,
-        existing.headRepositoryId,
-        pullRequest.repository.id,
-        pullRequest.baseRepository.id,
-        pullRequest.headRepository?.id,
-      ]
+      pullRequest.nodeId
     );
   }
   const mutable = {
@@ -1805,7 +1932,8 @@ export const claimDueGitHubPullRequests = async (
   account: TrackedGitHubAccount,
   maximumAgeDays: number,
   limit = 4,
-  now = new Date()
+  now = new Date(),
+  scope?: GitHubActivityWorkerScope
 ): Promise<readonly DueGitHubPullRequest[]> => {
   if (!Number.isSafeInteger(limit) || limit < 1 || limit > 8) {
     throw new RangeError("The GitHub pull request claim limit is invalid.");
@@ -1853,6 +1981,7 @@ export const claimDueGitHubPullRequests = async (
       .where(
         and(
           eq(githubPullRequests.account, account),
+          githubPullRequestInWorkerScope(scope),
           isNotNull(githubPullRequests.nextReconcileAt),
           lte(githubPullRequests.nextReconcileAt, now),
           or(
@@ -1935,8 +2064,7 @@ export const persistGitHubPullRequestMembership = async (
     }
     await invalidateGitHubPullRequestDerivedAliases(
       transaction,
-      stored.pullRequestNodeId,
-      [stored.baseRepositoryId, stored.commitRepositoryId]
+      stored.pullRequestNodeId
     );
     await transaction
       .delete(githubPullRequestMemberships)
@@ -2000,28 +2128,6 @@ export const completeGitHubPullRequestReconciliation = async (
       return false;
     }
 
-    if (
-      state === "merged" &&
-      pullRequest.mergedAt !== null &&
-      trackedGitHubAccountFrom(pullRequest.author) !== null
-    ) {
-      await transaction
-        .insert(githubPublicActivities)
-        .values({
-          kind: "pull_request",
-          occurredAt: new Date(pullRequest.mergedAt),
-          publishedAt: now,
-          repositoryId: pullRequest.repository.id,
-          sourceNodeId: pullRequest.nodeId,
-        })
-        .onConflictDoNothing({
-          target: [
-            githubPublicActivities.kind,
-            githubPublicActivities.repositoryId,
-            githubPublicActivities.sourceNodeId,
-          ],
-        });
-    }
     return true;
   });
 
@@ -2530,8 +2636,13 @@ export const canonicalizeGitHubCommitActivity = async (
 
 export const canonicalizePendingGitHubActivities = async (
   limit = 8,
-  now = new Date()
+  now = new Date(),
+  activeAccounts: readonly TrackedGitHubAccount[] = TRACKED_GITHUB_ACCOUNTS,
+  scope?: GitHubActivityWorkerScope
 ) => {
+  if (activeAccounts.length === 0) {
+    return 0;
+  }
   const candidates = await getDatabase()
     .select({
       repositoryId: githubCommits.repositoryId,
@@ -2541,6 +2652,8 @@ export const canonicalizePendingGitHubActivities = async (
     .innerJoin(githubPublicActivities, commitActivityIdentity)
     .where(
       and(
+        inArray(githubCommits.author, [...activeAccounts]),
+        githubCommitInWorkerScope(scope),
         eq(githubCommits.enrichmentState, "complete"),
         inArray(githubCommits.pullRequestDiscoveryState, [
           "complete",
@@ -2609,8 +2722,13 @@ export const ensureGitHubSummaryAttempt = async (
 
 export const ensureMissingGitHubSummaryAttempts = async (
   limit = 50,
-  now = new Date()
+  now = new Date(),
+  activeAccounts: readonly TrackedGitHubAccount[] = TRACKED_GITHUB_ACCOUNTS,
+  scope?: GitHubActivityWorkerScope
 ) => {
+  if (activeAccounts.length === 0) {
+    return 0;
+  }
   const rows = await getDatabase()
     .select({ publicId: githubPublicActivities.publicId })
     .from(githubPublicActivities)
@@ -2628,6 +2746,8 @@ export const ensureMissingGitHubSummaryAttempts = async (
     .where(
       and(
         eq(githubPublicActivities.kind, "commit"),
+        inArray(githubCommits.author, [...activeAccounts]),
+        githubCommitInWorkerScope(scope),
         isNull(githubPublicActivities.canonicalPublicId),
         isNull(githubPublicActivities.hiddenAt),
         isNull(githubSummaryAttempts.activityPublicId),
@@ -2650,7 +2770,8 @@ export const ensureMissingGitHubSummaryAttempts = async (
 export const claimGitHubSummaryAttempts = async (
   limit: number,
   activeAccounts: readonly TrackedGitHubAccount[],
-  now = new Date()
+  now = new Date(),
+  scope?: GitHubActivityWorkerScope
 ): Promise<readonly ClaimedGitHubSummary[]> => {
   if (!Number.isSafeInteger(limit) || limit < 1 || limit > 8) {
     throw new RangeError("The GitHub summary claim limit is invalid.");
@@ -2711,6 +2832,7 @@ export const claimGitHubSummaryAttempts = async (
           isNull(githubPublicActivities.canonicalPublicId),
           isNull(githubPublicActivities.hiddenAt),
           inArray(githubCommits.author, [...activeAccounts]),
+          githubCommitInWorkerScope(scope),
           eq(githubCommits.enrichmentState, "complete"),
           isNotNull(githubCommits.canonicalizedAt),
           isNonMergeCommit
@@ -2869,6 +2991,28 @@ export const deferGitHubSummaryAttempt = async (
       leaseToken: null,
       leaseUntil: dueAt(attempt.attemptCount, now, retryAt),
       state: "pending",
+    })
+    .where(
+      and(
+        eq(githubSummaryAttempts.activityPublicId, attempt.activityPublicId),
+        eq(githubSummaryAttempts.revision, attempt.revision),
+        eq(githubSummaryAttempts.state, "processing"),
+        eq(githubSummaryAttempts.leaseToken, attempt.leaseToken)
+      )
+    );
+};
+
+export const markGitHubSummaryAttemptIndeterminate = async (
+  attempt: ClaimedGitHubSummary,
+  errorCode: string
+) => {
+  await getDatabase()
+    .update(githubSummaryAttempts)
+    .set({
+      errorCode,
+      leaseToken: null,
+      leaseUntil: null,
+      state: "indeterminate",
     })
     .where(
       and(

--- a/src/lib/github-activity-worker.ts
+++ b/src/lib/github-activity-worker.ts
@@ -39,6 +39,7 @@ import {
   markGitHubPullRequestDiscoveryUnavailable,
   markGitHubPullRequestSignalUnavailable,
   markGitHubPushObservationUnavailable,
+  markGitHubSummaryAttemptIndeterminate,
   persistGitHubPullRequestMembership,
   persistGitHubPullRequestSnapshot,
   releaseGitHubCommitEnrichment,
@@ -49,23 +50,37 @@ import {
   releaseGitHubSummaryAttempt,
   stopGitHubPullRequestReconciliation,
 } from "@/lib/github-activity-worker-store";
-import type { DueGitHubPullRequest } from "@/lib/github-activity-worker-store";
+import type {
+  DueGitHubPullRequest,
+  GitHubActivityWorkerScope,
+} from "@/lib/github-activity-worker-store";
 import {
   GitHubRequestDeadlineError,
   GitHubResponseError,
 } from "@/lib/github-api";
-import { TRACKED_GITHUB_ACCOUNTS } from "@/lib/github-commits-core";
+import {
+  repositoryIdFrom,
+  TRACKED_GITHUB_ACCOUNTS,
+} from "@/lib/github-commits-core";
 import type { TrackedGitHubAccount } from "@/lib/github-commits-core";
 import {
   isGitHubAccountPaused,
+  persistGitHubCommitReferences,
   readGitHubAccountCheckpoint,
 } from "@/lib/github-commits-store";
 
 const DEFAULT_WORKER_MAXIMUM_DURATION_MS = 90_000;
-// A 404 is visibility-dependent on GitHub and must remain recoverable after a
-// token or repository-permission change.
-const PERMANENT_GITHUB_STATUSES = new Set([410, 422]);
-const MINIMUM_TERMINAL_GITHUB_ATTEMPTS = 8;
+const TERMINAL_GITHUB_STATUSES = new Set([403, 404, 410, 422]);
+const TERMINAL_ACTIVITY_PROCESSING_CODES = new Set([
+  "membership_incomplete",
+  "source_auth_missing",
+  "source_incomplete",
+  "source_invalid",
+  "source_unavailable",
+]);
+// Three independent worker claims tolerate short propagation/permission races
+// without letting deterministic provider failures restart a backfill forever.
+export const GITHUB_ACTIVITY_TERMINAL_ATTEMPTS = 3;
 
 interface StageResult {
   claimed: number;
@@ -95,6 +110,7 @@ export interface GitHubActivityWorkerResult {
 }
 
 export interface GitHubActivityWorkerOptions {
+  accounts?: readonly TrackedGitHubAccount[];
   commitLimit?: number;
   maximumDurationMs?: number;
   observationLimit?: number;
@@ -102,6 +118,7 @@ export interface GitHubActivityWorkerOptions {
   pullRequestLimit?: number;
   pullRequestSignalLimit?: number;
   summaryLimit?: number;
+  scope?: GitHubActivityWorkerScope;
 }
 
 const errorCode = (error: unknown) => {
@@ -123,17 +140,36 @@ const retryAtFrom = (error: unknown) =>
     ? error.retryAt
     : null;
 
-const permanentlyUnavailable = (error: unknown, attemptCount: number) =>
-  (error instanceof ActivityProcessingError &&
-    error.code === "provenance_changed") ||
-  (error instanceof GitHubResponseError &&
-    !error.retryable &&
-    PERMANENT_GITHUB_STATUSES.has(error.status) &&
-    attemptCount >= MINIMUM_TERMINAL_GITHUB_ATTEMPTS);
+export const githubActivityFailureIsTerminal = (
+  error: unknown,
+  attemptCount: number
+) => {
+  if (
+    error instanceof ActivityProcessingError &&
+    error.code === "provenance_changed"
+  ) {
+    return true;
+  }
+  if (attemptCount < GITHUB_ACTIVITY_TERMINAL_ATTEMPTS) {
+    return false;
+  }
+  if (error instanceof GitHubGraphQlResponseError) {
+    return !error.retryable;
+  }
+  if (error instanceof GitHubResponseError) {
+    return !error.retryable && TERMINAL_GITHUB_STATUSES.has(error.status);
+  }
+  return (
+    error instanceof ActivityProcessingError &&
+    TERMINAL_ACTIVITY_PROCESSING_CODES.has(error.code)
+  );
+};
 
-const activeTrackedAccounts = async () => {
+const activeTrackedAccounts = async (
+  requestedAccounts: readonly TrackedGitHubAccount[] = TRACKED_GITHUB_ACCOUNTS
+) => {
   const accounts: TrackedGitHubAccount[] = [];
-  for (const account of TRACKED_GITHUB_ACCOUNTS) {
+  for (const account of requestedAccounts) {
     const checkpoint = await readGitHubAccountCheckpoint(account);
     if (!isGitHubAccountPaused(checkpoint)) {
       accounts.push(account);
@@ -153,6 +189,7 @@ interface WorkerContext {
   activeAccounts: readonly TrackedGitHubAccount[];
   deadlineAt: number;
   deadlineReached: () => boolean;
+  scope?: GitHubActivityWorkerScope;
   sourceCache: Map<string, CommitSource>;
 }
 
@@ -166,7 +203,9 @@ const processObservations = async (
   }
   const claimed = await claimGitHubPushObservations(
     limit,
-    context.activeAccounts
+    context.activeAccounts,
+    new Date(),
+    context.scope
   );
   result.claimed = claimed.length;
   for (const observation of claimed) {
@@ -186,7 +225,9 @@ const processObservations = async (
       if (error instanceof GitHubRequestDeadlineError) {
         await releaseGitHubPushObservation(observation);
         result.deferred += 1;
-      } else if (permanentlyUnavailable(error, observation.attemptCount)) {
+      } else if (
+        githubActivityFailureIsTerminal(error, observation.attemptCount)
+      ) {
         await markGitHubPushObservationUnavailable(observation, code);
         result.unavailable += 1;
       } else {
@@ -208,7 +249,9 @@ const processCommits = async (
   }
   const claimed = await claimGitHubCommitsForEnrichment(
     limit,
-    context.activeAccounts
+    context.activeAccounts,
+    new Date(),
+    context.scope
   );
   result.claimed = claimed.length;
   for (const commit of claimed) {
@@ -237,7 +280,7 @@ const processCommits = async (
       if (error instanceof GitHubRequestDeadlineError) {
         await releaseGitHubCommitEnrichment(commit);
         result.deferred += 1;
-      } else if (permanentlyUnavailable(error, commit.attemptCount)) {
+      } else if (githubActivityFailureIsTerminal(error, commit.attemptCount)) {
         await markGitHubCommitUnavailable(commit, code);
         result.unavailable += 1;
       } else {
@@ -259,7 +302,9 @@ const processPullRequestDiscovery = async (
   }
   const claimed = await claimGitHubCommitsForPullRequestDiscovery(
     limit,
-    context.activeAccounts
+    context.activeAccounts,
+    new Date(),
+    context.scope
   );
   result.claimed = claimed.length;
   for (const commit of claimed) {
@@ -282,7 +327,7 @@ const processPullRequestDiscovery = async (
       if (error instanceof GitHubRequestDeadlineError) {
         await releaseGitHubPullRequestDiscovery(commit);
         result.deferred += 1;
-      } else if (permanentlyUnavailable(error, commit.attemptCount)) {
+      } else if (githubActivityFailureIsTerminal(error, commit.attemptCount)) {
         await markGitHubPullRequestDiscoveryUnavailable(commit, code);
         result.unavailable += 1;
       } else {
@@ -304,7 +349,9 @@ const processPullRequestSignals = async (
   }
   const claimed = await claimGitHubPullRequestSignals(
     limit,
-    context.activeAccounts
+    context.activeAccounts,
+    new Date(),
+    context.scope
   );
   result.claimed = claimed.length;
   for (const signal of claimed) {
@@ -329,7 +376,7 @@ const processPullRequestSignals = async (
       if (error instanceof GitHubRequestDeadlineError) {
         await releaseGitHubPullRequestSignal(signal);
         result.deferred += 1;
-      } else if (permanentlyUnavailable(error, signal.attemptCount)) {
+      } else if (githubActivityFailureIsTerminal(error, signal.attemptCount)) {
         await markGitHubPullRequestSignalUnavailable(signal, code);
         result.unavailable += 1;
       } else {
@@ -386,6 +433,7 @@ const reconcilePullRequest = async (
         expectedHeadSha: snapshot.pullRequest.headSha,
       }
     );
+    await persistGitHubCommitReferences({ commits: membership.commits });
     const complete = await persistGitHubPullRequestMembership(
       stored,
       snapshot.pullRequest.headSha,
@@ -429,7 +477,9 @@ const processPullRequests = async (
       const [due] = await claimDueGitHubPullRequests(
         account,
         GITHUB_PR_RECONCILIATION_MAX_AGE_DAYS,
-        1
+        1,
+        new Date(),
+        context.scope
       );
       if (due !== undefined) {
         duePullRequests.push(due);
@@ -452,7 +502,7 @@ const processPullRequests = async (
       if (error instanceof GitHubRequestDeadlineError) {
         await releaseGitHubPullRequestReconciliation(due);
         result.deferred += 1;
-      } else if (permanentlyUnavailable(error, due.attemptCount)) {
+      } else if (githubActivityFailureIsTerminal(error, due.attemptCount)) {
         await stopGitHubPullRequestReconciliation(due, code);
         result.unavailable += 1;
       } else {
@@ -478,7 +528,9 @@ const processSummaries = async (
   }
   const claimed = await claimGitHubSummaryAttempts(
     limit,
-    context.activeAccounts
+    context.activeAccounts,
+    new Date(),
+    context.scope
   );
   result.claimed = claimed.length;
   for (const attempt of claimed) {
@@ -515,17 +567,58 @@ const processSummaries = async (
         result.failed += 1;
       }
     } catch (error) {
-      await (error instanceof GitHubRequestDeadlineError
-        ? releaseGitHubSummaryAttempt(attempt)
-        : deferGitHubSummaryAttempt(
-            attempt,
-            errorCode(error),
-            retryAtFrom(error)
-          ));
-      result.deferred += 1;
+      const code = errorCode(error);
+      if (error instanceof GitHubRequestDeadlineError) {
+        await releaseGitHubSummaryAttempt(attempt);
+        result.deferred += 1;
+      } else if (githubActivityFailureIsTerminal(error, attempt.attemptCount)) {
+        await markGitHubSummaryAttemptIndeterminate(attempt, code);
+        result.unavailable += 1;
+      } else {
+        await deferGitHubSummaryAttempt(attempt, code, retryAtFrom(error));
+        result.deferred += 1;
+      }
     }
   }
   result.failed = result.deferred + result.unavailable;
+};
+
+const checkedWorkerAccounts = (
+  accounts: readonly TrackedGitHubAccount[] | undefined
+) => {
+  const requested = accounts ?? TRACKED_GITHUB_ACCOUNTS;
+  if (
+    requested.length === 0 ||
+    new Set(requested).size !== requested.length ||
+    requested.some((account) => !TRACKED_GITHUB_ACCOUNTS.includes(account))
+  ) {
+    throw new RangeError(
+      "The GitHub activity worker account scope is invalid."
+    );
+  }
+  return requested;
+};
+
+const checkedWorkerScope = (
+  scope: GitHubActivityWorkerScope | undefined
+): GitHubActivityWorkerScope | undefined => {
+  if (scope === undefined) {
+    return undefined;
+  }
+  if (
+    Number.isNaN(scope.sinceAt.getTime()) ||
+    Number.isNaN(scope.untilAt.getTime()) ||
+    scope.sinceAt > scope.untilAt ||
+    (scope.repositoryId !== null &&
+      repositoryIdFrom(scope.repositoryId) === null)
+  ) {
+    throw new RangeError("The GitHub activity worker scope is invalid.");
+  }
+  return {
+    repositoryId: scope.repositoryId,
+    sinceAt: new Date(scope.sinceAt),
+    untilAt: new Date(scope.untilAt),
+  };
 };
 
 export const runGitHubActivityWorker = async (
@@ -543,6 +636,8 @@ export const runGitHubActivityWorker = async (
   const summaryLimit = boundedWorkerLimit(options.summaryLimit);
   const maximumDurationMs =
     options.maximumDurationMs ?? DEFAULT_WORKER_MAXIMUM_DURATION_MS;
+  const requestedAccounts = checkedWorkerAccounts(options.accounts);
+  const scope = checkedWorkerScope(options.scope);
   if (
     !Number.isSafeInteger(maximumDurationMs) ||
     maximumDurationMs < 1 ||
@@ -560,10 +655,12 @@ export const runGitHubActivityWorker = async (
   const pullRequestDiscovery = emptyStageResult();
   const pullRequestSignals = emptyStageResult();
   const summaries = emptyStageResult();
+  const activeAccounts = await activeTrackedAccounts(requestedAccounts);
   const context: WorkerContext = {
-    activeAccounts: await activeTrackedAccounts(),
+    activeAccounts,
     deadlineAt: startedAt + maximumDurationMs,
     deadlineReached,
+    scope,
     sourceCache: new Map(),
   };
 
@@ -582,9 +679,19 @@ export const runGitHubActivityWorker = async (
   await processPullRequests(context, pullRequestLimit, pullRequests);
   const aliases = context.deadlineReached()
     ? 0
-    : await canonicalizePendingGitHubActivities(8);
+    : await canonicalizePendingGitHubActivities(
+        8,
+        new Date(),
+        activeAccounts,
+        scope
+      );
   if (!context.deadlineReached()) {
-    await ensureMissingGitHubSummaryAttempts();
+    await ensureMissingGitHubSummaryAttempts(
+      50,
+      new Date(),
+      activeAccounts,
+      scope
+    );
   }
   await processSummaries(context, summaryLimit, summaries);
 

--- a/src/lib/github-backfill-core.ts
+++ b/src/lib/github-backfill-core.ts
@@ -1,3 +1,4 @@
+import type { GitHubActivityAuditStatus } from "@/lib/github-activity-audit";
 import {
   repositoryIdFrom,
   TRACKED_GITHUB_ACCOUNTS,
@@ -7,10 +8,67 @@ import type { TrackedGitHubAccount } from "@/lib/github-commits-core";
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 const DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+const MAXIMUM_BACKFILL_DAYS = 31;
+const MAXIMUM_BROAD_BACKFILL_LOOKBACK_DAYS = 62;
 const MINIMUM_GITHUB_DATE = Date.UTC(1970, 0, 1);
 const MAXIMUM_GITHUB_DATE = Date.UTC(2099, 11, 31);
 
 export const GITHUB_BACKFILL_WORKER_BATCH_SIZE = 8;
+
+export interface GitHubBackfillCompletion {
+  complete: boolean;
+  pipelineSettled: boolean;
+}
+
+export type GitHubBackfillOutcome =
+  | "complete"
+  | "completed_with_gaps"
+  | "incomplete";
+
+export const githubBackfillDiscoveryCompleteFrom = (
+  inventories: readonly {
+    direct: { complete: boolean } | null;
+    pullRequests: { complete: boolean };
+  }[]
+) =>
+  inventories.length > 0 &&
+  inventories.every(
+    ({ direct, pullRequests }) =>
+      direct?.complete === true && pullRequests.complete
+  );
+
+export const githubBackfillCompletionFrom = (input: {
+  auditStatuses: readonly GitHubActivityAuditStatus[];
+  boundedDiscoveryComplete: boolean;
+}): GitHubBackfillCompletion => {
+  const pipelineSettled =
+    input.auditStatuses.length > 0 &&
+    input.auditStatuses.every(
+      (status) => status === "stored_projection_verified"
+    );
+  return {
+    complete: input.boundedDiscoveryComplete && pipelineSettled,
+    pipelineSettled,
+  };
+};
+
+export const githubBackfillExitCodeFrom = (
+  completion: GitHubBackfillCompletion
+) => (completion.complete ? 0 : 1);
+
+export const githubBackfillOutcomeFrom = (
+  completion: GitHubBackfillCompletion,
+  coverageGaps: number
+): GitHubBackfillOutcome => {
+  if (!Number.isSafeInteger(coverageGaps) || coverageGaps < 0) {
+    throw new RangeError("The GitHub backfill coverage gap count is invalid.");
+  }
+  return completion.complete
+    ? coverageGaps === 0
+      ? "complete"
+      : "completed_with_gaps"
+    : "incomplete";
+};
 
 interface GitHubBackfillWorkerStageCounts {
   claimed: number;
@@ -38,6 +96,10 @@ export interface GitHubBackfillProcessingCounts {
   processed: number;
   unavailable: number;
 }
+
+export const githubBackfillProcessingMadeProgress = (
+  counts: Pick<GitHubBackfillProcessingCounts, "aliases" | "claimed">
+) => counts.claimed > 0 || counts.aliases > 0;
 
 type JsonObject = Record<string, unknown>;
 
@@ -126,6 +188,10 @@ const normalizedGitHubBackfillInputFrom = (
   ) {
     return null;
   }
+  const dayCount = (endDay.getTime() - startAt.getTime()) / DAY_MS + 1;
+  if (dayCount > MAXIMUM_BACKFILL_DAYS) {
+    return null;
+  }
   const account =
     value.account === "all" ? "all" : trackedGitHubAccountFrom(value.account);
   if (account === null) {
@@ -138,6 +204,13 @@ const normalizedGitHubBackfillInputFrom = (
   const repositoryId =
     rawRepositoryId.length === 0 ? null : repositoryIdFrom(rawRepositoryId);
   if (rawRepositoryId.length > 0 && repositoryId === null) {
+    return null;
+  }
+  const lookbackDays = (today.getTime() - startAt.getTime()) / DAY_MS + 1;
+  if (
+    repositoryId === null &&
+    lookbackDays > MAXIMUM_BROAD_BACKFILL_LOOKBACK_DAYS
+  ) {
     return null;
   }
 

--- a/src/lib/github-commits-store.ts
+++ b/src/lib/github-commits-store.ts
@@ -1223,14 +1223,7 @@ const invalidateChangedPullRequestAliases = async (
   }
   await invalidateGitHubPullRequestDerivedAliases(
     transaction,
-    pullRequest.nodeId,
-    [
-      existing.repositoryId,
-      existing.headRepositoryId,
-      pullRequest.repository.id,
-      pullRequest.baseRepository.id,
-      pullRequest.headRepository?.id,
-    ]
+    pullRequest.nodeId
   );
 };
 
@@ -1478,10 +1471,7 @@ const signalKnownPullRequestReconciliation = async (
     occurredAt > known.providerUpdatedAt ||
     TERMINAL_PULL_REQUEST_EVENT_ACTIONS.has(signal.action);
   if (promoteToProvisionalClosed) {
-    await invalidateGitHubPullRequestDerivedAliases(transaction, known.nodeId, [
-      known.repositoryId,
-      known.headRepositoryId,
-    ]);
+    await invalidateGitHubPullRequestDerivedAliases(transaction, known.nodeId);
   }
   await transaction
     .update(githubPullRequests)

--- a/src/lib/github-direct-backfill.ts
+++ b/src/lib/github-direct-backfill.ts
@@ -27,6 +27,7 @@ const DEADLINE_MARGIN_MS = 30_000;
 const GITHUB_PAGE_SIZE = 100;
 const PERSISTENCE_BATCH_SIZE = 1000;
 const RATE_LIMIT_RESET_PADDING_MS = 1000;
+const PERMANENT_RESOURCE_STATUSES = new Set([403, 404, 410, 422]);
 
 type JsonObject = Record<string, unknown>;
 
@@ -43,6 +44,11 @@ const repositoryApiPath = (repository: string, suffix: string) => {
 
 const deadlineReached = (deadlineAt: number) =>
   Date.now() + DEADLINE_MARGIN_MS >= deadlineAt;
+
+const permanentlyUnavailableResource = (error: unknown) =>
+  error instanceof GitHubResponseError &&
+  !error.retryable &&
+  PERMANENT_RESOURCE_STATUSES.has(error.status);
 
 const withRateLimitWait = async <Value>(
   operation: () => Promise<Value>,
@@ -250,6 +256,7 @@ export interface GitHubDirectBackfillResult {
   repositories: number;
   retryAt: Date | null;
   stopReason: GitHubDirectBackfillStopReason;
+  unavailableRepositories: number;
   uniqueCommits: number;
 }
 
@@ -264,6 +271,7 @@ const emptyResult = (): GitHubDirectBackfillResult => ({
   repositories: 0,
   retryAt: null,
   stopReason: "complete",
+  unavailableRepositories: 0,
   uniqueCommits: 0,
 });
 
@@ -323,7 +331,7 @@ export const backfillGitHubCommitsFromCurrentRefs = async (input: {
         await collectAccessibleGitHubRepositories(
           input.token,
           input.repositoryId,
-          { deadlineAt: input.deadlineAt }
+          { deadlineAt: input.deadlineAt, pushedSinceAt: input.sinceAt }
         ),
       input
     );
@@ -331,33 +339,51 @@ export const backfillGitHubCommitsFromCurrentRefs = async (input: {
       if (deadlineReached(input.deadlineAt)) {
         throw new GitHubRequestDeadlineError();
       }
-      const refs = await withRateLimitWait(
-        async () =>
-          await collectGitHubRepositoryRefs(repository, input.token, {
-            deadlineAt: input.deadlineAt,
-          }),
-        input
-      );
+      let refs: readonly GitHubRepositoryRefSnapshot[] | null;
+      try {
+        refs = await withRateLimitWait(
+          async () =>
+            await collectGitHubRepositoryRefs(repository, input.token, {
+              deadlineAt: input.deadlineAt,
+            }),
+          input
+        );
+      } catch (error) {
+        if (permanentlyUnavailableResource(error)) {
+          result.unavailableRepositories += 1;
+          continue;
+        }
+        throw error;
+      }
       if (refs === null) {
-        await flush();
-        return {
-          ...result,
-          complete: false,
-          stopReason: "provider_retry",
-        };
+        result.unavailableRepositories += 1;
+        continue;
       }
       result.repositories += 1;
       result.refs += refs.length;
       const distinctHeads = distinctGitHubCurrentRefHeads(refs);
+      let repositoryHasUnavailableHead = false;
       for (const { headSha } of distinctHeads) {
         if (deadlineReached(input.deadlineAt)) {
           throw new GitHubRequestDeadlineError();
         }
-        const page = await collectGitHubCommitsFromHead({
-          ...input,
-          headSha,
-          repository,
-        });
+        let page: Awaited<ReturnType<typeof collectGitHubCommitsFromHead>>;
+        try {
+          page = await collectGitHubCommitsFromHead({
+            ...input,
+            headSha,
+            repository,
+          });
+        } catch (error) {
+          if (permanentlyUnavailableResource(error)) {
+            if (!repositoryHasUnavailableHead) {
+              repositoryHasUnavailableHead = true;
+              result.unavailableRepositories += 1;
+            }
+            continue;
+          }
+          throw error;
+        }
         result.heads += 1;
         result.pages += page.pages;
         for (const commit of page.commits) {

--- a/src/lib/github-pull-request-backfill.ts
+++ b/src/lib/github-pull-request-backfill.ts
@@ -43,6 +43,7 @@ const PULL_REQUEST_PROCESSING_BATCH_SIZE = 10;
 const DEADLINE_MARGIN_MS = 30_000;
 const RATE_LIMIT_RESET_PADDING_MS = 1000;
 const AUTHORED_PULL_REQUEST_PAGE_SIZE = 100;
+const PERMANENT_RESOURCE_STATUSES = new Set([403, 404, 410, 422]);
 
 const AUTHORED_PULL_REQUESTS_QUERY = `query AuthoredPullRequests($login: String!, $cursor: String, $pageSize: Int!) {
   user(login: $login) {
@@ -50,7 +51,7 @@ const AUTHORED_PULL_REQUESTS_QUERY = `query AuthoredPullRequests($login: String!
     pullRequests(
       first: $pageSize
       after: $cursor
-      orderBy: { field: CREATED_AT, direction: DESC }
+      orderBy: { field: UPDATED_AT, direction: DESC }
     ) {
       totalCount
       nodes {
@@ -235,7 +236,8 @@ export const mergeGitHubPullRequestBackfillCandidates = (
  * Independently enumerates PRs authored by the tracked account. Unlike
  * `/user/repos`, this connection includes PRs whose base is an unrelated
  * public repository. The cursor is intentionally unbounded; total and unique
- * progress checks make a mutable or incomplete connection fail closed.
+ * progress checks make a mutable or incomplete connection fail closed. The
+ * updated-time ordering lets a bounded history run stop at its lower bound.
  */
 // oxlint-disable eslint/complexity -- Every page, identity, count, progress, and cursor invariant fails closed independently.
 export const collectGitHubAuthoredPullRequestBackfillCandidates =
@@ -243,13 +245,20 @@ export const collectGitHubAuthoredPullRequestBackfillCandidates =
     account: TrackedGitHubAccount;
     deadlineAt: number;
     token: string;
+    updatedSinceAt: Date;
   }): Promise<GitHubAuthoredPullRequestBackfillCandidateCollection> => {
+    if (Number.isNaN(input.updatedSinceAt.getTime())) {
+      throw new RangeError(
+        "The GitHub authored pull request activity cutoff is invalid."
+      );
+    }
     const candidates = new Map<string, GitHubPullRequestBackfillCandidate>();
     const visitedCursors = new Set<string>();
     let cursor: string | null = null;
     let expectedTotal: number | null = null;
     let pages = 0;
     let observedNodes = 0;
+    let previousUpdatedAt = Number.POSITIVE_INFINITY;
 
     while (true) {
       if (deadlineReached(input.deadlineAt)) {
@@ -297,9 +306,31 @@ export const collectGitHubAuthoredPullRequestBackfillCandidates =
       const pageCandidates = nodes.map((node) =>
         authoredPullRequestCandidateFrom(node, input.account)
       );
-      mergeGitHubPullRequestBackfillCandidates(candidates, pageCandidates);
+      let reachedCutoff = false;
+      for (const candidate of pageCandidates) {
+        const updatedAt = new Date(candidate.providerUpdatedAt).getTime();
+        if (updatedAt > previousUpdatedAt) {
+          throw new TypeError(
+            "GitHub returned authored pull requests outside descending updated order."
+          );
+        }
+        previousUpdatedAt = updatedAt;
+        if (updatedAt < input.updatedSinceAt.getTime()) {
+          reachedCutoff = true;
+          continue;
+        }
+        mergeGitHubPullRequestBackfillCandidates(candidates, [candidate]);
+      }
       observedNodes += nodes.length;
       pages += 1;
+
+      if (reachedCutoff) {
+        return {
+          pages,
+          pullRequests: [...candidates.values()],
+          totalCount: expectedTotal,
+        };
+      }
 
       if (!pageInfo.hasNextPage) {
         if (
@@ -397,10 +428,10 @@ const validateNextPullRequestPage = (
   const numericPath = `/repositories/${encodeURIComponent(repository.id)}/pulls`;
   if (
     (next.pathname !== namedPath && next.pathname !== numericPath) ||
-    next.searchParams.get("direction") !== "asc" ||
+    next.searchParams.get("direction") !== "desc" ||
     next.searchParams.get("page") !== String(currentPage + 1) ||
     next.searchParams.get("per_page") !== String(GITHUB_PAGE_SIZE) ||
-    next.searchParams.get("sort") !== "created" ||
+    next.searchParams.get("sort") !== "updated" ||
     next.searchParams.get("state") !== "all" ||
     next.searchParams.size !== 5
   ) {
@@ -408,25 +439,29 @@ const validateNextPullRequestPage = (
   }
 };
 
-/** Enumerates every PR because Git commit timestamps can be arbitrary. */
+/** Enumerates PRs changed since the requested history window began. */
 export const collectGitHubPullRequestBackfillCandidates = async (input: {
   account: TrackedGitHubAccount;
   deadlineAt: number;
   onRateLimitWait?: (retryAt: Date) => void;
   repository: GitHubRepositoryFacts;
   token: string;
+  updatedSinceAt: Date;
 }): Promise<GitHubPullRequestBackfillCandidateCollection> => {
+  if (Number.isNaN(input.updatedSinceAt.getTime())) {
+    throw new RangeError("The GitHub pull request activity cutoff is invalid.");
+  }
   let url: URL | null = githubApiUrl(
     repositoryApiPath(input.repository.fullName, "/pulls")
   );
-  url.searchParams.set("direction", "asc");
+  url.searchParams.set("direction", "desc");
   url.searchParams.set("page", "1");
   url.searchParams.set("per_page", String(GITHUB_PAGE_SIZE));
-  url.searchParams.set("sort", "created");
+  url.searchParams.set("sort", "updated");
   url.searchParams.set("state", "all");
   const pullRequests = new Map<string, GitHubPullRequestBackfillCandidate>();
   const visited = new Set<string>();
-  let previousCreatedAt = Number.NEGATIVE_INFINITY;
+  let previousUpdatedAt = Number.POSITIVE_INFINITY;
   let page = 1;
 
   while (url !== null) {
@@ -451,18 +486,23 @@ export const collectGitHubPullRequestBackfillCandidates = async (input: {
       throw new TypeError("GitHub returned an invalid pull request page.");
     }
 
+    let reachedCutoff = false;
     for (const value of payload) {
       const parsed = pullRequestCandidateFromListValue(value, input);
       if (parsed === null) {
         throw new TypeError("GitHub returned an invalid pull request page.");
       }
-      const createdAt = new Date(parsed.createdAt).getTime();
-      if (createdAt < previousCreatedAt) {
+      const updatedAt = new Date(parsed.candidate.providerUpdatedAt).getTime();
+      if (updatedAt > previousUpdatedAt) {
         throw new TypeError(
-          "GitHub returned pull requests outside ascending created order."
+          "GitHub returned pull requests outside descending updated order."
         );
       }
-      previousCreatedAt = createdAt;
+      previousUpdatedAt = updatedAt;
+      if (updatedAt < input.updatedSinceAt.getTime()) {
+        reachedCutoff = true;
+        continue;
+      }
       const { candidate } = parsed;
       const existing = pullRequests.get(candidate.nodeId);
       if (
@@ -473,6 +513,9 @@ export const collectGitHubPullRequestBackfillCandidates = async (input: {
         throw new TypeError("GitHub returned conflicting pull requests.");
       }
       pullRequests.set(candidate.nodeId, candidate);
+    }
+    if (reachedCutoff) {
+      return { complete: true, pullRequests: [...pullRequests.values()] };
     }
     const next = nextGitHubPage(response);
     if (next !== null) {
@@ -491,7 +534,7 @@ export type GitHubPullRequestBackfillStopReason =
 
 export interface GitHubPullRequestBackfillResult {
   authoredPullRequestPages: number;
-  authoredPullRequests: number;
+  authoredPullRequestsLifetime: number;
   commits: number;
   complete: boolean;
   duplicateCommits: number;
@@ -500,8 +543,11 @@ export interface GitHubPullRequestBackfillResult {
   repositories: number;
   retryAt: Date | null;
   scannedPullRequests: number;
+  selectedAuthoredPullRequests: number;
   skippedPullRequests: number;
   stopReason: GitHubPullRequestBackfillStopReason;
+  unavailablePullRequests: number;
+  unavailableRepositories: number;
 }
 
 interface PreparedPullRequest {
@@ -512,7 +558,7 @@ interface PreparedPullRequest {
 
 const emptyResult = (): GitHubPullRequestBackfillResult => ({
   authoredPullRequestPages: 0,
-  authoredPullRequests: 0,
+  authoredPullRequestsLifetime: 0,
   commits: 0,
   complete: true,
   duplicateCommits: 0,
@@ -521,12 +567,33 @@ const emptyResult = (): GitHubPullRequestBackfillResult => ({
   repositories: 0,
   retryAt: null,
   scannedPullRequests: 0,
+  selectedAuthoredPullRequests: 0,
   skippedPullRequests: 0,
   stopReason: "complete",
+  unavailablePullRequests: 0,
+  unavailableRepositories: 0,
 });
 
 const isDeadlineError = (error: unknown) =>
   error instanceof GitHubRequestDeadlineError;
+
+const permanentlyUnavailableResource = (error: unknown) =>
+  error instanceof GitHubResponseError &&
+  !error.retryable &&
+  PERMANENT_RESOURCE_STATUSES.has(error.status);
+
+const pullRequestEvidenceIsUnavailable = (error: unknown) => {
+  if (permanentlyUnavailableResource(error)) {
+    return true;
+  }
+  if (error instanceof GitHubGraphQlResponseError) {
+    return !error.retryable || error.kind === "unresolved_merge_commit";
+  }
+  return (
+    error instanceof ActivityProcessingError &&
+    (error.code === "source_incomplete" || error.code === "source_invalid")
+  );
+};
 
 const withinInclusiveWindow = (
   commit: GitHubCommit,
@@ -543,23 +610,12 @@ export const githubPullRequestBelongsInBackfillWindow = (input: {
   pullRequest: Pick<GitHubPullRequest, "authorAccount" | "mergedAt">;
   sinceAt: Date;
   untilAt: Date;
-}) => {
-  const mergedAt =
-    input.pullRequest.mergedAt === null
-      ? null
-      : new Date(input.pullRequest.mergedAt);
-  return (
-    input.commits.some(
-      (commit) =>
-        commit.author === input.account &&
-        withinInclusiveWindow(commit, input.sinceAt, input.untilAt)
-    ) ||
-    (input.pullRequest.authorAccount === input.account &&
-      mergedAt !== null &&
-      mergedAt >= input.sinceAt &&
-      mergedAt <= input.untilAt)
+}) =>
+  input.commits.some(
+    (commit) =>
+      commit.author === input.account &&
+      withinInclusiveWindow(commit, input.sinceAt, input.untilAt)
   );
-};
 
 const withResolvedMergeCommits = async (
   prepared: readonly PreparedPullRequest[],
@@ -655,6 +711,24 @@ const persistPreparedPullRequests = async (
       result.memberships += 1;
     }
     result.pullRequests += 1;
+  }
+};
+
+const persistPreparedPullRequestsWithGaps = async (
+  prepared: readonly PreparedPullRequest[],
+  account: TrackedGitHubAccount,
+  result: GitHubPullRequestBackfillResult
+) => {
+  for (const item of prepared) {
+    try {
+      await persistPreparedPullRequests([item], account, result);
+    } catch (error) {
+      if (pullRequestEvidenceIsUnavailable(error)) {
+        result.unavailablePullRequests += 1;
+        continue;
+      }
+      throw error;
+    }
   }
 };
 
@@ -788,6 +862,10 @@ const processPullRequestCandidates = async (
           interrupted = { reason: "deadline", retryAt: null };
           break;
         }
+        if (pullRequestEvidenceIsUnavailable(error)) {
+          result.unavailablePullRequests += 1;
+          continue;
+        }
         const retry = providerRetryFrom(error);
         if (retry !== null) {
           interrupted = {
@@ -803,13 +881,13 @@ const processPullRequestCandidates = async (
     const unmerged = prepared.filter(
       ({ snapshot }) => !snapshot.pullRequest.merged
     );
-    await persistPreparedPullRequests(unmerged, input.account, result);
+    await persistPreparedPullRequestsWithGaps(unmerged, input.account, result);
     const merged = prepared.filter(
       ({ snapshot }) => snapshot.pullRequest.merged
     );
     if (merged.length > 0) {
       try {
-        await persistPreparedPullRequests(
+        await persistPreparedPullRequestsWithGaps(
           await withProviderRetryWait(
             async () =>
               await withResolvedMergeCommits(
@@ -826,11 +904,47 @@ const processPullRequestCandidates = async (
         if (isDeadlineError(error)) {
           return { reason: "deadline", retryAt: null };
         }
-        const retry = providerRetryFrom(error);
-        if (retry !== null) {
-          return { reason: "provider_retry", retryAt: retry.retryAt };
+        if (pullRequestEvidenceIsUnavailable(error)) {
+          for (const item of merged) {
+            try {
+              await persistPreparedPullRequestsWithGaps(
+                await withProviderRetryWait(
+                  async () =>
+                    await withResolvedMergeCommits(
+                      [item],
+                      input.token,
+                      input.deadlineAt
+                    ),
+                  input
+                ),
+                input.account,
+                result
+              );
+            } catch (candidateError) {
+              if (isDeadlineError(candidateError)) {
+                return { reason: "deadline", retryAt: null };
+              }
+              if (pullRequestEvidenceIsUnavailable(candidateError)) {
+                result.unavailablePullRequests += 1;
+                continue;
+              }
+              const candidateRetry = providerRetryFrom(candidateError);
+              if (candidateRetry !== null) {
+                return {
+                  reason: "provider_retry",
+                  retryAt: candidateRetry.retryAt,
+                };
+              }
+              throw candidateError;
+            }
+          }
+        } else {
+          const retry = providerRetryFrom(error);
+          if (retry !== null) {
+            return { reason: "provider_retry", retryAt: retry.retryAt };
+          }
+          throw error;
         }
-        throw error;
       }
     }
     if (interrupted !== null) {
@@ -865,7 +979,7 @@ export const backfillGitHubPullRequests = async (input: {
         await collectAccessibleGitHubRepositories(
           input.token,
           input.repositoryId,
-          { deadlineAt: input.deadlineAt }
+          { deadlineAt: input.deadlineAt, pushedSinceAt: input.sinceAt }
         ),
       input
     );
@@ -892,11 +1006,13 @@ export const backfillGitHubPullRequests = async (input: {
             account: input.account,
             deadlineAt: input.deadlineAt,
             token: input.token,
+            updatedSinceAt: input.sinceAt,
           }),
         input
       );
       result.authoredPullRequestPages = authored.pages;
-      result.authoredPullRequests = authored.totalCount;
+      result.authoredPullRequestsLifetime = authored.totalCount;
+      result.selectedAuthoredPullRequests = authored.pullRequests.length;
       mergeGitHubPullRequestBackfillCandidates(
         authoredCandidates,
         authored.pullRequests
@@ -953,12 +1069,31 @@ export const backfillGitHubPullRequests = async (input: {
             onRateLimitWait: input.onRateLimitWait,
             repository,
             token: input.token,
+            updatedSinceAt: input.sinceAt,
           }),
         input
       );
     } catch (error) {
       if (isDeadlineError(error)) {
         return stop(result, "deadline");
+      }
+      if (permanentlyUnavailableResource(error)) {
+        result.unavailableRepositories += 1;
+        const authoredRepositoryCandidates = [...authoredCandidates.values()]
+          .filter((candidate) => candidate.repositoryId === repository.id)
+          .toSorted(comparePullRequestCandidates);
+        for (const candidate of authoredRepositoryCandidates) {
+          authoredCandidates.delete(candidate.nodeId);
+        }
+        const interrupted = await processPullRequestCandidates(
+          authoredRepositoryCandidates,
+          input,
+          result
+        );
+        if (interrupted !== null) {
+          return stop(result, interrupted.reason, interrupted.retryAt);
+        }
+        continue;
       }
       const retry = providerRetryFrom(error);
       if (retry !== null) {

--- a/src/lib/github-reconciliation.ts
+++ b/src/lib/github-reconciliation.ts
@@ -64,8 +64,14 @@ const fetchPaginatedArray = async (
 export const collectAccessibleGitHubRepositories = async (
   token: string,
   repositoryId: string | null = null,
-  options: { deadlineAt?: number } = {}
+  options: { deadlineAt?: number; pushedSinceAt?: Date } = {}
 ) => {
+  if (
+    options.pushedSinceAt !== undefined &&
+    Number.isNaN(options.pushedSinceAt.getTime())
+  ) {
+    throw new RangeError("The GitHub repository activity cutoff is invalid.");
+  }
   if (repositoryId !== null) {
     const { payload } = await fetchJson(
       githubApiUrl(`/repositories/${encodeURIComponent(repositoryId)}`),
@@ -87,6 +93,22 @@ export const collectAccessibleGitHubRepositories = async (
   const values = await fetchPaginatedArray(url, token, options);
   const repositories = new Map<string, GitHubRepositoryFacts>();
   for (const value of values) {
+    if (options.pushedSinceAt !== undefined) {
+      const pushedAt = isObject(value) ? value.pushed_at : undefined;
+      if (pushedAt === null) {
+        continue;
+      }
+      const pushedDate =
+        typeof pushedAt === "string"
+          ? new Date(pushedAt)
+          : new Date(Number.NaN);
+      if (Number.isNaN(pushedDate.getTime())) {
+        throw new TypeError("GitHub returned an invalid repository push date.");
+      }
+      if (pushedDate < options.pushedSinceAt) {
+        continue;
+      }
+    }
     const repository = repositoryFactsFrom(value);
     if (repository === null) {
       throw new TypeError("GitHub returned an invalid repository response.");

--- a/tests/github-activity-audit.test.mjs
+++ b/tests/github-activity-audit.test.mjs
@@ -1,0 +1,621 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  githubActivityAuditArgumentsFrom,
+  githubActivityAuditExitCodeFromStatus,
+} from "../scripts/audit-github-activity.ts";
+import {
+  auditPublicGitHubActivityDays,
+  buildGitHubActivityAuditReport,
+  githubActivityAuditEvidenceFingerprint,
+  githubActivityAuditRequestFrom,
+  scopePublicGitHubActivityDays,
+} from "../src/lib/github-activity-audit.ts";
+
+const now = new Date("2026-08-30T12:00:00.000Z");
+
+const request = githubActivityAuditRequestFrom(
+  {
+    account: "f0rr0",
+    endDate: "2026-08-30",
+    startDate: "2026-08-01",
+  },
+  now
+);
+
+if (request === null) {
+  throw new Error("The GitHub activity audit test request is invalid.");
+}
+
+const repository = {
+  avatarUrl: null,
+  key: "repository-one",
+  label: "f0rr0/example",
+  url: "https://github.com/f0rr0/example",
+};
+
+const commit = {
+  additions: 10,
+  changedFiles: 2,
+  committedAt: "2026-08-30T10:00:00.000Z",
+  deletions: 3,
+  headline: "Add an audit contract",
+  id: "00000000-0000-4000-8000-000000000001",
+  languages: [],
+  providerFileCapReached: false,
+  summary: null,
+};
+
+const healthyDay = {
+  day: "2026-08-30",
+  items: [
+    {
+      commit,
+      id: commit.id,
+      kind: "commit",
+      occurredAt: commit.committedAt,
+      repository,
+    },
+  ],
+  totals: {
+    additions: 10,
+    deletions: 3,
+    issuesOpened: 0,
+    repositories: 1,
+  },
+};
+
+const healthyCommitEvidence = {
+  activityPublicId: commit.id,
+  additions: 10,
+  canonicalPublicId: null,
+  canonicalizedAt: new Date("2026-08-30T10:01:00.000Z"),
+  changedFiles: 2,
+  deletions: 3,
+  enrichmentState: "complete",
+  hiddenAt: null,
+  parentShas: ["a".repeat(40)],
+  publishedAt: new Date("2026-08-30T10:02:00.000Z"),
+  pullRequestDiscoveryState: "complete",
+  substantiveLoc: 13,
+  summaryComplete: true,
+};
+
+const emptyPipelineEvidence = {
+  earliestRetryAt: null,
+  pullRequestMembershipsPending: 0,
+  pullRequestMembershipsUnavailable: 0,
+  pullRequestReconciliationsPending: 0,
+  pullRequestReconciliationsUnavailable: 0,
+  pullRequestSignalsPending: 0,
+  pullRequestSignalsUnavailable: 0,
+  pushObservationsPending: 0,
+  pushObservationsUnavailable: 0,
+  summaryAttemptsPending: 0,
+  summaryAttemptsUnavailable: 0,
+};
+
+describe("GitHub activity audit", () => {
+  test("requires an explicit account and an inclusive window of at most 31 days", () => {
+    expect(
+      githubActivityAuditArgumentsFrom([
+        "--account",
+        "f0rr0",
+        "--start-date",
+        "2026-08-01",
+        "--end-date",
+        "2026-08-30",
+      ])
+    ).toEqual({
+      account: "f0rr0",
+      endDate: "2026-08-30",
+      startDate: "2026-08-01",
+    });
+    expect(() =>
+      githubActivityAuditArgumentsFrom([
+        "--account",
+        "f0rr0",
+        "--account",
+        "f0rr0",
+      ])
+    ).toThrow("arguments are invalid");
+    expect(
+      githubActivityAuditRequestFrom(
+        {
+          account: "f0rr0",
+          endDate: "2026-08-30",
+          startDate: "2026-07-30",
+        },
+        now
+      )
+    ).toBeNull();
+    expect(
+      githubActivityAuditRequestFrom(
+        {
+          account: "f0rr0",
+          endDate: "2026-08-30",
+          repositoryId: "123456789",
+          startDate: "2026-08-01",
+        },
+        now
+      )
+    ).toMatchObject({ repositoryId: "123456789" });
+  });
+
+  test("scopes rendered work and recomputes totals without unrelated repositories", () => {
+    const otherCommit = {
+      ...commit,
+      additions: 4,
+      deletions: 1,
+      id: "00000000-0000-4000-8000-000000000002",
+    };
+    const scoped = scopePublicGitHubActivityDays(
+      [
+        {
+          ...healthyDay,
+          items: [
+            ...healthyDay.items,
+            {
+              commit: otherCommit,
+              id: otherCommit.id,
+              kind: "commit",
+              occurredAt: otherCommit.committedAt,
+              repository: { ...repository, key: "repository-two" },
+            },
+          ],
+          totals: {
+            additions: 14,
+            deletions: 4,
+            issuesOpened: 0,
+            repositories: 2,
+          },
+        },
+      ],
+      new Set([commit.id])
+    );
+
+    expect(scoped).toEqual([healthyDay]);
+  });
+
+  test("verifies exact day totals and one repository-group count", () => {
+    expect(auditPublicGitHubActivityDays([healthyDay])).toEqual(
+      expect.arrayContaining([
+        { id: "day_addition_totals", ok: true, violations: 0 },
+        { id: "day_deletion_totals", ok: true, violations: 0 },
+        { id: "day_repository_totals", ok: true, violations: 0 },
+      ])
+    );
+
+    const badDay = {
+      ...healthyDay,
+      totals: { ...healthyDay.totals, additions: 11, repositories: 2 },
+    };
+    expect(auditPublicGitHubActivityDays([badDay])).toEqual(
+      expect.arrayContaining([
+        { id: "day_addition_totals", ok: false, violations: 1 },
+        { id: "day_repository_totals", ok: false, violations: 1 },
+      ])
+    );
+  });
+
+  test("treats published merge milestones and duplicate work as projection failures", () => {
+    const invalidDay = {
+      ...healthyDay,
+      items: [
+        ...healthyDay.items,
+        healthyDay.items[0],
+        {
+          id: "legacy-pr",
+          kind: "pull-request-merged",
+          occurredAt: "2026-08-30T11:00:00.000Z",
+          repository,
+        },
+      ],
+    };
+    const checks = auditPublicGitHubActivityDays([invalidDay]);
+    expect(checks).toEqual(
+      expect.arrayContaining([
+        {
+          id: "no_pull_request_merge_milestones",
+          ok: false,
+          violations: 1,
+        },
+        { id: "unique_work_sources", ok: false, violations: 1 },
+      ])
+    );
+  });
+
+  test("verifies rendered sources through the canonical non-merge gate", () => {
+    const report = buildGitHubActivityAuditReport(request, {
+      commits: [healthyCommitEvidence],
+      globalProjectionSourceIds: [commit.id],
+      issues: [],
+      legacyPullRequestMilestones: 4,
+      projectionDays: [healthyDay],
+      projectionError: null,
+    });
+
+    expect(report).toMatchObject({
+      coverage: {
+        evidence: "stored_postgresql_rows",
+        providerCompleteness: "not_assessed",
+      },
+      inventory: { legacyPullRequestMilestonesExcluded: 4 },
+      projection: {
+        expectedActivitySources: 1,
+        renderedActivitySources: 1,
+      },
+      status: "stored_projection_verified",
+    });
+    expect(report.coverage.statement).toContain(
+      "Provider completeness is not assessed"
+    );
+  });
+
+  test("compares the global projection while keeping inventory account-scoped", () => {
+    const otherAccountCommit = {
+      ...commit,
+      id: "00000000-0000-4000-8000-000000000002",
+    };
+    const report = buildGitHubActivityAuditReport(request, {
+      commits: [healthyCommitEvidence],
+      globalProjectionSourceIds: [commit.id, otherAccountCommit.id],
+      issues: [],
+      legacyPullRequestMilestones: 0,
+      projectionDays: [
+        {
+          ...healthyDay,
+          items: [
+            ...healthyDay.items,
+            {
+              commit: otherAccountCommit,
+              id: otherAccountCommit.id,
+              kind: "commit",
+              occurredAt: otherAccountCommit.committedAt,
+              repository,
+            },
+          ],
+          totals: {
+            additions: 20,
+            deletions: 6,
+            issuesOpened: 0,
+            repositories: 1,
+          },
+        },
+      ],
+      projectionError: null,
+    });
+
+    expect(report.status).toBe("stored_projection_verified");
+    expect(report.inventory.commitsObserved).toBe(1);
+    expect(report.projection).toMatchObject({
+      expectedActivitySources: 2,
+      renderedActivitySources: 2,
+    });
+  });
+
+  test("compares every rendered source instead of hiding unexpected rows", () => {
+    const unexpectedCommit = {
+      ...commit,
+      id: "00000000-0000-4000-8000-000000000002",
+    };
+    const report = buildGitHubActivityAuditReport(request, {
+      commits: [healthyCommitEvidence],
+      globalProjectionSourceIds: [commit.id],
+      issues: [],
+      legacyPullRequestMilestones: 0,
+      projectionDays: [
+        {
+          ...healthyDay,
+          items: [
+            ...healthyDay.items,
+            {
+              commit: unexpectedCommit,
+              id: unexpectedCommit.id,
+              kind: "commit",
+              occurredAt: unexpectedCommit.committedAt,
+              repository,
+            },
+          ],
+          totals: {
+            additions: 20,
+            deletions: 6,
+            issuesOpened: 0,
+            repositories: 1,
+          },
+        },
+      ],
+      projectionError: null,
+    });
+
+    expect(report.status).toBe("mismatch");
+    expect(report.checks).toContainEqual({
+      id: "exact_stored_activity_sources",
+      ok: false,
+      violations: 1,
+    });
+    expect(report.projection.renderedActivitySources).toBe(2);
+  });
+
+  test("marks projection query failures inconclusive with exit code 2", () => {
+    const report = buildGitHubActivityAuditReport(request, {
+      commits: [healthyCommitEvidence],
+      globalProjectionSourceIds: [commit.id],
+      issues: [],
+      legacyPullRequestMilestones: 0,
+      projectionDays: [],
+      projectionError: "DatabaseError",
+    });
+
+    expect(report.status).toBe("inconclusive");
+    expect(githubActivityAuditExitCodeFromStatus(report.status)).toBe(2);
+    expect(githubActivityAuditExitCodeFromStatus("mismatch")).toBe(1);
+    expect(
+      githubActivityAuditExitCodeFromStatus("stored_projection_verified")
+    ).toBe(0);
+  });
+
+  test("fingerprints stored evidence independent of row order", () => {
+    const secondCommit = {
+      ...healthyCommitEvidence,
+      activityPublicId: "00000000-0000-4000-8000-000000000003",
+    };
+    const forward = {
+      commits: [healthyCommitEvidence, secondCommit],
+      globalProjectionSourceIds: [secondCommit.activityPublicId, commit.id],
+      issues: [],
+      legacyPullRequestMilestones: 0,
+    };
+    const reversed = {
+      ...forward,
+      commits: forward.commits.toReversed(),
+      globalProjectionSourceIds: forward.globalProjectionSourceIds.toReversed(),
+    };
+
+    expect(githubActivityAuditEvidenceFingerprint(forward)).toBe(
+      githubActivityAuditEvidenceFingerprint(reversed)
+    );
+    expect(
+      githubActivityAuditEvidenceFingerprint({
+        ...forward,
+        commits: [
+          healthyCommitEvidence,
+          { ...secondCommit, summaryComplete: false },
+        ],
+      })
+    ).not.toBe(githubActivityAuditEvidenceFingerprint(forward));
+    expect(
+      githubActivityAuditEvidenceFingerprint({
+        ...forward,
+        globalProjectionSourceIds: [commit.id],
+      })
+    ).not.toBe(githubActivityAuditEvidenceFingerprint(forward));
+  });
+
+  test("reports a mismatch when an uncanonicalized commit reaches the projection", () => {
+    const report = buildGitHubActivityAuditReport(request, {
+      commits: [{ ...healthyCommitEvidence, canonicalizedAt: null }],
+      globalProjectionSourceIds: [],
+      issues: [],
+      legacyPullRequestMilestones: 0,
+      projectionDays: [healthyDay],
+      projectionError: null,
+    });
+
+    expect(report.status).toBe("mismatch");
+    expect(report.checks).toEqual(
+      expect.arrayContaining([
+        { id: "canonical_commit_gate", ok: false, violations: 1 },
+        { id: "exact_stored_activity_sources", ok: false, violations: 1 },
+      ])
+    );
+  });
+
+  test("fails readiness when stored work is still waiting for the pipeline", () => {
+    const report = buildGitHubActivityAuditReport(request, {
+      commits: [
+        {
+          ...healthyCommitEvidence,
+          activityPublicId: null,
+          canonicalizedAt: null,
+          publishedAt: null,
+          pullRequestDiscoveryState: "pending",
+          summaryComplete: false,
+        },
+      ],
+      globalProjectionSourceIds: [],
+      issues: [],
+      legacyPullRequestMilestones: 0,
+      projectionDays: [],
+      projectionError: null,
+    });
+
+    expect(report.status).toBe("pipeline_incomplete");
+    expect(report.pipeline).toMatchObject({
+      unsettledCommits: 1,
+      unsettledIssues: 0,
+    });
+  });
+
+  test("settles a projection with an explicit terminal PR-discovery gap", () => {
+    const report = buildGitHubActivityAuditReport(request, {
+      commits: [
+        {
+          ...healthyCommitEvidence,
+          pullRequestDiscoveryState: "unavailable",
+        },
+      ],
+      globalProjectionSourceIds: [commit.id],
+      issues: [],
+      legacyPullRequestMilestones: 0,
+      projectionDays: [healthyDay],
+      projectionError: null,
+    });
+
+    expect(report.status).toBe("stored_projection_verified");
+    expect(report.coverage.gaps).toMatchObject({
+      pullRequestDiscoveryUnavailable: 1,
+      total: 1,
+    });
+    expect(report.pipeline).toMatchObject({
+      pullRequestDiscoveryIncomplete: 0,
+      unsettledCommits: 0,
+    });
+  });
+
+  test("settles missing commit enrichment as a visible coverage gap", () => {
+    const report = buildGitHubActivityAuditReport(request, {
+      commits: [
+        {
+          ...healthyCommitEvidence,
+          activityPublicId: null,
+          additions: null,
+          canonicalizedAt: null,
+          changedFiles: null,
+          deletions: null,
+          enrichmentState: "unavailable",
+          parentShas: null,
+          publishedAt: null,
+          substantiveLoc: null,
+          summaryComplete: false,
+        },
+      ],
+      globalProjectionSourceIds: [],
+      issues: [],
+      legacyPullRequestMilestones: 0,
+      projectionDays: [],
+      projectionError: null,
+    });
+
+    expect(report.status).toBe("stored_projection_verified");
+    expect(report.coverage.gaps).toMatchObject({
+      commitEnrichmentUnavailable: 1,
+      total: 1,
+    });
+    expect(report.pipeline).toMatchObject({
+      enrichmentIncomplete: 0,
+      unsettledCommits: 0,
+    });
+  });
+
+  test("keeps every scoped retryable queue state pipeline-incomplete with its earliest retry", () => {
+    const earliestRetryAt = new Date("2026-08-30T12:05:00.000Z");
+    const report = buildGitHubActivityAuditReport(request, {
+      commits: [healthyCommitEvidence],
+      globalProjectionSourceIds: [commit.id],
+      issues: [],
+      legacyPullRequestMilestones: 0,
+      pipelineEvidence: {
+        ...emptyPipelineEvidence,
+        earliestRetryAt,
+        pullRequestMembershipsPending: 1,
+        pullRequestReconciliationsPending: 1,
+        pullRequestSignalsPending: 1,
+        pushObservationsPending: 1,
+        summaryAttemptsPending: 1,
+      },
+      projectionDays: [healthyDay],
+      projectionError: null,
+    });
+
+    expect(report.status).toBe("pipeline_incomplete");
+    expect(report.pipeline).toMatchObject({
+      earliestRetryAt: earliestRetryAt.toISOString(),
+      pullRequestMembershipsPending: 1,
+      pullRequestReconciliationsPending: 1,
+      pullRequestSignalsPending: 1,
+      pushObservationsPending: 1,
+      summaryAttemptsPending: 1,
+    });
+  });
+
+  test("reports terminal queue failures as gaps without keeping the pipeline alive", () => {
+    const report = buildGitHubActivityAuditReport(request, {
+      commits: [healthyCommitEvidence],
+      globalProjectionSourceIds: [commit.id],
+      issues: [],
+      legacyPullRequestMilestones: 0,
+      pipelineEvidence: {
+        ...emptyPipelineEvidence,
+        pullRequestMembershipsUnavailable: 1,
+        pullRequestReconciliationsUnavailable: 1,
+        pullRequestSignalsUnavailable: 1,
+        pushObservationsUnavailable: 1,
+      },
+      projectionDays: [healthyDay],
+      projectionError: null,
+    });
+
+    expect(report.status).toBe("stored_projection_verified");
+    expect(report.coverage.gaps).toEqual({
+      commitEnrichmentUnavailable: 0,
+      pullRequestDiscoveryUnavailable: 0,
+      pullRequestMembershipsUnavailable: 1,
+      pullRequestReconciliationsUnavailable: 1,
+      pullRequestSignalsUnavailable: 1,
+      pushObservationsUnavailable: 1,
+      summaryAttemptsUnavailable: 0,
+      total: 4,
+    });
+    expect(report.pipeline.earliestRetryAt).toBeNull();
+  });
+
+  test("settles a terminal summary failure as a coverage gap", () => {
+    const report = buildGitHubActivityAuditReport(request, {
+      commits: [
+        {
+          ...healthyCommitEvidence,
+          publishedAt: null,
+          summaryComplete: false,
+          summaryUnavailable: true,
+        },
+      ],
+      globalProjectionSourceIds: [],
+      issues: [],
+      legacyPullRequestMilestones: 0,
+      pipelineEvidence: {
+        ...emptyPipelineEvidence,
+        summaryAttemptsUnavailable: 1,
+      },
+      projectionDays: [],
+      projectionError: null,
+    });
+
+    expect(report.status).toBe("stored_projection_verified");
+    expect(report.coverage.gaps).toMatchObject({
+      summaryAttemptsUnavailable: 1,
+      total: 1,
+    });
+    expect(report.pipeline).toMatchObject({
+      summaryAttemptsPending: 0,
+      summaryIncomplete: 0,
+      unsettledCommits: 0,
+    });
+  });
+
+  test("does not wait for irrelevant PR discovery on excluded integration commits", () => {
+    const report = buildGitHubActivityAuditReport(request, {
+      commits: [
+        {
+          ...healthyCommitEvidence,
+          canonicalPublicId: null,
+          parentShas: ["a".repeat(40), "b".repeat(40)],
+          publishedAt: null,
+          pullRequestDiscoveryState: "pending",
+          summaryComplete: false,
+        },
+      ],
+      globalProjectionSourceIds: [],
+      issues: [],
+      legacyPullRequestMilestones: 0,
+      projectionDays: [],
+      projectionError: null,
+    });
+
+    expect(report.status).toBe("stored_projection_verified");
+    expect(report.pipeline).toMatchObject({
+      integrationCommitsExcluded: 1,
+      unsettledCommits: 0,
+    });
+  });
+});

--- a/tests/github-activity-feed-postgres.test.mjs
+++ b/tests/github-activity-feed-postgres.test.mjs
@@ -38,6 +38,7 @@ const activityIds = {
   previousDay: "00000000-0000-4000-8000-000000000006",
   postSnapshot: "00000000-0000-4000-8000-000000000007",
   summaryEligible: "00000000-0000-4000-8000-000000000020",
+  uncanonicalized: "00000000-0000-4000-8000-000000000040",
 };
 
 const shas = {
@@ -49,6 +50,7 @@ const shas = {
   previousDay: "d".repeat(40),
   postSnapshot: "e".repeat(40),
   summaryEligible: `${"0".repeat(39)}2`,
+  uncanonicalized: `${"0".repeat(39)}3`,
 };
 
 const versionIds = {
@@ -85,6 +87,7 @@ describe.skipIf(!dockerAvailable)(
     let ensureGitHubSummaryAttempt;
     let ensureGitHubEvidenceIntegrity;
     let ensureMissingGitHubSummaryAttempts;
+    let getDatabase;
     let inspectGitHubEvidenceRecovery;
     let originalCronSecret;
     let originalDatabaseUrl;
@@ -92,10 +95,12 @@ describe.skipIf(!dockerAvailable)(
     let beginGitHubEventPoll;
     let finishGitHubRefReconciliationLease;
     let persistAccountIntake;
+    let persistGitHubPullRequestMembership;
     let persistGitHubPullRequestSnapshot;
     let persistGitHubRepositoryRefPage;
     let persistGitHubWebhookPullRequest;
     let persistGitHubWebhookPush;
+    let pullRequestFromGitHub;
     let readGitHubAccountCheckpoint;
     let readPublicGitHubActivityPage;
     let releaseGitHubCommitEnrichment;
@@ -105,6 +110,7 @@ describe.skipIf(!dockerAvailable)(
     let releaseGitHubPushObservation;
     let releaseGitHubSummaryAttempt;
     let repairLegacyGitHubEvidence;
+    let runGitHubActivityWorker;
 
     beforeAll(async () => {
       originalCronSecret = env.CRON_SECRET;
@@ -170,7 +176,11 @@ describe.skipIf(!dockerAvailable)(
 
       env.CRON_SECRET = "github-activity-cursor-test-secret";
       env.DATABASE_URL = databaseUrl;
-      ({ closeDatabase } = await import("../src/db/client.ts"));
+      ({ closeDatabase, getDatabase } = await import("../src/db/client.ts"));
+      ({ runGitHubActivityWorker } =
+        await import("../src/lib/github-activity-worker.ts"));
+      ({ pullRequestFromGitHub } =
+        await import("../src/lib/github-commits-core.ts"));
       ({ readPublicGitHubActivityPage } =
         await import("../src/lib/github-activity-store.ts"));
       ({
@@ -187,6 +197,7 @@ describe.skipIf(!dockerAvailable)(
         ensureGitHubSummaryAttempt,
         ensureMissingGitHubSummaryAttempts,
         inspectGitHubEvidenceRecovery,
+        persistGitHubPullRequestMembership,
         persistGitHubPullRequestSnapshot,
         releaseGitHubCommitEnrichment,
         releaseGitHubPullRequestDiscovery,
@@ -226,6 +237,438 @@ describe.skipIf(!dockerAvailable)(
           stderr: "ignore",
           stdout: "ignore",
         });
+      }
+    });
+
+    test("reads each public page in one repeatable-read transaction", async () => {
+      const database = getDatabase();
+      const originalTransaction = database.transaction;
+      let observedConfiguration = null;
+      database.transaction = async function transaction(
+        operation,
+        configuration
+      ) {
+        observedConfiguration = configuration;
+        return await originalTransaction.call(this, operation, configuration);
+      };
+
+      try {
+        const page = await readPublicGitHubActivityPage(null, 1);
+        expect(page.days).toEqual([]);
+      } finally {
+        database.transaction = originalTransaction;
+      }
+
+      expect(observedConfiguration).toEqual({
+        accessMode: "read only",
+        isolationLevel: "repeatable read",
+      });
+    });
+
+    test("persists tracked PR member commits before completing live reconciliation", async () => {
+      const originalFetch = globalThis.fetch;
+      const originalF0rr0Token = env.GITHUB_F0RR0_TOKEN;
+      const repositoryId = "601";
+      const repository = "f0rr0/live-pr-membership";
+      const pullRequestNodeId = "PR_live_membership_160";
+      const baseSha = "5".repeat(40);
+      const headSha = "6".repeat(40);
+      const mergeSha = "7".repeat(40);
+      const restRepository = {
+        full_name: repository,
+        html_url: `https://github.com/${repository}`,
+        id: Number(repositoryId),
+        owner: { id: 101, login: "f0rr0", type: "User" },
+        private: true,
+        visibility: "private",
+      };
+      const restPullRequest = {
+        base: { ref: "main", repo: restRepository, sha: baseSha },
+        body: null,
+        closed_at: "2026-08-30T20:01:00.000Z",
+        commits: 1,
+        created_at: "2026-08-30T19:00:00.000Z",
+        draft: false,
+        head: {
+          ref: "fix/live-membership",
+          repo: restRepository,
+          sha: headSha,
+        },
+        html_url: `https://github.com/${repository}/pull/160`,
+        id: 60_160,
+        merge_commit_sha: mergeSha,
+        merged: true,
+        merged_at: "2026-08-30T20:01:00.000Z",
+        node_id: pullRequestNodeId,
+        number: 160,
+        state: "closed",
+        title: "Keep a just-merged head visible",
+        updated_at: "2026-08-30T20:01:00.000Z",
+        user: { id: 101, login: "f0rr0" },
+      };
+
+      try {
+        const pullRequest = pullRequestFromGitHub(
+          restPullRequest,
+          { fullName: repository, id: repositoryId },
+          "closed"
+        );
+        expect(pullRequest).not.toBeNull();
+        await persistGitHubPullRequestSnapshot(
+          "f0rr0",
+          pullRequest,
+          { refreshMembership: true },
+          new Date(Date.now() - 60_000)
+        );
+        await admin`
+          alter table github_pull_request_memberships
+          add constraint test_live_membership_commit_fk
+          foreign key (commit_repository_id, commit_sha)
+          references github_commits (repository_id, sha)
+        `;
+
+        env.GITHUB_F0RR0_TOKEN = "worker-live-membership-test-token";
+        globalThis.fetch = async (input) => {
+          const url = new URL(input instanceof Request ? input.url : input);
+          if (url.pathname === "/graphql") {
+            return Response.json({
+              data: {
+                nodes: [
+                  {
+                    __typename: "PullRequest",
+                    id: pullRequestNodeId,
+                    mergeCommit: { oid: mergeSha },
+                    merged: true,
+                  },
+                ],
+              },
+            });
+          }
+          if (url.pathname === "/repos/f0rr0/live-pr-membership/pulls/160") {
+            return Response.json(restPullRequest);
+          }
+          if (
+            url.pathname === "/repos/f0rr0/live-pr-membership/pulls/160/commits"
+          ) {
+            return Response.json([
+              {
+                author: { id: 101, login: "f0rr0" },
+                commit: {
+                  committer: { date: "2026-08-30T20:00:00.000Z" },
+                  message: "fix: keep live work visible",
+                },
+                sha: headSha,
+              },
+            ]);
+          }
+          return Response.json({ message: "not found" }, { status: 404 });
+        };
+
+        const result = await runGitHubActivityWorker({
+          commitLimit: 1,
+          maximumDurationMs: 10_000,
+          observationLimit: 1,
+          pullRequestDiscoveryLimit: 1,
+          pullRequestLimit: 1,
+          pullRequestSignalLimit: 1,
+          summaryLimit: 1,
+        });
+
+        expect(result.pullRequests).toEqual({
+          claimed: 1,
+          completed: 1,
+          deferred: 0,
+          failed: 0,
+          unavailable: 0,
+        });
+        const [storedHead] = await admin`
+          select author_login, message
+          from github_commits
+          where repository_id = ${repositoryId} and sha = ${headSha}
+        `;
+        expect(storedHead).toEqual({
+          author_login: "f0rr0",
+          message: "fix: keep live work visible",
+        });
+        const [membership] = await admin`
+          select m.commit_repository_id, m.commit_sha, m.is_head,
+                 v.membership_complete
+          from github_pull_request_memberships m
+          join github_pull_request_versions v on v.id = m.version_id
+          where v.pull_request_node_id = ${pullRequestNodeId}
+        `;
+        expect(membership).toEqual({
+          commit_repository_id: repositoryId,
+          commit_sha: headSha,
+          is_head: true,
+          membership_complete: true,
+        });
+      } finally {
+        globalThis.fetch = originalFetch;
+        if (originalF0rr0Token === undefined) {
+          delete env.GITHUB_F0RR0_TOKEN;
+        } else {
+          env.GITHUB_F0RR0_TOKEN = originalF0rr0Token;
+        }
+        await admin`
+          alter table github_pull_request_memberships
+          drop constraint if exists test_live_membership_commit_fk
+        `;
+        await admin`
+          delete from github_pull_requests
+          where node_id = ${pullRequestNodeId}
+        `;
+        await admin`
+          delete from github_public_activities
+          where repository_id = ${repositoryId}
+        `;
+        await admin`
+          delete from github_commits
+          where repository_id = ${repositoryId}
+        `;
+        await admin`
+          delete from github_repositories
+          where id = ${repositoryId}
+        `;
+        expect(
+          await admin`
+            select
+              (select count(*)::integer from github_commits) as commits,
+              (select count(*)::integer from github_public_activities) as public,
+              (select count(*)::integer from github_summary_attempts) as summaries
+          `
+        ).toEqual([{ commits: 0, public: 0, summaries: 0 }]);
+      }
+    });
+
+    test("re-invalidates prior-version members when delayed PR membership arrives", async () => {
+      const repositoryId = "602";
+      const repository = "f0rr0/versioned-membership-invalidation";
+      const pullRequestNodeId = "PR_versioned_membership_invalidation";
+      const baseSha = "1".repeat(40);
+      const oldSha = `${"a".repeat(39)}1`;
+      const newSha = `${"b".repeat(39)}1`;
+      const oldActivityId = "00000000-0000-4000-8000-000000000602";
+      const newActivityId = "00000000-0000-4000-8000-000000000603";
+      const changeFingerprint = "c".repeat(64);
+      const repositoryFacts = {
+        fullName: repository,
+        htmlUrl: `https://github.com/${repository}`,
+        id: repositoryId,
+        ownerAvatarUrl: null,
+        ownerId: "101",
+        ownerLogin: "f0rr0",
+        ownerType: "User",
+        visibility: "public",
+      };
+      const versionOne = {
+        action: "synchronize",
+        additions: null,
+        author: "f0rr0",
+        authorAccount: "f0rr0",
+        authorUserId: "101",
+        baseRef: "main",
+        baseRepository: repositoryFacts,
+        baseSha,
+        body: null,
+        changedFiles: null,
+        closedAt: null,
+        commitCount: 1,
+        createdAt: "2026-08-30T08:00:00.000Z",
+        deletions: null,
+        draft: false,
+        headRef: "feature",
+        headRepository: repositoryFacts,
+        headSha: oldSha,
+        id: "602",
+        mergeCommitSha: null,
+        merged: false,
+        mergedAt: null,
+        nodeId: pullRequestNodeId,
+        number: 602,
+        providerUpdatedAt: "2026-08-30T10:00:00.000Z",
+        repository: repositoryFacts,
+        state: "open",
+        title: "Preserve aliases across force-push membership refreshes",
+        url: `https://github.com/${repository}/pull/602`,
+      };
+
+      try {
+        const storedVersionOne = await persistGitHubPullRequestSnapshot(
+          "f0rr0",
+          versionOne,
+          { refreshMembership: true },
+          new Date("2026-08-30T10:00:00.000Z")
+        );
+        expect(storedVersionOne).not.toBeNull();
+        await admin`
+          insert into github_public_activities (
+            public_id, kind, occurred_at, repository_id, revision,
+            source_node_id
+          ) values
+            (
+              ${oldActivityId}, 'commit', '2026-08-30T10:00:00.000Z',
+              ${repositoryId}, 1, ${oldSha}
+            ),
+            (
+              ${newActivityId}, 'commit', '2026-08-30T11:00:00.000Z',
+              ${repositoryId}, 1, ${newSha}
+            )
+        `;
+        await admin`
+          insert into github_commits (
+            activity_public_id, author_login, authored_at, author_user_id,
+            change_fingerprint, committed_at, committer_at, enrichment_state,
+            fingerprint_complete, first_observed_at, full_message, message,
+            parent_shas, pr_discovery_state, repository, repository_id, sha
+          ) values
+            (
+              ${oldActivityId}, 'f0rr0', '2026-08-30T09:30:00.000Z', '101',
+              ${changeFingerprint}, '2026-08-30T10:00:00.000Z',
+              '2026-08-30T10:00:00.000Z', 'complete', true,
+              '2026-08-30T10:00:00.000Z', 'Implement the durable change',
+              'Implement the durable change', ${JSON.stringify([
+                "2".repeat(40),
+              ])}::jsonb, 'complete', ${repository}, ${repositoryId}, ${oldSha}
+            ),
+            (
+              ${newActivityId}, 'f0rr0', '2026-08-30T09:30:00.000Z', '101',
+              ${changeFingerprint}, '2026-08-30T09:00:00.000Z',
+              '2026-08-30T09:00:00.000Z', 'complete', true,
+              '2026-08-30T11:00:00.000Z', 'Implement the durable change',
+              'Implement the durable change', ${JSON.stringify([
+                "3".repeat(40),
+              ])}::jsonb, 'complete', ${repository}, ${repositoryId}, ${newSha}
+            )
+        `;
+        expect(
+          await persistGitHubPullRequestMembership(
+            storedVersionOne,
+            oldSha,
+            [oldSha],
+            true
+          )
+        ).toBe(true);
+        expect(
+          await canonicalizeGitHubCommitActivity(
+            repositoryId,
+            oldSha,
+            new Date("2026-08-30T10:30:00.000Z")
+          )
+        ).toEqual({
+          aliased: false,
+          aliases: 0,
+          publicId: oldActivityId,
+        });
+
+        const storedVersionTwo = await persistGitHubPullRequestSnapshot(
+          "f0rr0",
+          {
+            ...versionOne,
+            headSha: newSha,
+            providerUpdatedAt: "2026-08-30T11:00:00.000Z",
+          },
+          { refreshMembership: true },
+          new Date("2026-08-30T11:00:00.000Z")
+        );
+        expect(storedVersionTwo).not.toBeNull();
+        expect(storedVersionTwo.versionId).not.toBe(storedVersionOne.versionId);
+
+        // A retry can canonicalize the V1 member before V2's member list has
+        // arrived. Persisting V2 membership must invalidate that stale result.
+        expect(
+          await canonicalizeGitHubCommitActivity(
+            repositoryId,
+            oldSha,
+            new Date("2026-08-30T11:01:00.000Z")
+          )
+        ).toEqual({
+          aliased: false,
+          aliases: 0,
+          publicId: oldActivityId,
+        });
+        expect(
+          await persistGitHubPullRequestMembership(
+            storedVersionTwo,
+            newSha,
+            [newSha],
+            true
+          )
+        ).toBe(true);
+        expect(
+          await admin`
+            select canonicalized_at, sha
+            from github_commits
+            where repository_id = ${repositoryId}
+            order by sha
+          `
+        ).toEqual([
+          { canonicalized_at: null, sha: oldSha },
+          { canonicalized_at: null, sha: newSha },
+        ]);
+
+        expect(
+          await canonicalizeGitHubCommitActivity(
+            repositoryId,
+            oldSha,
+            new Date("2026-08-30T11:02:00.000Z")
+          )
+        ).toEqual({
+          aliased: true,
+          aliases: 1,
+          publicId: oldActivityId,
+        });
+        expect(
+          await canonicalizeGitHubCommitActivity(
+            repositoryId,
+            newSha,
+            new Date("2026-08-30T11:03:00.000Z")
+          )
+        ).toEqual({
+          aliased: false,
+          aliases: 0,
+          publicId: newActivityId,
+        });
+        expect(
+          await admin`
+            select alias_reason, canonical_public_id, public_id
+            from github_public_activities
+            where repository_id = ${repositoryId}
+            order by public_id
+          `
+        ).toEqual([
+          {
+            alias_reason: "pr_history_exact_copy",
+            canonical_public_id: newActivityId,
+            public_id: oldActivityId,
+          },
+          {
+            alias_reason: null,
+            canonical_public_id: null,
+            public_id: newActivityId,
+          },
+        ]);
+      } finally {
+        await admin`
+          delete from github_pull_requests
+          where node_id = ${pullRequestNodeId}
+        `;
+        await admin`
+          delete from github_public_activities
+          where public_id = ${oldActivityId}
+        `;
+        await admin`
+          delete from github_public_activities
+          where public_id = ${newActivityId}
+        `;
+        await admin`
+          delete from github_commits
+          where repository_id = ${repositoryId}
+        `;
+        await admin`
+          delete from github_repositories
+          where id = ${repositoryId}
+        `;
       }
     });
 
@@ -652,6 +1095,276 @@ describe.skipIf(!dockerAvailable)(
       await admin`
         delete from github_account_checkpoints where account = 'f0rr0'
       `;
+    });
+
+    test("scopes every manual worker stage to the account, window, and target PR members", async () => {
+      const targetRepositoryId = "8801";
+      const memberRepositoryId = "8802";
+      const unrelatedRepositoryId = "8803";
+      const versionId = "88000000-0000-4000-8000-000000000001";
+      const directSha = "1".repeat(40);
+      const memberSha = "2".repeat(40);
+      const unrelatedSha = "3".repeat(40);
+      const otherAccountSha = "4".repeat(40);
+      const outsideWindowSha = "5".repeat(40);
+      const now = new Date("2026-08-30T12:00:00.000Z");
+      const scope = {
+        repositoryId: targetRepositoryId,
+        sinceAt: new Date("2026-08-01T00:00:00.000Z"),
+        untilAt: new Date("2026-08-31T23:59:59.999Z"),
+      };
+
+      try {
+        await admin`
+          insert into github_account_checkpoints (account) values ('f0rr0')
+          on conflict (account) do nothing
+        `;
+        await admin`
+          insert into github_repositories (
+            first_observed_at, full_name, id, last_observed_at
+          ) values
+            ('2026-08-01T00:00:00.000Z', 'f0rr0/manual-scope-target', ${targetRepositoryId}, '2026-08-30T00:00:00.000Z'),
+            ('2026-08-01T00:00:00.000Z', 'fork/manual-scope-member', ${memberRepositoryId}, '2026-08-30T00:00:00.000Z'),
+            ('2026-08-01T00:00:00.000Z', 'f0rr0/manual-scope-unrelated', ${unrelatedRepositoryId}, '2026-08-30T00:00:00.000Z')
+        `;
+        await admin`
+          insert into github_commits (
+            author_login, committed_at, first_observed_at, message,
+            repository, repository_id, sha
+          ) values
+            ('f0rr0', '2026-08-10T10:00:00.000Z', '2026-08-10T10:00:00.000Z', 'feat: direct target', 'f0rr0/manual-scope-target', ${targetRepositoryId}, ${directSha}),
+            ('f0rr0', '2026-08-11T10:00:00.000Z', '2026-08-11T10:00:00.000Z', 'feat: PR member', 'fork/manual-scope-member', ${memberRepositoryId}, ${memberSha}),
+            ('f0rr0', '2026-08-09T10:00:00.000Z', '2026-08-09T10:00:00.000Z', 'feat: unrelated repo', 'f0rr0/manual-scope-unrelated', ${unrelatedRepositoryId}, ${unrelatedSha}),
+            ('yuppiestechdev', '2026-08-08T10:00:00.000Z', '2026-08-08T10:00:00.000Z', 'feat: other account', 'f0rr0/manual-scope-target', ${targetRepositoryId}, ${otherAccountSha}),
+            ('f0rr0', '2026-07-31T10:00:00.000Z', '2026-07-31T10:00:00.000Z', 'feat: outside window', 'f0rr0/manual-scope-target', ${targetRepositoryId}, ${outsideWindowSha})
+        `;
+        await admin`
+          insert into github_pull_requests (
+            account, author_login, author_user_id, created_at, node_id, number,
+            provider_updated_at, repository_id, state, title, title_snapshot, url
+          ) values
+            (
+              'f0rr0', 'f0rr0', '101', '2026-08-01T00:00:00.000Z',
+              'PR_manual_worker_scope', 8801, '2026-08-11T10:00:00.000Z',
+              ${targetRepositoryId}, 'open', 'Manual worker scope',
+              'Manual worker scope',
+              'https://github.com/f0rr0/manual-scope-target/pull/8801'
+            ),
+            (
+              'f0rr0', 'f0rr0', '101', '2026-07-01T00:00:00.000Z',
+              'PR_manual_worker_scope_old', 8800, '2026-07-31T10:00:00.000Z',
+              ${targetRepositoryId}, 'open', 'Old manual worker backlog',
+              'Old manual worker backlog',
+              'https://github.com/f0rr0/manual-scope-target/pull/8800'
+            )
+        `;
+        await admin`
+          update github_pull_requests
+          set next_reconcile_at = '2026-08-01T00:00:00.000Z'
+          where node_id = 'PR_manual_worker_scope_old'
+        `;
+        await admin`
+          insert into github_pull_request_versions (
+            base_repository_id, base_sha, commit_count, head_repository_id,
+            head_sha, id, is_current, membership_complete, merge_snapshot,
+            provider_updated_at, pull_request_node_id
+          ) values (
+            ${targetRepositoryId}, ${"a".repeat(40)}, 1, ${memberRepositoryId},
+            ${memberSha}, ${versionId}, true, true, false,
+            '2026-08-11T10:00:00.000Z', 'PR_manual_worker_scope'
+          )
+        `;
+        await admin`
+          insert into github_pull_request_memberships (
+            commit_repository_id, commit_sha, is_head, position, version_id
+          ) values (${memberRepositoryId}, ${memberSha}, true, 0, ${versionId})
+        `;
+        await admin`
+          insert into github_push_observations (
+            account, after_sha, before_sha, observed_at, ref_name,
+            repository_id, repository_name_snapshot, source, source_id, state
+          ) values (
+            'f0rr0', ${"6".repeat(40)}, ${"0".repeat(40)},
+            '2026-07-31T10:00:00.000Z', 'refs/heads/old-backlog',
+            ${targetRepositoryId}, 'f0rr0/manual-scope-target', 'events',
+            'manual-scope-old-observation', 'pending'
+          )
+        `;
+        await admin`
+          insert into github_push_observations (
+            account, after_sha, before_sha, observed_at, ref_name,
+            repository_id, repository_name_snapshot, source, source_id, state
+          ) values (
+            'f0rr0', ${"7".repeat(40)}, ${"0".repeat(40)},
+            '2026-09-02T10:00:00.000Z', 'refs/heads/future-backlog',
+            ${targetRepositoryId}, 'f0rr0/manual-scope-target', 'events',
+            'manual-scope-future-observation', 'pending'
+          )
+        `;
+        await admin`
+          insert into github_pull_request_signals (
+            account, action, event_id, number, observed_at, occurred_at,
+            repository_id, repository_name_snapshot, state
+          ) values (
+            'f0rr0', 'synchronize', '880000000', 8800,
+            '2026-07-31T10:00:00.000Z', '2026-07-31T10:00:00.000Z',
+            ${targetRepositoryId}, 'f0rr0/manual-scope-target', 'pending'
+          )
+        `;
+        await admin`
+          insert into github_pull_request_signals (
+            account, action, event_id, number, observed_at, occurred_at,
+            repository_id, repository_name_snapshot, state
+          ) values (
+            'f0rr0', 'synchronize', '880000001', 8801,
+            '2026-09-02T10:00:00.000Z', '2026-09-02T10:00:00.000Z',
+            ${targetRepositoryId}, 'f0rr0/manual-scope-target', 'pending'
+          )
+        `;
+
+        const enrichments = await claimGitHubCommitsForEnrichment(
+          8,
+          ["f0rr0"],
+          now,
+          scope
+        );
+        expect(
+          enrichments.map(({ repositoryId, sha }) => `${repositoryId}:${sha}`)
+        ).toEqual([
+          `${targetRepositoryId}:${directSha}`,
+          `${memberRepositoryId}:${memberSha}`,
+        ]);
+        for (const enrichment of enrichments) {
+          await releaseGitHubCommitEnrichment(enrichment);
+        }
+
+        await admin`
+          update github_commits
+          set enrichment_state = 'complete', parent_shas = '[]'::jsonb
+          where repository_id in (${targetRepositoryId}, ${memberRepositoryId}, ${unrelatedRepositoryId})
+        `;
+        const discoveries = await claimGitHubCommitsForPullRequestDiscovery(
+          8,
+          ["f0rr0"],
+          now,
+          scope
+        );
+        expect(
+          discoveries.map(({ repositoryId, sha }) => `${repositoryId}:${sha}`)
+        ).toEqual([
+          `${targetRepositoryId}:${directSha}`,
+          `${memberRepositoryId}:${memberSha}`,
+        ]);
+        for (const discovery of discoveries) {
+          await releaseGitHubPullRequestDiscovery(discovery);
+        }
+        await admin`
+          update github_commits
+          set pr_discovery_state = 'complete'
+          where (repository_id = ${targetRepositoryId} and sha = ${directSha})
+             or (repository_id = ${memberRepositoryId} and sha = ${memberSha})
+        `;
+
+        const drained = await runGitHubActivityWorker({
+          accounts: ["f0rr0"],
+          commitLimit: 8,
+          maximumDurationMs: 5000,
+          observationLimit: 8,
+          pullRequestDiscoveryLimit: 8,
+          pullRequestLimit: 8,
+          pullRequestSignalLimit: 8,
+          scope,
+          summaryLimit: 8,
+        });
+        expect(drained.deadlineReached).toBe(false);
+        expect(
+          [
+            drained.observations,
+            drained.commits,
+            drained.pullRequestDiscovery,
+            drained.pullRequestSignals,
+            drained.pullRequests,
+            drained.summaries,
+          ].reduce((total, stage) => total + stage.claimed, 0)
+        ).toBe(0);
+        expect(
+          await admin`
+            select author_login, committed_at, pr_discovery_state,
+              repository_id, sha
+            from github_commits
+            where (repository_id = ${unrelatedRepositoryId} and sha = ${unrelatedSha})
+               or (repository_id = ${targetRepositoryId} and sha in (${otherAccountSha}, ${outsideWindowSha}))
+            order by sha
+          `
+        ).toEqual([
+          {
+            author_login: "f0rr0",
+            committed_at: "2026-08-09 10:00:00+00",
+            pr_discovery_state: "pending",
+            repository_id: unrelatedRepositoryId,
+            sha: unrelatedSha,
+          },
+          {
+            author_login: "yuppiestechdev",
+            committed_at: "2026-08-08 10:00:00+00",
+            pr_discovery_state: "pending",
+            repository_id: targetRepositoryId,
+            sha: otherAccountSha,
+          },
+          {
+            author_login: "f0rr0",
+            committed_at: "2026-07-31 10:00:00+00",
+            pr_discovery_state: "pending",
+            repository_id: targetRepositoryId,
+            sha: outsideWindowSha,
+          },
+        ]);
+        expect(
+          await admin`
+            select next_reconcile_at, node_id
+            from github_pull_requests
+            where node_id = 'PR_manual_worker_scope_old'
+          `
+        ).toEqual([
+          {
+            next_reconcile_at: "2026-08-01 00:00:00+00",
+            node_id: "PR_manual_worker_scope_old",
+          },
+        ]);
+      } finally {
+        await admin`
+          delete from github_pull_request_signals
+          where event_id in ('880000000', '880000001')
+        `;
+        await admin`
+          delete from github_push_observations
+          where source_id in (
+            'manual-scope-old-observation',
+            'manual-scope-future-observation'
+          )
+        `;
+        await admin`
+          delete from github_pull_request_memberships where version_id = ${versionId}
+        `;
+        await admin`
+          delete from github_pull_request_versions where id = ${versionId}
+        `;
+        await admin`
+          delete from github_pull_requests
+          where node_id in ('PR_manual_worker_scope', 'PR_manual_worker_scope_old')
+        `;
+        await admin`
+          delete from github_commits
+          where repository_id in (${targetRepositoryId}, ${memberRepositoryId}, ${unrelatedRepositoryId})
+        `;
+        await admin`
+          delete from github_repositories
+          where id in (${targetRepositoryId}, ${memberRepositoryId}, ${unrelatedRepositoryId})
+        `;
+        await admin`
+          delete from github_account_checkpoints where account = 'f0rr0'
+        `;
+      }
     });
 
     test("releases deadline claims without spending retry attempts or backoff", async () => {
@@ -1351,7 +2064,10 @@ describe.skipIf(!dockerAvailable)(
       ).toEqual([
         { canonicalized_at: null, repository_id: baseRepository.id },
         { canonicalized_at: null, repository_id: headRepository.id },
-        { canonicalized_at: null, repository_id: headRepository.id },
+        {
+          canonicalized_at: "2026-08-29 10:00:00+00",
+          repository_id: headRepository.id,
+        },
       ]);
       const [storedPullRequest] = await admin`
         select head_repository_id, head_sha, next_reconcile_at,
@@ -1434,11 +2150,28 @@ describe.skipIf(!dockerAvailable)(
       `;
       expect(eventStoredPullRequest.head_sha).toBe(eventHeadSha);
       await admin`
+        delete from github_pull_requests where node_id = ${pullRequestNodeId}
+      `;
+      await admin`
+        delete from github_public_activities
+        where public_id in (
+          ${sourceActivityId}, ${baseAliasActivityId}, ${headAliasActivityId}
+        )
+      `;
+      await admin`
+        delete from github_commits
+        where repository_id in (${baseRepository.id}, ${headRepository.id})
+      `;
+      await admin`
+        delete from github_repositories
+        where id in (${baseRepository.id}, ${headRepository.id})
+      `;
+      await admin`
         delete from github_account_checkpoints where account = 'f0rr0'
       `;
     });
 
-    test("pages complete UTC days and projects only current complete PR membership", async () => {
+    test("given canonical work and legacy merge artifacts, returns only visible authored work", async () => {
       await admin.begin(async (transaction) => {
         await transaction`
         insert into github_repositories (
@@ -1509,6 +2242,13 @@ describe.skipIf(!dockerAvailable)(
             1, 0, 'complete', '[]'::jsonb,
             'Ordinary summary candidate', 'f0rr0/source', '101',
             ${shas.summaryEligible}, 1
+          ),
+          (
+            ${activityIds.uncanonicalized}, 99, 'f0rr0',
+            '2026-08-26T08:15:00.000Z', '2026-08-26T08:15:00.000Z',
+            1, 99, 'complete', '[]'::jsonb,
+            'Published before canonicalization', 'f0rr0/source', '101',
+            ${shas.uncanonicalized}, 198
           )
       `;
 
@@ -1550,6 +2290,11 @@ describe.skipIf(!dockerAvailable)(
         set parent_shas = '[]'::jsonb,
           canonicalized_at = '2026-08-28T08:45:00.000Z'
         where repository_id = '101' and sha = ${shas.summaryEligible}
+      `;
+        await transaction`
+        update github_commits
+        set parent_shas = '[]'::jsonb
+        where repository_id = '101' and sha = ${shas.uncanonicalized}
       `;
 
         await transaction`
@@ -1634,7 +2379,7 @@ describe.skipIf(!dockerAvailable)(
           ),
           (
             ${activityIds.mergedPullRequest}, 'pull_request',
-            '2026-08-28T11:00:00.000Z', '2026-08-28T13:00:00.000Z', '202', 1,
+            '2026-08-29T11:00:00.000Z', '2026-08-28T13:00:00.000Z', '202', 1,
             'PR_current'
           ),
           (
@@ -1659,6 +2404,11 @@ describe.skipIf(!dockerAvailable)(
             ${activityIds.summaryEligible}, 'commit',
             '2026-08-28T08:30:00.000Z', null, '101', 1,
             ${shas.summaryEligible}
+          ),
+          (
+            ${activityIds.uncanonicalized}, 'commit',
+            '2026-08-26T08:15:00.000Z', '2026-08-28T13:00:00.000Z', '101', 1,
+            ${shas.uncanonicalized}
           )
       `;
 
@@ -1695,6 +2445,11 @@ describe.skipIf(!dockerAvailable)(
           (
             ${activityIds.mergeOnlyDay}, '2026-08-28T13:00:00.000Z', 1,
             'complete', 'Octopus merge headline', 'Octopus merge summary'
+          ),
+          (
+            ${activityIds.uncanonicalized}, '2026-08-28T13:00:00.000Z', 1,
+            'complete', 'Uncanonicalized headline',
+            'Uncanonicalized summary'
           )
       `;
       });
@@ -1706,7 +2461,6 @@ describe.skipIf(!dockerAvailable)(
         additions: 12,
         deletions: 3,
         issuesOpened: 1,
-        pullRequestsMerged: 1,
         repositories: 2,
       });
       expect(firstPage.nextCursor).not.toBeNull();
@@ -1855,6 +2609,11 @@ describe.skipIf(!dockerAvailable)(
       const postSnapshotPublishedAtIso = postSnapshotPublishedAt.toISOString();
       await admin.begin(async (transaction) => {
         await transaction`
+        update github_commits
+        set canonicalized_at = ${postSnapshotPublishedAtIso}
+        where activity_public_id = ${activityIds.uncanonicalized}
+      `;
+        await transaction`
         insert into github_commits (
           activity_public_id, additions, author_login, committed_at,
           committer_at, changed_files, deletions, enrichment_state, languages,
@@ -1899,10 +2658,28 @@ describe.skipIf(!dockerAvailable)(
         additions: 3,
         deletions: 1,
         issuesOpened: 0,
-        pullRequestsMerged: 0,
         repositories: 1,
       });
       expect(secondPage.nextCursor).toBeNull();
+
+      const freshPage = await readPublicGitHubActivityPage(
+        {
+          beforeDay: "2026-08-27",
+          snapshotAt: new Date(
+            postSnapshotPublishedAt.getTime() + 1000
+          ).toISOString(),
+          version: 1,
+        },
+        1
+      );
+      expect(freshPage.days[0]?.day).toBe("2026-08-26");
+      expect(
+        freshPage.days[0]?.items.flatMap((item) =>
+          item.kind === "pull-request-commits"
+            ? item.commits.map(({ id }) => id)
+            : [item.id]
+        )
+      ).toContain(activityIds.uncanonicalized);
 
       const milestoneLease = new Date("2026-08-28T16:00:00.000Z");
       await admin`
@@ -2122,6 +2899,13 @@ describe.skipIf(!dockerAvailable)(
         next_reconcile_at: null,
         state: "merged",
       });
+      const newlyPublishedMergeMilestone = await admin`
+        select public_id
+        from github_public_activities
+        where kind = 'pull_request'
+          and source_node_id = 'PR_old_equal_terminal'
+      `;
+      expect(newlyPublishedMergeMilestone).toHaveLength(0);
 
       await admin`
         insert into github_pull_requests (
@@ -2980,7 +3764,6 @@ describe.skipIf(!dockerAvailable)(
         additions: 600,
         deletions: 60,
         issuesOpened: 0,
-        pullRequestsMerged: 0,
         repositories: 1,
       });
       expect(rewritePage.days[0]?.items).toMatchObject([
@@ -3000,6 +3783,23 @@ describe.skipIf(!dockerAvailable)(
           kind: "commit",
         },
       ]);
+    });
+
+    test("bounds the evidence preflight while its advisory lock is held", async () => {
+      await admin.begin(async (transaction) => {
+        await transaction`
+          select pg_advisory_xact_lock(
+            hashtextextended('github-evidence-recovery-v1', 0)
+          )
+        `;
+        const startedAt = Date.now();
+        await expect(
+          ensureGitHubEvidenceIntegrity(new Date(), {
+            deadlineAt: startedAt + 200,
+          })
+        ).rejects.toThrow();
+        expect(Date.now() - startedAt).toBeLessThan(1500);
+      });
     });
 
     test("repairs legacy merge evidence atomically and only once", async () => {

--- a/tests/github-activity-feed.test.mjs
+++ b/tests/github-activity-feed.test.mjs
@@ -50,7 +50,7 @@ describe("public GitHub activity projection", () => {
     ).toThrow("cursor is invalid");
   });
 
-  test("groups each repository's daily work under one header", () => {
+  test("given mixed work in one day, shows each repository once without merge milestones", () => {
     const portfolioRepository = {
       avatarUrl: null,
       key: "public:portfolio",
@@ -143,19 +143,7 @@ describe("public GitHub activity projection", () => {
               additions: 22,
               deletions: 6,
               issuesOpened: 1,
-              pullRequestsMerged: 1,
               repositories: 2,
-            },
-          },
-          {
-            day: "2026-08-27",
-            items: [],
-            totals: {
-              additions: 0,
-              deletions: 0,
-              issuesOpened: 0,
-              pullRequestsMerged: 1,
-              repositories: 1,
             },
           },
         ],
@@ -167,11 +155,9 @@ describe("public GitHub activity projection", () => {
     expect(html).toContain("Polish repository activity rows");
     expect(html).toContain("Document the worker contract");
     expect(html).toContain("Issue opened");
-    expect(html).toContain("1 pull request merged");
-    expect(html).not.toContain("Pull request work");
-    expect(html).not.toContain("Pull request merged");
+    expect(html).not.toMatch(/pull requests? (?:work|merged)/iu);
+    expect(html).toContain("Across 2 repositories");
     expect(html).toContain('aria-label="Activity for 2026-08-28"');
-    expect(html).not.toContain('aria-label="Activity for 2026-08-27"');
     expect(html.match(/<header(?:\s[^>]*)?>/gu)).toHaveLength(2);
 
     const portfolioGroup = '<article aria-label="f0rr0/portfolio activity">';

--- a/tests/github-activity-worker.test.mjs
+++ b/tests/github-activity-worker.test.mjs
@@ -1,6 +1,10 @@
 import { describe, expect, test } from "bun:test";
 
 import {
+  ActivityProcessingError,
+  GitHubGraphQlResponseError,
+} from "../src/lib/github-activity-processor.ts";
+import {
   boundedWorkerLimit,
   DEFAULT_GITHUB_ACTIVITY_WORKER_BATCH_SIZE,
   exactGitHubDiffDigest,
@@ -16,6 +20,83 @@ import {
   workerBatchSizeFrom,
   workerDeadlineReached,
 } from "../src/lib/github-activity-worker-core.ts";
+import {
+  GITHUB_ACTIVITY_TERMINAL_ATTEMPTS,
+  githubActivityFailureIsTerminal,
+} from "../src/lib/github-activity-worker.ts";
+import { GitHubResponseError } from "../src/lib/github-api.ts";
+
+describe("GitHub activity terminal gaps", () => {
+  test("given a deterministic REST gap, it becomes unavailable on the third worker claim", () => {
+    for (const status of [403, 404, 410, 422]) {
+      const error = new GitHubResponseError(status, { retryable: false });
+      expect(
+        githubActivityFailureIsTerminal(
+          error,
+          GITHUB_ACTIVITY_TERMINAL_ATTEMPTS - 1
+        )
+      ).toBe(false);
+      expect(
+        githubActivityFailureIsTerminal(
+          error,
+          GITHUB_ACTIVITY_TERMINAL_ATTEMPTS
+        )
+      ).toBe(true);
+    }
+  });
+
+  test("given rate-limit evidence, repeated REST or GraphQL failures stay retryable", () => {
+    expect(
+      githubActivityFailureIsTerminal(
+        new GitHubResponseError(403, { retryable: true }),
+        GITHUB_ACTIVITY_TERMINAL_ATTEMPTS + 10
+      )
+    ).toBe(false);
+    expect(
+      githubActivityFailureIsTerminal(
+        new GitHubGraphQlResponseError("rate_limited", { retryable: true }),
+        GITHUB_ACTIVITY_TERMINAL_ATTEMPTS + 10
+      )
+    ).toBe(false);
+  });
+
+  test("given repeatedly unusable provider evidence, it becomes a terminal coverage gap", () => {
+    expect(
+      githubActivityFailureIsTerminal(
+        new GitHubGraphQlResponseError("request_rejected", {
+          retryable: false,
+        }),
+        GITHUB_ACTIVITY_TERMINAL_ATTEMPTS
+      )
+    ).toBe(true);
+    expect(
+      githubActivityFailureIsTerminal(
+        new ActivityProcessingError("source_invalid", "invalid source"),
+        GITHUB_ACTIVITY_TERMINAL_ATTEMPTS
+      )
+    ).toBe(true);
+    for (const code of [
+      "membership_incomplete",
+      "source_auth_missing",
+      "source_incomplete",
+      "source_invalid",
+      "source_unavailable",
+    ]) {
+      expect(
+        githubActivityFailureIsTerminal(
+          new ActivityProcessingError(code, "unusable source"),
+          GITHUB_ACTIVITY_TERMINAL_ATTEMPTS - 1
+        )
+      ).toBe(false);
+      expect(
+        githubActivityFailureIsTerminal(
+          new ActivityProcessingError(code, "unusable source"),
+          GITHUB_ACTIVITY_TERMINAL_ATTEMPTS
+        )
+      ).toBe(true);
+    }
+  });
+});
 
 const commit = (files, overrides = {}) => {
   const additions = files.reduce((total, file) => total + file.additions, 0);

--- a/tests/github-backfill.test.mjs
+++ b/tests/github-backfill.test.mjs
@@ -1,13 +1,34 @@
 import { describe, expect, test } from "bun:test";
+import { setTimeout as delay } from "node:timers/promises";
 
-import { backfillArgumentsFrom } from "../scripts/backfill-github-activity.ts";
+import {
+  backfillArgumentsFrom,
+  backfillRetryWaitMillisecondsFrom,
+  runBeforeDeadline,
+} from "../scripts/backfill-github-activity.ts";
 import {
   GITHUB_BACKFILL_WORKER_BATCH_SIZE,
+  githubBackfillCompletionFrom,
+  githubBackfillDiscoveryCompleteFrom,
+  githubBackfillExitCodeFrom,
+  githubBackfillOutcomeFrom,
+  githubBackfillProcessingMadeProgress,
   githubBackfillProcessingCountsFrom,
   githubBackfillRequestFrom,
 } from "../src/lib/github-backfill-core.ts";
 
 const now = new Date("2026-08-29T15:00:00.000Z");
+
+const discoveryInventory = (overrides = {}) => ({
+  direct: { complete: true, unavailableRepositories: 0 },
+  pullRequests: { complete: true, unavailablePullRequests: 0 },
+  ...overrides,
+});
+
+const auditResult = (status, earliestRetryAt) => ({
+  pipeline: { earliestRetryAt },
+  status,
+});
 
 describe("GitHub history backfill requests", () => {
   test("rejects duplicate and unknown command arguments", () => {
@@ -21,6 +42,86 @@ describe("GitHub history backfill requests", () => {
 
   test("uses the maximum batch size accepted by every configurable worker stage", () => {
     expect(GITHUB_BACKFILL_WORKER_BATCH_SIZE).toBe(8);
+  });
+
+  test("exits successfully only after discovery and every scoped audit settle", () => {
+    const complete = githubBackfillCompletionFrom({
+      auditStatuses: [
+        "stored_projection_verified",
+        "stored_projection_verified",
+      ],
+      boundedDiscoveryComplete: true,
+    });
+    expect(complete).toEqual({ complete: true, pipelineSettled: true });
+    expect(githubBackfillExitCodeFrom(complete)).toBe(0);
+
+    for (const incomplete of [
+      githubBackfillCompletionFrom({
+        auditStatuses: ["stored_projection_verified"],
+        boundedDiscoveryComplete: false,
+      }),
+      ...["pipeline_incomplete", "mismatch", "inconclusive"].map((status) =>
+        githubBackfillCompletionFrom({
+          auditStatuses: ["stored_projection_verified", status],
+          boundedDiscoveryComplete: true,
+        })
+      ),
+      githubBackfillCompletionFrom({
+        auditStatuses: [],
+        boundedDiscoveryComplete: true,
+      }),
+    ]) {
+      expect(incomplete.complete).toBe(false);
+      expect(githubBackfillExitCodeFrom(incomplete)).toBe(1);
+    }
+  });
+
+  test("distinguishes a finished traversal with explicit coverage gaps", () => {
+    const complete = { complete: true, pipelineSettled: true };
+    expect(githubBackfillOutcomeFrom(complete, 0)).toBe("complete");
+    expect(githubBackfillOutcomeFrom(complete, 2)).toBe("completed_with_gaps");
+    expect(
+      githubBackfillOutcomeFrom({ complete: false, pipelineSettled: false }, 2)
+    ).toBe("incomplete");
+    expect(() => githubBackfillOutcomeFrom(complete, -1)).toThrow(
+      "coverage gap count"
+    );
+  });
+
+  test("reports traversal completion separately from explicit coverage gaps", () => {
+    expect(githubBackfillDiscoveryCompleteFrom([discoveryInventory()])).toBe(
+      true
+    );
+    expect(githubBackfillDiscoveryCompleteFrom([])).toBe(false);
+    expect(
+      githubBackfillDiscoveryCompleteFrom([
+        discoveryInventory({ direct: null }),
+      ])
+    ).toBe(false);
+    expect(
+      githubBackfillDiscoveryCompleteFrom([
+        discoveryInventory({
+          direct: { complete: true, unavailableRepositories: 1 },
+        }),
+      ])
+    ).toBe(true);
+    expect(
+      githubBackfillDiscoveryCompleteFrom([
+        discoveryInventory({
+          pullRequests: { complete: true, unavailablePullRequests: 1 },
+        }),
+      ])
+    ).toBe(true);
+    expect(
+      githubBackfillDiscoveryCompleteFrom([
+        discoveryInventory({ direct: { complete: false } }),
+      ])
+    ).toBe(false);
+    expect(
+      githubBackfillDiscoveryCompleteFrom([
+        discoveryInventory({ pullRequests: { complete: false } }),
+      ])
+    ).toBe(false);
   });
 
   test("reports disjoint outcomes across every stage including PR reconciliation", () => {
@@ -80,13 +181,65 @@ describe("GitHub history backfill requests", () => {
     });
   });
 
-  test("normalizes one arbitrary inclusive UTC range", () => {
+  test("keeps draining when canonicalization progresses without queue claims", () => {
+    expect(
+      githubBackfillProcessingMadeProgress({ aliases: 1, claimed: 0 })
+    ).toBe(true);
+    expect(
+      githubBackfillProcessingMadeProgress({ aliases: 0, claimed: 1 })
+    ).toBe(true);
+    expect(
+      githubBackfillProcessingMadeProgress({ aliases: 0, claimed: 0 })
+    ).toBe(false);
+  });
+
+  test("waits for a scoped retry only when it fits inside the hard budget", () => {
+    const nowAt = Date.parse("2026-08-30T00:00:00.000Z");
+    expect(
+      backfillRetryWaitMillisecondsFrom(
+        [auditResult("pipeline_incomplete", "2026-08-30T00:15:00.000Z")],
+        nowAt + 60 * 60 * 1000,
+        nowAt
+      )
+    ).toBe(15 * 60 * 1000);
+    expect(
+      backfillRetryWaitMillisecondsFrom(
+        [auditResult("pipeline_incomplete", "2026-08-29T23:59:00.000Z")],
+        nowAt + 60 * 60 * 1000,
+        nowAt
+      )
+    ).toBe(1000);
+    expect(
+      backfillRetryWaitMillisecondsFrom(
+        [auditResult("pipeline_incomplete", "2026-08-30T00:59:45.000Z")],
+        nowAt + 60 * 60 * 1000,
+        nowAt
+      )
+    ).toBeNull();
+    expect(
+      backfillRetryWaitMillisecondsFrom(
+        [auditResult("mismatch", "2026-08-30T00:15:00.000Z")],
+        nowAt + 60 * 60 * 1000,
+        nowAt
+      )
+    ).toBeNull();
+  });
+
+  test("ends an in-flight stage at the selected wall-clock deadline", async () => {
+    const startedAt = Date.now();
+    await expect(
+      runBeforeDeadline(delay(1000), startedAt + 25)
+    ).rejects.toThrow("deadline");
+    expect(Date.now() - startedAt).toBeLessThan(500);
+  });
+
+  test("normalizes one bounded inclusive UTC range", () => {
     const request = githubBackfillRequestFrom(
       {
         account: "all",
         endDate: "2026-08-29",
         repositoryId: "123456789",
-        startDate: "2026-07-01",
+        startDate: "2026-08-01",
       },
       now
     );
@@ -95,9 +248,9 @@ describe("GitHub history backfill requests", () => {
       accounts: ["f0rr0", "yuppiestechdev"],
       endDate: "2026-08-29",
       repositoryId: "123456789",
-      startDate: "2026-07-01",
+      startDate: "2026-08-01",
     });
-    expect(request?.sinceAt).toEqual(new Date("2026-07-01T00:00:00.000Z"));
+    expect(request?.sinceAt).toEqual(new Date("2026-08-01T00:00:00.000Z"));
     expect(request?.untilAt).toEqual(new Date("2026-08-29T23:59:59.999Z"));
   });
 
@@ -115,21 +268,55 @@ describe("GitHub history backfill requests", () => {
     ).toMatchObject({ accounts: ["f0rr0"], repositoryId: null });
   });
 
-  test("accepts a range longer than 366 days without splitting it", () => {
-    const request = githubBackfillRequestFrom(
-      {
-        account: "f0rr0",
-        endDate: "2026-08-29",
-        repositoryId: "",
-        startDate: "2024-01-01",
-      },
-      now
-    );
+  test("accepts at most 31 commit days per invocation", () => {
+    expect(
+      githubBackfillRequestFrom(
+        {
+          account: "f0rr0",
+          endDate: "2026-08-31",
+          repositoryId: "",
+          startDate: "2026-08-01",
+        },
+        new Date("2026-08-31T15:00:00.000Z")
+      )
+    ).not.toBeNull();
+    expect(
+      githubBackfillRequestFrom(
+        {
+          account: "f0rr0",
+          endDate: "2026-08-29",
+          repositoryId: "",
+          startDate: "2024-01-01",
+        },
+        now
+      )
+    ).toBeNull();
+  });
 
-    expect(request).toMatchObject({
-      endDate: "2026-08-29",
-      startDate: "2024-01-01",
-    });
+  test("bounds broad provider discovery while allowing older repository recovery", () => {
+    const oldScope = {
+      account: "f0rr0",
+      endDate: "2026-07-28",
+      startDate: "2026-06-28",
+    };
+
+    expect(
+      githubBackfillRequestFrom({ ...oldScope, repositoryId: "" }, now)
+    ).toBeNull();
+    expect(
+      githubBackfillRequestFrom({ ...oldScope, repositoryId: "123456789" }, now)
+    ).toMatchObject({ repositoryId: "123456789" });
+    expect(
+      githubBackfillRequestFrom(
+        {
+          account: "f0rr0",
+          endDate: "2026-07-29",
+          repositoryId: "",
+          startDate: "2026-06-29",
+        },
+        now
+      )
+    ).not.toBeNull();
   });
 
   test("accepts GitHub's documented final timestamp day", () => {

--- a/tests/github-direct-backfill.test.mjs
+++ b/tests/github-direct-backfill.test.mjs
@@ -34,6 +34,7 @@ const rawRepository = {
     type: repository.ownerType,
   },
   private: true,
+  pushed_at: "2026-08-20T00:00:00Z",
   visibility: repository.visibility,
 };
 
@@ -158,14 +159,103 @@ describe("direct GitHub ref backfill", () => {
     ).rejects.toThrow("invalid commit pagination");
   });
 
-  test("fails incomplete when a listed repository becomes inaccessible", async () => {
+  test("given listed repositories disappear or deny access, records gaps and continues", async () => {
+    const requestedPaths = [];
+    const forbiddenRepository = {
+      ...rawRepository,
+      full_name: "forbidden-org/forbidden-repo",
+      html_url: "https://github.com/forbidden-org/forbidden-repo",
+      id: 125,
+      owner: {
+        ...rawRepository.owner,
+        id: 458,
+        login: "forbidden-org",
+      },
+    };
+    const laterRepository = {
+      ...rawRepository,
+      full_name: "later-org/later-repo",
+      html_url: "https://github.com/later-org/later-repo",
+      id: 124,
+      owner: {
+        ...rawRepository.owner,
+        id: 457,
+        login: "later-org",
+      },
+    };
+    globalThis.fetch = async (input) => {
+      const url = new URL(input instanceof Request ? input.url : input);
+      requestedPaths.push(url.pathname);
+      if (url.pathname === "/user/repos") {
+        return Response.json([
+          laterRepository,
+          rawRepository,
+          forbiddenRepository,
+        ]);
+      }
+      if (url.pathname === "/repos/example-org/example-repo/branches") {
+        return Response.json({ message: "Not Found" }, { status: 404 });
+      }
+      if (url.pathname === "/repos/forbidden-org/forbidden-repo/branches") {
+        return Response.json({ message: "Forbidden" }, { status: 403 });
+      }
+      if (
+        url.pathname === "/repos/later-org/later-repo/branches" ||
+        url.pathname === "/repos/later-org/later-repo/tags"
+      ) {
+        return Response.json([]);
+      }
+      throw new Error(`Unexpected GitHub request: ${url.href}`);
+    };
+
+    const result = await backfillGitHubCommitsFromCurrentRefs({
+      account: "f0rr0",
+      deadlineAt: Date.now() + 120_000,
+      repositoryId: null,
+      sinceAt: new Date("2026-08-01T00:00:00.000Z"),
+      token: "test-token",
+      untilAt: new Date("2026-08-31T23:59:59.999Z"),
+    });
+
+    expect(result).toMatchObject({
+      complete: true,
+      repositories: 1,
+      stopReason: "complete",
+      unavailableRepositories: 2,
+    });
+    expect(requestedPaths).toEqual([
+      "/user/repos",
+      "/repos/example-org/example-repo/branches",
+      "/repos/forbidden-org/forbidden-repo/branches",
+      "/repos/later-org/later-repo/branches",
+      "/repos/later-org/later-repo/tags",
+    ]);
+  });
+
+  test("given one current head disappears, records the repository gap and scans the next head", async () => {
+    const unavailableHeadSha = "1".repeat(40);
+    const laterHeadSha = "2".repeat(40);
+    const requestedHeads = [];
     globalThis.fetch = async (input) => {
       const url = new URL(input instanceof Request ? input.url : input);
       if (url.pathname === "/user/repos") {
         return Response.json([rawRepository]);
       }
       if (url.pathname === "/repos/example-org/example-repo/branches") {
-        return Response.json({ message: "Not Found" }, { status: 404 });
+        return Response.json([
+          { commit: { sha: unavailableHeadSha }, name: "first" },
+          { commit: { sha: laterHeadSha }, name: "later" },
+        ]);
+      }
+      if (url.pathname === "/repos/example-org/example-repo/tags") {
+        return Response.json([]);
+      }
+      if (url.pathname === "/repos/example-org/example-repo/commits") {
+        const headSha = url.searchParams.get("sha");
+        requestedHeads.push(headSha);
+        return headSha === unavailableHeadSha
+          ? Response.json({ message: "Gone" }, { status: 410 })
+          : Response.json([]);
       }
       throw new Error(`Unexpected GitHub request: ${url.href}`);
     };
@@ -179,6 +269,94 @@ describe("direct GitHub ref backfill", () => {
         token: "test-token",
         untilAt: new Date("2026-08-31T23:59:59.999Z"),
       })
-    ).toMatchObject({ complete: false, stopReason: "provider_retry" });
+    ).toMatchObject({
+      complete: true,
+      heads: 1,
+      repositories: 1,
+      stopReason: "complete",
+      unavailableRepositories: 1,
+    });
+    expect(requestedHeads).toEqual([unavailableHeadSha, laterHeadSha]);
+  });
+
+  test("given current-head hydration is rate limited, leaves traversal incomplete without a gap", async () => {
+    const headSha = "3".repeat(40);
+    globalThis.fetch = async (input) => {
+      const url = new URL(input instanceof Request ? input.url : input);
+      if (url.pathname === "/user/repos") {
+        return Response.json([rawRepository]);
+      }
+      if (url.pathname === "/repos/example-org/example-repo/branches") {
+        return Response.json([{ commit: { sha: headSha }, name: "main" }]);
+      }
+      if (url.pathname === "/repos/example-org/example-repo/tags") {
+        return Response.json([]);
+      }
+      if (url.pathname === "/repos/example-org/example-repo/commits") {
+        return Response.json(
+          { message: "rate limited" },
+          { headers: { "retry-after": "120" }, status: 429 }
+        );
+      }
+      throw new Error(`Unexpected GitHub request: ${url.href}`);
+    };
+
+    expect(
+      await backfillGitHubCommitsFromCurrentRefs({
+        account: "f0rr0",
+        deadlineAt: Date.now() + 60_000,
+        repositoryId: null,
+        sinceAt: new Date("2026-08-01T00:00:00.000Z"),
+        token: "test-token",
+        untilAt: new Date("2026-08-31T23:59:59.999Z"),
+      })
+    ).toMatchObject({
+      complete: false,
+      stopReason: "provider_retry",
+      unavailableRepositories: 0,
+    });
+  });
+
+  test("keeps retryable provider failures and deadlines incomplete", async () => {
+    globalThis.fetch = async (input) => {
+      const url = new URL(input instanceof Request ? input.url : input);
+      if (url.pathname === "/user/repos") {
+        return Response.json([rawRepository]);
+      }
+      return Response.json(
+        { message: "rate limited" },
+        { headers: { "retry-after": "120" }, status: 429 }
+      );
+    };
+
+    expect(
+      await backfillGitHubCommitsFromCurrentRefs({
+        account: "f0rr0",
+        deadlineAt: Date.now() + 60_000,
+        repositoryId: null,
+        sinceAt: new Date("2026-08-01T00:00:00.000Z"),
+        token: "test-token",
+        untilAt: new Date("2026-08-31T23:59:59.999Z"),
+      })
+    ).toMatchObject({
+      complete: false,
+      stopReason: "provider_retry",
+      unavailableRepositories: 0,
+    });
+
+    expect(
+      await backfillGitHubCommitsFromCurrentRefs({
+        account: "f0rr0",
+        deadlineAt: Date.now() + 1,
+        repositoryId: null,
+        sinceAt: new Date("2026-08-01T00:00:00.000Z"),
+        token: "test-token",
+        untilAt: new Date("2026-08-31T23:59:59.999Z"),
+      })
+    ).toMatchObject({
+      complete: false,
+      stopReason: "deadline",
+      unavailableRepositories: 0,
+    });
   });
 });

--- a/tests/github-evidence-integrity.test.mjs
+++ b/tests/github-evidence-integrity.test.mjs
@@ -1,0 +1,13 @@
+import { describe, expect, test } from "bun:test";
+
+import { ensureGitHubEvidenceIntegrity } from "../src/lib/github-activity-worker-store.ts";
+
+describe("GitHub evidence integrity preflight", () => {
+  test("fails before opening a transaction when the backfill deadline expired", async () => {
+    await expect(
+      ensureGitHubEvidenceIntegrity(new Date("2026-08-30T00:00:00.000Z"), {
+        deadlineAt: Date.now() - 1,
+      })
+    ).rejects.toThrow("deadline was reached");
+  });
+});

--- a/tests/github-pull-request-backfill.test.mjs
+++ b/tests/github-pull-request-backfill.test.mjs
@@ -36,6 +36,7 @@ const rawRepository = {
     type: repository.ownerType,
   },
   private: true,
+  pushed_at: "2026-08-20T00:00:00Z",
   visibility: repository.visibility,
 };
 
@@ -65,12 +66,23 @@ const pullRequestValue = (
   user: { id: 900, login: "other-maintainer" },
 });
 
+const trackedPullRequestCommitValue = (sha) => ({
+  author: { login: "f0rr0" },
+  commit: {
+    author: { date: "2026-08-15T12:00:00Z" },
+    committer: { date: "2026-08-15T12:00:00Z" },
+    message: "feat: retain tracked work",
+  },
+  sha,
+});
+
 const authoredPullRequestNode = (
   number,
   {
     nodeId = `PR_authored_${String(number)}`,
     repositoryId = 5000 + number,
     repositoryName = `external-org/repository-${String(number)}`,
+    updatedAt = "2026-08-29T12:00:00Z",
   } = {}
 ) => ({
   author: { login: "f0rr0" },
@@ -80,7 +92,7 @@ const authoredPullRequestNode = (
     databaseId: repositoryId,
     nameWithOwner: repositoryName,
   },
-  updatedAt: "2026-08-29T12:00:00Z",
+  updatedAt,
   url: `https://github.com/${repositoryName}/pull/${String(number)}`,
 });
 
@@ -139,6 +151,7 @@ describe("GitHub pull request historical backfill", () => {
       expect(body.variables.login).toBe("f0rr0");
       expect(body.variables.pageSize).toBe(100);
       expect(body.query).toContain("user(login: $login)");
+      expect(body.query).toContain("field: UPDATED_AT");
       requests += 1;
       return Response.json(
         authoredPullRequestPage({
@@ -157,6 +170,7 @@ describe("GitHub pull request historical backfill", () => {
       account: "f0rr0",
       deadlineAt: Date.now() + 120_000,
       token: "test-token",
+      updatedSinceAt: new Date("2026-08-01T00:00:00.000Z"),
     });
 
     expect(result.pages).toBe(101);
@@ -184,6 +198,7 @@ describe("GitHub pull request historical backfill", () => {
         account: "f0rr0",
         deadlineAt: Date.now() + 120_000,
         token: "test-token",
+        updatedSinceAt: new Date("2026-08-01T00:00:00.000Z"),
       })
     ).rejects.toThrow("invalid authored pull request pagination");
   });
@@ -207,6 +222,7 @@ describe("GitHub pull request historical backfill", () => {
         account: "f0rr0",
         deadlineAt: Date.now() + 120_000,
         token: "test-token",
+        updatedSinceAt: new Date("2026-08-01T00:00:00.000Z"),
       })
     ).rejects.toThrow("invalid authored pull request pagination");
   });
@@ -230,6 +246,7 @@ describe("GitHub pull request historical backfill", () => {
         account: "f0rr0",
         deadlineAt: Date.now() + 120_000,
         token: "test-token",
+        updatedSinceAt: new Date("2026-08-01T00:00:00.000Z"),
       })
     ).rejects.toThrow("invalid authored pull request connection");
   });
@@ -259,6 +276,7 @@ describe("GitHub pull request historical backfill", () => {
         account: "f0rr0",
         deadlineAt: Date.now() + 120_000,
         token: "test-token",
+        updatedSinceAt: new Date("2026-08-01T00:00:00.000Z"),
       })
     ).rejects.toThrow("conflicting pull requests");
   });
@@ -282,6 +300,7 @@ describe("GitHub pull request historical backfill", () => {
       account: "f0rr0",
       deadlineAt: Date.now() + 120_000,
       token: "test-token",
+      updatedSinceAt: new Date("2026-08-01T00:00:00.000Z"),
     });
     expect(result.pullRequests).toEqual([
       expect.objectContaining({
@@ -292,7 +311,55 @@ describe("GitHub pull request historical backfill", () => {
     ]);
   });
 
-  test("processes unshardable external authored PRs before affiliated repositories", async () => {
+  test("stops the authored PR stream once updated work predates the window", async () => {
+    let requests = 0;
+    globalThis.fetch = async () => {
+      requests += 1;
+      if (requests === 1) {
+        return Response.json(
+          authoredPullRequestPage({
+            endCursor: "page-two",
+            hasNextPage: true,
+            nodes: [
+              authoredPullRequestNode(1, {
+                updatedAt: "2026-08-29T12:00:00Z",
+              }),
+              authoredPullRequestNode(2, {
+                updatedAt: "2026-08-01T00:00:00Z",
+              }),
+            ],
+            totalCount: 4,
+          })
+        );
+      }
+      return Response.json(
+        authoredPullRequestPage({
+          endCursor: "unused-page-three",
+          hasNextPage: true,
+          nodes: [
+            authoredPullRequestNode(3, {
+              updatedAt: "2026-07-31T23:59:59Z",
+            }),
+          ],
+          totalCount: 4,
+        })
+      );
+    };
+
+    const result = await collectGitHubAuthoredPullRequestBackfillCandidates({
+      account: "f0rr0",
+      deadlineAt: Date.now() + 120_000,
+      token: "test-token",
+      updatedSinceAt: new Date("2026-08-01T00:00:00.000Z"),
+    });
+
+    expect(requests).toBe(2);
+    expect(result.pages).toBe(2);
+    expect(result.totalCount).toBe(4);
+    expect(result.pullRequests.map(({ number }) => number)).toEqual([1, 2]);
+  });
+
+  test("skips an unavailable external PR and processes the following affiliated PR", async () => {
     const requestedPaths = [];
     globalThis.fetch = async (input) => {
       const url = new URL(input instanceof Request ? input.url : input);
@@ -317,6 +384,18 @@ describe("GitHub pull request historical backfill", () => {
       if (url.pathname === "/repos/unaffiliated/example/pulls/7") {
         return Response.json({ message: "Not Found" }, { status: 404 });
       }
+      if (url.pathname === "/repos/example-org/example-repo/pulls") {
+        return Response.json([pullRequestValue(2, "2026-08-20T00:00:00Z")]);
+      }
+      if (url.pathname === "/repos/example-org/example-repo/pulls/2") {
+        return Response.json({
+          ...pullRequestValue(2, "2026-08-20T00:00:00Z"),
+          commits: 0,
+        });
+      }
+      if (url.pathname === "/repos/example-org/example-repo/pulls/2/commits") {
+        return Response.json([]);
+      }
       throw new Error(`Unexpected GitHub request: ${url.href}`);
     };
 
@@ -330,37 +409,39 @@ describe("GitHub pull request historical backfill", () => {
         untilAt: new Date("2026-08-31T23:59:59.999Z"),
       })
     ).toMatchObject({
-      complete: false,
-      repositories: 1,
-      scannedPullRequests: 1,
-      stopReason: "provider_retry",
+      complete: true,
+      repositories: 2,
+      scannedPullRequests: 2,
+      skippedPullRequests: 1,
+      stopReason: "complete",
+      unavailablePullRequests: 1,
+      unavailableRepositories: 0,
     });
     expect(requestedPaths).toEqual([
       "/user/repos",
       "/graphql",
       "/repos/unaffiliated/example/pulls/7",
+      "/repos/example-org/example-repo/pulls",
+      "/repos/example-org/example-repo/pulls/2",
+      "/repos/example-org/example-repo/pulls/2/commits",
     ]);
   });
 
-  test("walks stable created-order pages and accepts numeric pagination paths", async () => {
+  test("walks recent updated-order pages and accepts numeric pagination paths", async () => {
     const requests = [];
     globalThis.fetch = async (input) => {
       const url = new URL(input instanceof Request ? input.url : input);
       requests.push(url);
       if (url.searchParams.get("page") === "2") {
-        return Response.json([
-          pullRequestValue(3, "2026-07-31T23:59:59Z", "2026-07-03T00:00:00Z"),
-        ]);
+        return Response.json([pullRequestValue(3, "2026-08-01T00:00:00Z")]);
       }
       const next = new URL(url);
       next.pathname = `/repositories/${repository.id}/pulls`;
       next.searchParams.set("page", "2");
       return Response.json(
         [
-          // Updated after the commit window still matters: the PR may have
-          // retained an in-window commit only after that window closed.
-          pullRequestValue(1, "2026-09-10T00:00:00Z", "2026-07-01T00:00:00Z"),
-          pullRequestValue(2, "2026-08-01T00:00:00Z", "2026-07-02T00:00:00Z"),
+          pullRequestValue(1, "2026-09-10T00:00:00Z"),
+          pullRequestValue(2, "2026-08-02T00:00:00Z"),
         ],
         { headers: { link: `<${next.href}>; rel="next"` } }
       );
@@ -371,6 +452,7 @@ describe("GitHub pull request historical backfill", () => {
       deadlineAt: Date.now() + 120_000,
       repository,
       token: "test-token",
+      updatedSinceAt: new Date("2026-08-01T00:00:00.000Z"),
     });
 
     expect(result.complete).toBe(true);
@@ -385,12 +467,12 @@ describe("GitHub pull request historical backfill", () => {
       "/repositories/123/pulls",
     ]);
     for (const url of requests) {
-      expect(url.searchParams.get("direction")).toBe("asc");
+      expect(url.searchParams.get("direction")).toBe("desc");
       expect(url.searchParams.get("page")).toBe(
         String(requests.indexOf(url) + 1)
       );
       expect(url.searchParams.get("per_page")).toBe("100");
-      expect(url.searchParams.get("sort")).toBe("created");
+      expect(url.searchParams.get("sort")).toBe("updated");
       expect(url.searchParams.get("state")).toBe("all");
     }
   });
@@ -412,15 +494,16 @@ describe("GitHub pull request historical backfill", () => {
         deadlineAt: Date.now() + 120_000,
         repository,
         token: "test-token",
+        updatedSinceAt: new Date("2026-08-01T00:00:00.000Z"),
       })
     ).rejects.toThrow("invalid pull request pagination");
   });
 
-  test("rejects pages that violate the documented ascending created order", async () => {
+  test("rejects pages that violate descending updated order", async () => {
     globalThis.fetch = async () =>
       Response.json([
-        pullRequestValue(1, "2026-08-01T00:00:00Z", "2026-07-02T00:00:00Z"),
-        pullRequestValue(2, "2026-08-02T00:00:00Z", "2026-07-01T00:00:00Z"),
+        pullRequestValue(1, "2026-08-01T00:00:00Z"),
+        pullRequestValue(2, "2026-08-02T00:00:00Z"),
       ]);
 
     await expect(
@@ -429,11 +512,43 @@ describe("GitHub pull request historical backfill", () => {
         deadlineAt: Date.now() + 120_000,
         repository,
         token: "test-token",
+        updatedSinceAt: new Date("2026-08-01T00:00:00.000Z"),
       })
-    ).rejects.toThrow("outside ascending created order");
+    ).rejects.toThrow("outside descending updated order");
   });
 
-  test("fails incomplete when a listed pull request becomes inaccessible", async () => {
+  test("stops once repository pull requests are older than the backfill window", async () => {
+    const requests = [];
+    globalThis.fetch = async (input) => {
+      const url = new URL(input instanceof Request ? input.url : input);
+      requests.push(url);
+      const next = new URL(url);
+      next.searchParams.set("page", "2");
+      return Response.json(
+        [
+          pullRequestValue(1, "2026-08-15T00:00:00Z"),
+          pullRequestValue(2, "2026-07-31T23:59:59Z"),
+        ],
+        { headers: { link: `<${next.href}>; rel="next"` } }
+      );
+    };
+
+    const result = await collectGitHubPullRequestBackfillCandidates({
+      account: "f0rr0",
+      deadlineAt: Date.now() + 120_000,
+      repository,
+      token: "test-token",
+      updatedSinceAt: new Date("2026-08-01T00:00:00.000Z"),
+    });
+
+    expect(result).toEqual({
+      complete: true,
+      pullRequests: [expect.objectContaining({ number: 1 })],
+    });
+    expect(requests).toHaveLength(1);
+  });
+
+  test("skips a listed pull request that becomes inaccessible", async () => {
     globalThis.fetch = async (input) => {
       const url = new URL(input instanceof Request ? input.url : input);
       if (url.pathname === "/user/repos") {
@@ -452,7 +567,7 @@ describe("GitHub pull request historical backfill", () => {
         );
       }
       if (url.pathname === "/repos/example-org/example-repo/pulls/1") {
-        return Response.json({ message: "Not Found" }, { status: 404 });
+        return Response.json({ message: "Forbidden" }, { status: 403 });
       }
       throw new Error(`Unexpected GitHub request: ${url.href}`);
     };
@@ -467,14 +582,301 @@ describe("GitHub pull request historical backfill", () => {
         untilAt: new Date("2026-08-31T23:59:59.999Z"),
       })
     ).toMatchObject({
-      complete: false,
+      complete: true,
       scannedPullRequests: 1,
       skippedPullRequests: 0,
-      stopReason: "provider_retry",
+      stopReason: "complete",
+      unavailablePullRequests: 1,
     });
   });
 
-  test("includes only an in-window tracked commit or merged PR milestone", () => {
+  test("given one repository PR inventory disappears, records a gap and scans the later repository", async () => {
+    const deniedRepository = {
+      ...rawRepository,
+      full_name: "denied-org/denied-repo",
+      html_url: "https://github.com/denied-org/denied-repo",
+      id: 124,
+      owner: {
+        ...rawRepository.owner,
+        id: 457,
+        login: "denied-org",
+      },
+    };
+    const requestedPaths = [];
+    globalThis.fetch = async (input) => {
+      const url = new URL(input instanceof Request ? input.url : input);
+      requestedPaths.push(url.pathname);
+      if (url.pathname === "/user/repos") {
+        return Response.json([rawRepository, deniedRepository]);
+      }
+      if (url.pathname === "/graphql") {
+        return Response.json(
+          authoredPullRequestPage({
+            hasNextPage: false,
+            nodes: [],
+            totalCount: 0,
+          })
+        );
+      }
+      if (url.pathname === "/repos/denied-org/denied-repo/pulls") {
+        return Response.json({ message: "Not Found" }, { status: 404 });
+      }
+      if (url.pathname === "/repos/example-org/example-repo/pulls") {
+        return Response.json([pullRequestValue(2, "2026-08-20T00:00:00Z")]);
+      }
+      if (url.pathname === "/repos/example-org/example-repo/pulls/2") {
+        return Response.json({
+          ...pullRequestValue(2, "2026-08-20T00:00:00Z"),
+          commits: 0,
+        });
+      }
+      if (url.pathname === "/repos/example-org/example-repo/pulls/2/commits") {
+        return Response.json([]);
+      }
+      throw new Error(`Unexpected GitHub request: ${url.href}`);
+    };
+
+    expect(
+      await backfillGitHubPullRequests({
+        account: "f0rr0",
+        deadlineAt: Date.now() + 120_000,
+        repositoryId: null,
+        sinceAt: new Date("2026-08-01T00:00:00.000Z"),
+        token: "test-token",
+        untilAt: new Date("2026-08-31T23:59:59.999Z"),
+      })
+    ).toMatchObject({
+      complete: true,
+      repositories: 1,
+      scannedPullRequests: 1,
+      skippedPullRequests: 1,
+      stopReason: "complete",
+      unavailablePullRequests: 0,
+      unavailableRepositories: 1,
+    });
+    expect(requestedPaths).toContain("/repos/example-org/example-repo/pulls/2");
+  });
+
+  test("given one PR has deterministic incomplete membership, records a gap and hydrates the next PR", async () => {
+    const hydratedPullRequests = [];
+    globalThis.fetch = async (input) => {
+      const url = new URL(input instanceof Request ? input.url : input);
+      if (url.pathname === "/repositories/123") {
+        return Response.json(rawRepository);
+      }
+      if (url.pathname === "/repos/example-org/example-repo/pulls") {
+        return Response.json([
+          pullRequestValue(1, "2026-08-20T00:00:00Z"),
+          pullRequestValue(2, "2026-08-19T00:00:00Z"),
+        ]);
+      }
+      const snapshot =
+        /^\/repos\/example-org\/example-repo\/pulls\/(\d+)$/u.exec(
+          url.pathname
+        );
+      if (snapshot?.[1] !== undefined) {
+        const number = Number(snapshot[1]);
+        hydratedPullRequests.push(number);
+        return Response.json({
+          ...pullRequestValue(
+            number,
+            number === 1 ? "2026-08-20T00:00:00Z" : "2026-08-19T00:00:00Z"
+          ),
+          commits: number === 1 ? 1 : 0,
+        });
+      }
+      if (url.pathname.endsWith("/pulls/1/commits")) {
+        return Response.json([]);
+      }
+      if (url.pathname.includes("/compare/")) {
+        return Response.json({ ahead_by: 1, commits: [], total_commits: 1 });
+      }
+      if (url.pathname.endsWith("/pulls/2/commits")) {
+        return Response.json([]);
+      }
+      throw new Error(`Unexpected GitHub request: ${url.href}`);
+    };
+
+    expect(
+      await backfillGitHubPullRequests({
+        account: "f0rr0",
+        deadlineAt: Date.now() + 120_000,
+        repositoryId: repository.id,
+        sinceAt: new Date("2026-08-01T00:00:00.000Z"),
+        token: "test-token",
+        untilAt: new Date("2026-08-31T23:59:59.999Z"),
+      })
+    ).toMatchObject({
+      complete: true,
+      scannedPullRequests: 2,
+      skippedPullRequests: 1,
+      stopReason: "complete",
+      unavailablePullRequests: 1,
+    });
+    expect(hydratedPullRequests).toEqual([1, 2]);
+  });
+
+  test("given one merged PR never resolves, records a gap and reaches the next candidate batch", async () => {
+    const candidates = Array.from({ length: 11 }, (_, index) =>
+      pullRequestValue(
+        index + 1,
+        `2026-08-${String(20 - index).padStart(2, "0")}T00:00:00Z`
+      )
+    );
+    let mergeResolutionRequests = 0;
+    const hydratedPullRequests = [];
+    globalThis.fetch = async (input) => {
+      const url = new URL(input instanceof Request ? input.url : input);
+      if (url.pathname === "/repositories/123") {
+        return Response.json(rawRepository);
+      }
+      if (url.pathname === "/repos/example-org/example-repo/pulls") {
+        return Response.json(candidates);
+      }
+      if (url.pathname === "/graphql") {
+        mergeResolutionRequests += 1;
+        return Response.json({ data: { nodes: [null] } });
+      }
+      const snapshot =
+        /^\/repos\/example-org\/example-repo\/pulls\/(\d+)$/u.exec(
+          url.pathname
+        );
+      if (snapshot?.[1] !== undefined) {
+        const number = Number(snapshot[1]);
+        hydratedPullRequests.push(number);
+        const value = pullRequestValue(
+          number,
+          `2026-08-${String(20 - (number - 1)).padStart(2, "0")}T00:00:00Z`
+        );
+        return Response.json(
+          number === 1
+            ? {
+                ...value,
+                closed_at: "2026-08-21T00:00:00Z",
+                commits: 1,
+                merged_at: "2026-08-21T00:00:00Z",
+                state: "closed",
+              }
+            : { ...value, commits: 0 }
+        );
+      }
+      if (url.pathname.endsWith("/pulls/1/commits")) {
+        return Response.json([
+          trackedPullRequestCommitValue(
+            pullRequestValue(1, "2026-08-20T00:00:00Z").head.sha
+          ),
+        ]);
+      }
+      if (/\/pulls\/\d+\/commits$/u.test(url.pathname)) {
+        return Response.json([]);
+      }
+      throw new Error(`Unexpected GitHub request: ${url.href}`);
+    };
+
+    expect(
+      await backfillGitHubPullRequests({
+        account: "f0rr0",
+        deadlineAt: Date.now() + 120_000,
+        repositoryId: repository.id,
+        sinceAt: new Date("2026-08-01T00:00:00.000Z"),
+        token: "test-token",
+        untilAt: new Date("2026-08-31T23:59:59.999Z"),
+      })
+    ).toMatchObject({
+      complete: true,
+      scannedPullRequests: 11,
+      skippedPullRequests: 10,
+      stopReason: "complete",
+      unavailablePullRequests: 1,
+    });
+    expect(mergeResolutionRequests).toBe(2);
+    expect(hydratedPullRequests).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]);
+  });
+
+  test("given merge resolution is rate limited, leaves traversal incomplete without a gap", async () => {
+    const value = pullRequestValue(1, "2026-08-20T00:00:00Z");
+    globalThis.fetch = async (input) => {
+      const url = new URL(input instanceof Request ? input.url : input);
+      if (url.pathname === "/repositories/123") {
+        return Response.json(rawRepository);
+      }
+      if (url.pathname === "/repos/example-org/example-repo/pulls") {
+        return Response.json([value]);
+      }
+      if (url.pathname === "/repos/example-org/example-repo/pulls/1") {
+        return Response.json({
+          ...value,
+          closed_at: "2026-08-21T00:00:00Z",
+          commits: 1,
+          merged_at: "2026-08-21T00:00:00Z",
+          state: "closed",
+        });
+      }
+      if (url.pathname === "/repos/example-org/example-repo/pulls/1/commits") {
+        return Response.json([trackedPullRequestCommitValue(value.head.sha)]);
+      }
+      if (url.pathname === "/graphql") {
+        return Response.json(
+          { message: "rate limited" },
+          { headers: { "retry-after": "120" }, status: 429 }
+        );
+      }
+      throw new Error(`Unexpected GitHub request: ${url.href}`);
+    };
+
+    expect(
+      await backfillGitHubPullRequests({
+        account: "f0rr0",
+        deadlineAt: Date.now() + 60_000,
+        repositoryId: repository.id,
+        sinceAt: new Date("2026-08-01T00:00:00.000Z"),
+        token: "test-token",
+        untilAt: new Date("2026-08-31T23:59:59.999Z"),
+      })
+    ).toMatchObject({
+      complete: false,
+      scannedPullRequests: 1,
+      stopReason: "provider_retry",
+      unavailablePullRequests: 0,
+    });
+  });
+
+  test("given candidate hydration is retryable, leaves traversal incomplete without recording a coverage gap", async () => {
+    globalThis.fetch = async (input) => {
+      const url = new URL(input instanceof Request ? input.url : input);
+      if (url.pathname === "/repositories/123") {
+        return Response.json(rawRepository);
+      }
+      if (url.pathname === "/repos/example-org/example-repo/pulls") {
+        return Response.json([pullRequestValue(1, "2026-08-01T00:00:00Z")]);
+      }
+      if (url.pathname === "/repos/example-org/example-repo/pulls/1") {
+        return Response.json(
+          { message: "Service Unavailable" },
+          { headers: { "retry-after": "120" }, status: 503 }
+        );
+      }
+      throw new Error(`Unexpected GitHub request: ${url.href}`);
+    };
+
+    expect(
+      await backfillGitHubPullRequests({
+        account: "f0rr0",
+        deadlineAt: Date.now() + 60_000,
+        repositoryId: repository.id,
+        sinceAt: new Date("2026-08-01T00:00:00.000Z"),
+        token: "test-token",
+        untilAt: new Date("2026-08-31T23:59:59.999Z"),
+      })
+    ).toMatchObject({
+      complete: false,
+      scannedPullRequests: 1,
+      stopReason: "provider_retry",
+      unavailablePullRequests: 0,
+    });
+  });
+
+  test("given a PR, includes it only when it contains tracked-authored work in the window", () => {
     const sinceAt = new Date("2026-08-01T00:00:00.000Z");
     const untilAt = new Date("2026-08-31T23:59:59.999Z");
     const commit = (committedAt) => ({
@@ -514,18 +916,22 @@ describe("GitHub pull request historical backfill", () => {
           mergedAt: "2026-08-15T00:00:00.000Z",
         },
       })
-    ).toBe(true);
+    ).toBe(false);
     expect(
       belongs({
-        pullRequest: {
-          authorAccount: "f0rr0",
-          mergedAt: "2026-09-01T00:00:00.000Z",
-        },
+        commits: [
+          { ...commit("2026-08-15T00:00:00.000Z"), author: "someone-else" },
+        ],
+        pullRequest: { authorAccount: "f0rr0", mergedAt: null },
       })
     ).toBe(false);
     expect(
       belongs({
-        pullRequest: { authorAccount: "f0rr0", mergedAt: null },
+        commits: [commit("2026-09-01T00:00:00.000Z")],
+        pullRequest: {
+          authorAccount: "f0rr0",
+          mergedAt: "2026-08-15T00:00:00.000Z",
+        },
       })
     ).toBe(false);
   });

--- a/tests/github-reconciliation.test.mjs
+++ b/tests/github-reconciliation.test.mjs
@@ -22,6 +22,7 @@ const repository = {
     type: "Organization",
   },
   private: true,
+  pushed_at: "2026-08-20T00:00:00Z",
   visibility: "private",
 };
 
@@ -55,7 +56,7 @@ describe("GitHub repository reconciliation", () => {
     ]);
   });
 
-  test("fetches one opaque repository ID without enumerating affiliations", async () => {
+  test("fetches one opaque repository ID even when its push predates the global cutoff", async () => {
     globalThis.fetch = async (input) => {
       const url =
         input instanceof Request ? new URL(input.url) : new URL(input);
@@ -63,9 +64,38 @@ describe("GitHub repository reconciliation", () => {
       return Response.json(repository);
     };
 
-    expect(await collectAccessibleGitHubRepositories("token", "123")).toEqual([
-      repositoryFacts,
-    ]);
+    expect(
+      await collectAccessibleGitHubRepositories("token", "123", {
+        pushedSinceAt: new Date("2026-09-01T00:00:00.000Z"),
+      })
+    ).toEqual([repositoryFacts]);
+  });
+
+  test("bounds a historical inventory to repositories pushed since the window began", async () => {
+    globalThis.fetch = async () =>
+      Response.json([
+        repository,
+        {
+          ...repository,
+          full_name: "example-org/stale-repo",
+          html_url: "https://github.com/example-org/stale-repo",
+          id: 124,
+          pushed_at: "2026-07-31T23:59:59Z",
+        },
+        {
+          ...repository,
+          full_name: "example-org/empty-repo",
+          html_url: "https://github.com/example-org/empty-repo",
+          id: 125,
+          pushed_at: null,
+        },
+      ]);
+
+    expect(
+      await collectAccessibleGitHubRepositories("token", null, {
+        pushedSinceAt: new Date("2026-08-01T00:00:00.000Z"),
+      })
+    ).toEqual([repositoryFacts]);
   });
 
   test("uses branch and repository-tag commit targets without tag peeling", async () => {


### PR DESCRIPTION
## Summary

- bound broad discovery to active repositories and 31-day windows, with one hard deadline covering every stage
- scope manual workers and audits to the requested account, date window, and optional repository
- continue beyond poisoned repositories and pull requests while reporting terminal evidence gaps explicitly
- keep merge artifacts as internal evidence and render each repository once per day
- add a read-only PostgreSQL audit and BDD regressions for completion, retry, gap, and projection semantics

## Real-data verification

- the failed August path visited 260 accessible repositories, 21,562 refs, and 8,168 pages despite only 15 repositories being active in the window
- the corrected read-only provider traversal completed in about 13 minutes, hydrated 366 pull-request candidates with zero failures, and found 343 commit occurrences
- the current August audit correctly remains pipeline-incomplete while its stored public projection matches exactly; provider completeness is reported separately

## Validation

- bun test: 239 passed
- bun run typecheck
- bun run lint
- bun run format:check
- bunx next build