### PR TITLE
fix(github): accept cache freshness for event polls

### DIFF
--- a/src/lib/github-api.ts
+++ b/src/lib/github-api.ts
@@ -184,7 +184,16 @@ export const githubNextPollAtFrom = (
   response: Response,
   receivedAt = Date.now()
 ) => {
-  const value = response.headers.get("x-poll-interval")?.trim();
+  const pollInterval = response.headers.get("x-poll-interval");
+  const cacheMaxAges =
+    pollInterval === null
+      ? (response.headers.get("cache-control")?.split(",") ?? [])
+          .map((directive) => /^max-age\s*=\s*(\d+)$/i.exec(directive.trim()))
+          .filter((match): match is RegExpExecArray => match !== null)
+      : [];
+  const value =
+    pollInterval?.trim() ??
+    (cacheMaxAges.length === 1 ? cacheMaxAges[0]?.[1] : undefined);
   if (
     value === undefined ||
     !/^\d+$/.test(value) ||

--- a/tests/github-commits.test.mjs
+++ b/tests/github-commits.test.mjs
@@ -995,13 +995,16 @@ describe("account pause state", () => {
 });
 
 describe("bounded event collection", () => {
-  test("uses the saved feed validator and treats 304 as a healthy no-op", async () => {
+  test("uses cache freshness when a 304 omits the poll interval", async () => {
     globalThis.fetch = async (_input, init) => {
       expect(new Headers(init?.headers).get("if-none-match")).toBe(
         'W/"events"'
       );
       return new Response(null, {
-        headers: { etag: 'W/"events"', "X-Poll-Interval": "60" },
+        headers: {
+          "Cache-Control": "private, max-age=300, s-maxage=300",
+          etag: 'W/"events"',
+        },
         status: 304,
       });
     };
@@ -1021,7 +1024,10 @@ describe("bounded event collection", () => {
       notModified: true,
     });
     expect(collected.nextPollAt.getTime()).toBeGreaterThanOrEqual(
-      startedAt + 59_000
+      startedAt + 299_000
+    );
+    expect(collected.nextPollAt.getTime()).toBeLessThanOrEqual(
+      startedAt + 301_000
     );
   });
 
@@ -1086,8 +1092,21 @@ describe("bounded event collection", () => {
     expect(collected.latestEventId).toBe("12");
   });
 
-  test("rejects a missing or malformed provider poll interval", async () => {
+  test("rejects a missing provider poll interval", async () => {
     globalThis.fetch = async () => Response.json([accountEvent("12")]);
+    expect(collectGitHubEvents("f0rr0", "token", null)).rejects.toBeInstanceOf(
+      TypeError
+    );
+  });
+
+  test("does not replace a malformed poll interval with cache freshness", async () => {
+    globalThis.fetch = async () =>
+      Response.json([accountEvent("12")], {
+        headers: {
+          "Cache-Control": "private, max-age=300",
+          "X-Poll-Interval": "later",
+        },
+      });
     expect(collectGitHubEvents("f0rr0", "token", null)).rejects.toBeInstanceOf(
       TypeError
     );


### PR DESCRIPTION
## Summary

- accept GitHub cache freshness as the Events retry interval when a 304 response omits X-Poll-Interval
- keep explicit malformed poll headers fail-closed
- cover the exact production 304 response shape and timing bound

## Production evidence

- retained pg_net history contained 62 Events responses with HTTP 503 versus 10 successes
- the real conditional request reproduced 304 with Cache-Control max-age=300 and no X-Poll-Interval
- the patched collector handles the same live response as a healthy no-op with a 300-second retry

## Validation

- bun test: 240 passed
- bun run typecheck
- bun run lint
- bun run format:check
- bunx next build