### PR TITLE
fix: settle github activity worker queues

### DIFF
--- a/scripts/backfill-github-activity.ts
+++ b/scripts/backfill-github-activity.ts
@@ -30,6 +30,8 @@ import { backfillGitHubCommitsFromCurrentRefs } from "../src/lib/github-direct-b
 import { backfillGitHubPullRequests } from "../src/lib/github-pull-request-backfill";
 
 const MAXIMUM_ACTION_MINUTES = 330;
+const MAXIMUM_INCONCLUSIVE_AUDIT_RETRIES = 2;
+const INCONCLUSIVE_AUDIT_RETRY_MS = 1000;
 const WORKER_CLEANUP_MARGIN_MS = 30_000;
 const WORKER_PASS_DURATION_MS = 240_000;
 
@@ -141,6 +143,8 @@ interface BackfillProcessingTotals extends GitHubBackfillProcessingCounts {
 
 const emptyProcessingCounts = (): GitHubBackfillProcessingCounts => ({
   aliases: 0,
+  canonicalizationAttempts: 0,
+  canonicalized: 0,
   claimed: 0,
   deferred: 0,
   failed: 0,
@@ -153,6 +157,8 @@ const addProcessingCounts = (
   counts: GitHubBackfillProcessingCounts
 ) => {
   totals.aliases += counts.aliases;
+  totals.canonicalizationAttempts += counts.canonicalizationAttempts;
+  totals.canonicalized += counts.canonicalized;
   totals.claimed += counts.claimed;
   totals.deferred += counts.deferred;
   totals.failed += counts.failed;
@@ -225,7 +231,7 @@ const processQueue = async (
     passes += 1;
     addProcessingCounts(totals, counts);
     process.stdout.write(
-      `Worker pass ${String(completedPasses + passes)}: claimed ${String(counts.claimed)}, processed ${String(counts.processed)}, deferred ${String(counts.deferred)}, unavailable ${String(counts.unavailable)}, failed ${String(counts.failed)}, aliases ${String(counts.aliases)}.\n`
+      `Worker pass ${String(completedPasses + passes)}: claimed ${String(counts.claimed)}, processed ${String(counts.processed)}, deferred ${String(counts.deferred)}, unavailable ${String(counts.unavailable)}, failed ${String(counts.failed)}, canonicalized ${String(counts.canonicalized)}/${String(counts.canonicalizationAttempts)}, aliases ${String(counts.aliases)}.\n`
     );
     if (!githubBackfillProcessingMadeProgress(counts)) {
       return {
@@ -251,17 +257,25 @@ const combineProcessingTotals = (
 export const backfillRetryWaitMillisecondsFrom = (
   audits: readonly Pick<GitHubActivityAuditReport, "pipeline" | "status">[],
   deadlineAt: number,
-  now = Date.now()
+  now = Date.now(),
+  inconclusiveRetries = 0
 ) => {
   if (
     audits.length === 0 ||
     audits.some(
       ({ status }) =>
+        status !== "inconclusive" &&
         status !== "pipeline_incomplete" &&
         status !== "stored_projection_verified"
     )
   ) {
     return null;
+  }
+  if (audits.some(({ status }) => status === "inconclusive")) {
+    return inconclusiveRetries < MAXIMUM_INCONCLUSIVE_AUDIT_RETRIES &&
+      now + INCONCLUSIVE_AUDIT_RETRY_MS + WORKER_CLEANUP_MARGIN_MS < deadlineAt
+      ? INCONCLUSIVE_AUDIT_RETRY_MS
+      : null;
   }
   const retryTimes = audits.flatMap(({ pipeline, status }) => {
     if (status !== "pipeline_incomplete" || pipeline.earliestRetryAt === null) {
@@ -402,6 +416,7 @@ const main = async () => {
       stopReason: "no_immediately_claimable_work",
     };
     let audits: readonly GitHubActivityAuditReport[] = [];
+    let inconclusiveAuditRetries = 0;
     let completion = githubBackfillCompletionFrom({
       auditStatuses: [],
       boundedDiscoveryComplete,
@@ -421,7 +436,15 @@ const main = async () => {
         worker.stopReason = "time_budget";
         break;
       }
-      const retryWait = backfillRetryWaitMillisecondsFrom(audits, deadlineAt);
+      const hasInconclusiveAudit = audits.some(
+        ({ status }) => status === "inconclusive"
+      );
+      const retryWait = backfillRetryWaitMillisecondsFrom(
+        audits,
+        deadlineAt,
+        Date.now(),
+        inconclusiveAuditRetries
+      );
       if (retryWait === null) {
         if (
           audits.some(
@@ -438,6 +461,9 @@ const main = async () => {
         }
         break;
       }
+      inconclusiveAuditRetries = hasInconclusiveAudit
+        ? inconclusiveAuditRetries + 1
+        : 0;
       process.stdout.write(
         `No scoped work is claimable; waiting ${String(Math.ceil(retryWait / 1000))} seconds for the next durable retry within the Action budget.\n`
       );

--- a/src/app/api/cron/github-worker/route.ts
+++ b/src/app/api/cron/github-worker/route.ts
@@ -57,6 +57,7 @@ export async function POST(request: Request) {
       evidenceRecovery.status === "applied" ||
       activity.summaries.completed > 0 ||
       activity.pullRequests.completed > 0 ||
+      activity.canonicalizationAttempts > 0 ||
       activity.aliases > 0
     ) {
       revalidateTag("github-activity", "max");

--- a/src/lib/github-activity-audit.ts
+++ b/src/lib/github-activity-audit.ts
@@ -15,6 +15,7 @@ import {
   githubIssues,
   githubPublicActivities,
   githubPullRequests,
+  githubPullRequestMemberships,
   githubPullRequestSignals,
   githubPullRequestVersions,
   githubPushObservations,
@@ -726,6 +727,9 @@ interface AuditRetryRow {
 interface AuditPullRequestPipelineRow {
   lastReconciledAt: Date | null;
   membershipComplete: boolean | null;
+  membershipCount: number;
+  membershipExpectedCount: number | null;
+  membershipHeadMatches: boolean;
   nextReconcileAt: Date | null;
   reconcileError: string | null;
   versionObservedAt: Date | null;
@@ -798,7 +802,11 @@ const pullRequestPipelineEvidenceFrom = (
   let pullRequestReconciliationsUnavailable = 0;
   const retryDates: Date[] = [];
   for (const pullRequest of rows) {
-    const membershipIncomplete = pullRequest.membershipComplete !== true;
+    const membershipIncomplete =
+      pullRequest.membershipComplete !== true ||
+      pullRequest.membershipExpectedCount === null ||
+      pullRequest.membershipCount !== pullRequest.membershipExpectedCount ||
+      !pullRequest.membershipHeadMatches;
     if (membershipIncomplete) {
       if (pullRequest.nextReconcileAt === null) {
         pullRequestMembershipsUnavailable += 1;
@@ -1083,6 +1091,22 @@ const readStoredEvidence = async (
       .select({
         lastReconciledAt: githubPullRequests.lastReconciledAt,
         membershipComplete: githubPullRequestVersions.membershipComplete,
+        membershipCount: sql<number>`(
+          SELECT count(*)::integer
+          FROM ${githubPullRequestMemberships}
+          WHERE ${githubPullRequestMemberships.versionId} = ${githubPullRequestVersions.id}
+        )`,
+        membershipExpectedCount: githubPullRequestVersions.commitCount,
+        membershipHeadMatches: sql<boolean>`
+          coalesce(${githubPullRequestVersions.commitCount} = 0, false)
+          OR coalesce((
+            SELECT ${githubPullRequestMemberships.commitSha} = ${githubPullRequestVersions.headSha}
+            FROM ${githubPullRequestMemberships}
+            WHERE ${githubPullRequestMemberships.versionId} = ${githubPullRequestVersions.id}
+            ORDER BY ${githubPullRequestMemberships.position} DESC
+            LIMIT 1
+          ), false)
+        `,
         nextReconcileAt: githubPullRequests.nextReconcileAt,
         reconcileError: githubPullRequests.reconcileError,
         versionObservedAt: githubPullRequestVersions.observedAt,

--- a/src/lib/github-activity-worker-store.ts
+++ b/src/lib/github-activity-worker-store.ts
@@ -577,7 +577,10 @@ export const claimGitHubPushObservations = async (
         beforeSha: githubPushObservations.beforeSha,
         errorCode: githubPushObservations.errorCode,
         expectedCommitCount: githubPushObservations.expectedCommitCount,
-        historySinceAt: sql<Date>`coalesce(${githubPushObservations.historySinceAt}, ${githubAccountCheckpoints.refBackfillSinceAt})`,
+        historySinceAt:
+          sql`coalesce(${githubPushObservations.historySinceAt}, ${githubAccountCheckpoints.refBackfillSinceAt})`.mapWith(
+            githubAccountCheckpoints.refBackfillSinceAt
+          ),
         historyUntilAt: githubPushObservations.historyUntilAt,
         id: githubPushObservations.id,
         leaseUntil: githubPushObservations.leaseUntil,
@@ -1738,6 +1741,18 @@ const persistPullRequestSnapshotInTransaction = async (
       id: githubPullRequestVersions.id,
       isCurrent: githubPullRequestVersions.isCurrent,
       membershipComplete: githubPullRequestVersions.membershipComplete,
+      membershipCount: sql<number>`(
+        SELECT count(*)::integer
+        FROM ${githubPullRequestMemberships}
+        WHERE ${githubPullRequestMemberships.versionId} = ${githubPullRequestVersions.id}
+      )`,
+      membershipHeadSha: sql<string | null>`(
+        SELECT ${githubPullRequestMemberships.commitSha}
+        FROM ${githubPullRequestMemberships}
+        WHERE ${githubPullRequestMemberships.versionId} = ${githubPullRequestVersions.id}
+        ORDER BY ${githubPullRequestMemberships.position} DESC
+        LIMIT 1
+      )`,
       providerUpdatedAt: githubPullRequestVersions.providerUpdatedAt,
     })
     .from(githubPullRequestVersions)
@@ -1805,7 +1820,10 @@ const persistPullRequestSnapshotInTransaction = async (
           pullRequest.headRepository?.id ?? version.headRepositoryId,
         isCurrent: true,
         mergeSnapshot: pullRequest.merged,
-        observedAt: now,
+        ...(providerUpdatedAt > version.providerUpdatedAt ||
+        canonicalEvidenceChanged
+          ? { observedAt: now }
+          : {}),
         providerUpdatedAt,
       })
       .where(eq(githubPullRequestVersions.id, version.id));
@@ -1813,8 +1831,32 @@ const persistPullRequestSnapshotInTransaction = async (
   if (versionId === undefined) {
     throw new Error("The GitHub pull request version is unavailable.");
   }
+  const expectedMembershipCount =
+    pullRequest.commitCount ?? version?.commitCount ?? null;
+  const storedMembershipCompleteFlag = version?.membershipComplete ?? false;
+  const storedMembershipComplete =
+    storedMembershipCompleteFlag &&
+    expectedMembershipCount !== null &&
+    version.membershipCount === expectedMembershipCount &&
+    (expectedMembershipCount === 0
+      ? version.membershipHeadSha === null
+      : version.membershipHeadSha === pullRequest.headSha);
+  const storedMembershipInvalid =
+    storedMembershipCompleteFlag && !storedMembershipComplete;
+  if (storedMembershipInvalid) {
+    await invalidateGitHubPullRequestDerivedAliases(
+      transaction,
+      pullRequest.nodeId
+    );
+    await transaction
+      .update(githubPullRequestVersions)
+      .set({ membershipComplete: false })
+      .where(eq(githubPullRequestVersions.id, versionId));
+  }
   const membershipRefreshRequired =
-    version === undefined || (refreshMembership && !version.membershipComplete);
+    version === undefined ||
+    storedMembershipInvalid ||
+    (refreshMembership && !storedMembershipComplete);
   if (membershipRefreshRequired && existing !== undefined) {
     await transaction
       .update(githubPullRequests)
@@ -2048,14 +2090,29 @@ export const persistGitHubPullRequestMembership = async (
 ) =>
   await getDatabase().transaction(async (transaction) => {
     const [version] = await transaction
-      .select({ id: githubPullRequestVersions.id })
+      .select({
+        commitCount: githubPullRequestVersions.commitCount,
+        headSha: githubPullRequestVersions.headSha,
+        id: githubPullRequestVersions.id,
+      })
       .from(githubPullRequestVersions)
       .where(eq(githubPullRequestVersions.id, stored.versionId))
       .for("update");
     if (version === undefined) {
       return false;
     }
-    if (!membershipComplete) {
+    const completeMembershipIsValid =
+      membershipComplete &&
+      version.commitCount !== null &&
+      commitShas.length === version.commitCount &&
+      new Set(commitShas).size === commitShas.length &&
+      headSha === version.headSha &&
+      (version.commitCount === 0 || commitShas.at(-1) === version.headSha);
+    if (!completeMembershipIsValid) {
+      await invalidateGitHubPullRequestDerivedAliases(
+        transaction,
+        stored.pullRequestNodeId
+      );
       await transaction
         .update(githubPullRequestVersions)
         .set({ membershipComplete: false })
@@ -2398,7 +2455,8 @@ const markGitHubCommitCanonicalized = async (
 export const canonicalizeGitHubCommitActivity = async (
   repositoryId: string,
   sha: string,
-  now = new Date()
+  now = new Date(),
+  options: { onlyIfPending?: boolean } = {}
 ) =>
   // oxlint-disable-next-line complexity -- Evidence classes deliberately fail open independently.
   await getDatabase().transaction(async (transaction) => {
@@ -2426,6 +2484,9 @@ export const canonicalizeGitHubCommitActivity = async (
             "complete",
             "unavailable",
           ]),
+          options.onlyIfPending === true
+            ? isNull(githubCommits.canonicalizedAt)
+            : undefined,
           isNull(githubPublicActivities.canonicalPublicId),
           isNull(githubPublicActivities.hiddenAt)
         )
@@ -2641,7 +2702,7 @@ export const canonicalizePendingGitHubActivities = async (
   scope?: GitHubActivityWorkerScope
 ) => {
   if (activeAccounts.length === 0) {
-    return 0;
+    return { aliases: 0, canonicalizationAttempts: 0, canonicalized: 0 };
   }
   const candidates = await getDatabase()
     .select({
@@ -2667,15 +2728,22 @@ export const canonicalizePendingGitHubActivities = async (
     .orderBy(asc(githubCommits.firstObservedAt), asc(githubCommits.sha))
     .limit(limit);
   let aliased = 0;
+  let canonicalized = 0;
   for (const candidate of candidates) {
     const result = await canonicalizeGitHubCommitActivity(
       candidate.repositoryId,
       candidate.sha,
-      now
+      now,
+      { onlyIfPending: true }
     );
     aliased += result.aliases;
+    canonicalized += result.publicId === null ? 0 : 1;
   }
-  return aliased;
+  return {
+    aliases: aliased,
+    canonicalizationAttempts: candidates.length,
+    canonicalized,
+  };
 };
 
 export const ensureGitHubSummaryAttempt = async (

--- a/src/lib/github-activity-worker.ts
+++ b/src/lib/github-activity-worker.ts
@@ -100,6 +100,8 @@ const emptyStageResult = (): StageResult => ({
 
 export interface GitHubActivityWorkerResult {
   aliases: number;
+  canonicalizationAttempts: number;
+  canonicalized: number;
   commits: StageResult;
   deadlineReached: boolean;
   observations: StageResult;
@@ -677,8 +679,8 @@ export const runGitHubActivityWorker = async (
     pullRequestDiscovery
   );
   await processPullRequests(context, pullRequestLimit, pullRequests);
-  const aliases = context.deadlineReached()
-    ? 0
+  const canonicalization = context.deadlineReached()
+    ? { aliases: 0, canonicalizationAttempts: 0, canonicalized: 0 }
     : await canonicalizePendingGitHubActivities(
         8,
         new Date(),
@@ -696,7 +698,9 @@ export const runGitHubActivityWorker = async (
   await processSummaries(context, summaryLimit, summaries);
 
   return {
-    aliases,
+    aliases: canonicalization.aliases,
+    canonicalizationAttempts: canonicalization.canonicalizationAttempts,
+    canonicalized: canonicalization.canonicalized,
     commits,
     deadlineReached: context.deadlineReached(),
     observations,

--- a/src/lib/github-backfill-core.ts
+++ b/src/lib/github-backfill-core.ts
@@ -80,6 +80,8 @@ interface GitHubBackfillWorkerStageCounts {
 
 interface GitHubBackfillWorkerPassCounts {
   aliases: number;
+  canonicalizationAttempts: number;
+  canonicalized: number;
   commits: GitHubBackfillWorkerStageCounts;
   observations: GitHubBackfillWorkerStageCounts;
   pullRequestDiscovery: GitHubBackfillWorkerStageCounts;
@@ -90,6 +92,8 @@ interface GitHubBackfillWorkerPassCounts {
 
 export interface GitHubBackfillProcessingCounts {
   aliases: number;
+  canonicalizationAttempts: number;
+  canonicalized: number;
   claimed: number;
   deferred: number;
   failed: number;
@@ -98,8 +102,11 @@ export interface GitHubBackfillProcessingCounts {
 }
 
 export const githubBackfillProcessingMadeProgress = (
-  counts: Pick<GitHubBackfillProcessingCounts, "aliases" | "claimed">
-) => counts.claimed > 0 || counts.aliases > 0;
+  counts: Pick<
+    GitHubBackfillProcessingCounts,
+    "canonicalizationAttempts" | "claimed"
+  >
+) => counts.claimed > 0 || counts.canonicalizationAttempts > 0;
 
 type JsonObject = Record<string, unknown>;
 
@@ -111,6 +118,8 @@ export const githubBackfillProcessingCountsFrom = (
 ): GitHubBackfillProcessingCounts => {
   const counts: GitHubBackfillProcessingCounts = {
     aliases: result.aliases,
+    canonicalizationAttempts: result.canonicalizationAttempts,
+    canonicalized: result.canonicalized,
     claimed: 0,
     deferred: 0,
     failed: 0,

--- a/tests/github-activity-feed-postgres.test.mjs
+++ b/tests/github-activity-feed-postgres.test.mjs
@@ -501,6 +501,14 @@ describe.skipIf(!dockerAvailable)(
           new Date("2026-08-30T10:00:00.000Z")
         );
         expect(storedVersionOne).not.toBeNull();
+        expect(
+          await persistGitHubPullRequestMembership(
+            storedVersionOne,
+            oldSha,
+            [],
+            true
+          )
+        ).toBe(false);
         await admin`
           insert into github_public_activities (
             public_id, kind, occurred_at, repository_id, revision,
@@ -549,6 +557,54 @@ describe.skipIf(!dockerAvailable)(
             true
           )
         ).toBe(true);
+        await admin`
+          delete from github_pull_request_memberships
+          where version_id = ${storedVersionOne.versionId}::uuid
+        `;
+        const corruptVersion = await persistGitHubPullRequestSnapshot(
+          "f0rr0",
+          versionOne,
+          { refreshMembership: true },
+          new Date("2026-08-30T10:44:00.000Z")
+        );
+        expect(corruptVersion).toMatchObject({
+          membershipRefreshRequired: true,
+          versionId: storedVersionOne.versionId,
+        });
+        expect(
+          await admin`
+            select membership_complete
+            from github_pull_request_versions
+            where id = ${storedVersionOne.versionId}::uuid
+          `
+        ).toEqual([{ membership_complete: false }]);
+        expect(
+          await persistGitHubPullRequestMembership(
+            storedVersionOne,
+            oldSha,
+            [oldSha],
+            true
+          )
+        ).toBe(true);
+        const unchangedVersion = await persistGitHubPullRequestSnapshot(
+          "f0rr0",
+          versionOne,
+          { refreshMembership: true },
+          new Date("2026-08-30T10:45:00.000Z")
+        );
+        expect(unchangedVersion).toMatchObject({
+          membershipRefreshRequired: false,
+          retryLifecycleReset: false,
+          versionId: storedVersionOne.versionId,
+        });
+        const [unchangedVersionObservation] = await admin`
+          select observed_at
+          from github_pull_request_versions
+          where id = ${storedVersionOne.versionId}::uuid
+        `;
+        expect(
+          new Date(unchangedVersionObservation.observed_at).toISOString()
+        ).toBe("2026-08-30T10:00:00.000Z");
         expect(
           await canonicalizeGitHubCommitActivity(
             repositoryId,
@@ -560,6 +616,22 @@ describe.skipIf(!dockerAvailable)(
           aliases: 0,
           publicId: oldActivityId,
         });
+        expect(
+          await canonicalizeGitHubCommitActivity(
+            repositoryId,
+            oldSha,
+            new Date("2026-08-30T10:31:00.000Z"),
+            { onlyIfPending: true }
+          )
+        ).toEqual({ aliased: false, aliases: 0, publicId: null });
+        const [stableCanonicalWatermark] = await admin`
+          select canonicalized_at
+          from github_commits
+          where repository_id = ${repositoryId} and sha = ${oldSha}
+        `;
+        expect(
+          new Date(stableCanonicalWatermark.canonicalized_at).toISOString()
+        ).toBe("2026-08-30T10:30:00.000Z");
 
         const storedVersionTwo = await persistGitHubPullRequestSnapshot(
           "f0rr0",
@@ -648,6 +720,55 @@ describe.skipIf(!dockerAvailable)(
             public_id: newActivityId,
           },
         ]);
+
+        const corruptVersionTwo = await persistGitHubPullRequestSnapshot(
+          "f0rr0",
+          {
+            ...versionOne,
+            commitCount: 2,
+            headSha: newSha,
+            providerUpdatedAt: "2026-08-30T11:00:00.000Z",
+          },
+          { refreshMembership: true },
+          new Date("2026-08-30T11:04:00.000Z")
+        );
+        expect(corruptVersionTwo).toMatchObject({
+          membershipRefreshRequired: true,
+          versionId: storedVersionTwo.versionId,
+        });
+        expect(
+          await admin`
+            select
+              c.canonicalized_at,
+              p.alias_reason,
+              p.canonical_public_id,
+              p.hidden_at,
+              p.published_at,
+              p.public_id
+            from github_commits c
+            inner join github_public_activities p
+              on p.public_id = c.activity_public_id
+            where c.repository_id = ${repositoryId}
+            order by p.public_id
+          `
+        ).toEqual([
+          {
+            alias_reason: null,
+            canonical_public_id: null,
+            canonicalized_at: null,
+            hidden_at: null,
+            public_id: oldActivityId,
+            published_at: null,
+          },
+          {
+            alias_reason: null,
+            canonical_public_id: null,
+            canonicalized_at: null,
+            hidden_at: null,
+            public_id: newActivityId,
+            published_at: null,
+          },
+        ]);
       } finally {
         await admin`
           delete from github_pull_requests
@@ -664,6 +785,98 @@ describe.skipIf(!dockerAvailable)(
         await admin`
           delete from github_commits
           where repository_id = ${repositoryId}
+        `;
+        await admin`
+          delete from github_repositories
+          where id = ${repositoryId}
+        `;
+      }
+    });
+
+    test("accepts an empty membership when the provider reports zero commits", async () => {
+      const repositoryId = "604";
+      const repository = "f0rr0/zero-commit-membership";
+      const pullRequestNodeId = "PR_zero_commit_membership";
+      const headSha = "6".repeat(40);
+      const repositoryFacts = {
+        fullName: repository,
+        htmlUrl: `https://github.com/${repository}`,
+        id: repositoryId,
+        ownerAvatarUrl: null,
+        ownerId: "101",
+        ownerLogin: "f0rr0",
+        ownerType: "User",
+        visibility: "public",
+      };
+      const snapshot = {
+        action: "opened",
+        additions: null,
+        author: "f0rr0",
+        authorAccount: "f0rr0",
+        authorUserId: "101",
+        baseRef: "main",
+        baseRepository: repositoryFacts,
+        baseSha: "5".repeat(40),
+        body: null,
+        changedFiles: null,
+        closedAt: null,
+        commitCount: 0,
+        createdAt: "2026-08-30T12:00:00.000Z",
+        deletions: null,
+        draft: false,
+        headRef: "empty-feature",
+        headRepository: repositoryFacts,
+        headSha,
+        id: "604",
+        mergeCommitSha: null,
+        merged: false,
+        mergedAt: null,
+        nodeId: pullRequestNodeId,
+        number: 604,
+        providerUpdatedAt: "2026-08-30T12:00:00.000Z",
+        repository: repositoryFacts,
+        state: "open",
+        title: "Represent an empty pull request",
+        url: `https://github.com/${repository}/pull/604`,
+      };
+
+      try {
+        const stored = await persistGitHubPullRequestSnapshot(
+          "f0rr0",
+          snapshot,
+          { refreshMembership: true },
+          new Date("2026-08-30T12:00:00.000Z")
+        );
+        expect(stored).not.toBeNull();
+        expect(
+          await persistGitHubPullRequestMembership(stored, headSha, [], true)
+        ).toBe(true);
+        expect(
+          await persistGitHubPullRequestSnapshot(
+            "f0rr0",
+            snapshot,
+            { refreshMembership: true },
+            new Date("2026-08-30T12:01:00.000Z")
+          )
+        ).toMatchObject({
+          membershipRefreshRequired: false,
+          versionId: stored.versionId,
+        });
+        expect(
+          await admin`
+            select
+              v.membership_complete,
+              count(m.*)::integer as membership_count
+            from github_pull_request_versions v
+            left join github_pull_request_memberships m on m.version_id = v.id
+            where v.id = ${stored.versionId}::uuid
+            group by v.id
+          `
+        ).toEqual([{ membership_complete: true, membership_count: 0 }]);
+      } finally {
+        await admin`
+          delete from github_pull_requests
+          where node_id = ${pullRequestNodeId}
         `;
         await admin`
           delete from github_repositories
@@ -1376,9 +1589,10 @@ describe.skipIf(!dockerAvailable)(
       const claimedAt = new Date("2026-08-30T12:00:00.000Z");
 
       await admin`
-        insert into github_account_checkpoints (account)
-        values ('f0rr0')
-        on conflict (account) do nothing
+        insert into github_account_checkpoints (account, ref_backfill_since_at)
+        values ('f0rr0', '2018-01-01T00:00:00.000Z')
+        on conflict (account) do update
+        set ref_backfill_since_at = excluded.ref_backfill_since_at
       `;
       await admin`
         insert into github_repositories (
@@ -1394,7 +1608,7 @@ describe.skipIf(!dockerAvailable)(
           lease_until, observed_at, ref_name, repository_id,
           repository_name_snapshot, source, source_id, state
         ) values (
-          'f0rr0', ${"4".repeat(40)}, 7, ${"3".repeat(40)},
+          'f0rr0', ${"4".repeat(40)}, 7, ${"0".repeat(40)},
           'observation_retry', ${priorRetryAt.toISOString()}, '2018-01-01T00:00:00.000Z',
           'refs/heads/deadline-release', ${repositoryId},
           'f0rr0/deadline-release', 'refs', 'deadline-release-observation',
@@ -1464,6 +1678,10 @@ describe.skipIf(!dockerAvailable)(
         claimedAt
       );
       expect(observation.repositoryId).toBe(repositoryId);
+      expect(observation.historySinceAt).toBeInstanceOf(Date);
+      expect(observation.historySinceAt.toISOString()).toBe(
+        "2018-01-01T00:00:00.000Z"
+      );
       expect(enrichment.repositoryId).toBe(repositoryId);
       expect(signal.repositoryId).toBe(repositoryId);
       expect(pullRequest.nodeId).toBe("PR_deadline_release");

--- a/tests/github-backfill.test.mjs
+++ b/tests/github-backfill.test.mjs
@@ -128,6 +128,8 @@ describe("GitHub history backfill requests", () => {
     expect(
       githubBackfillProcessingCountsFrom({
         aliases: 7,
+        canonicalizationAttempts: 9,
+        canonicalized: 8,
         commits: {
           claimed: 4,
           completed: 1,
@@ -173,6 +175,8 @@ describe("GitHub history backfill requests", () => {
       })
     ).toEqual({
       aliases: 7,
+      canonicalizationAttempts: 9,
+      canonicalized: 8,
       claimed: 20,
       deferred: 5,
       failed: 3,
@@ -183,13 +187,22 @@ describe("GitHub history backfill requests", () => {
 
   test("keeps draining when canonicalization progresses without queue claims", () => {
     expect(
-      githubBackfillProcessingMadeProgress({ aliases: 1, claimed: 0 })
+      githubBackfillProcessingMadeProgress({
+        canonicalizationAttempts: 1,
+        claimed: 0,
+      })
     ).toBe(true);
     expect(
-      githubBackfillProcessingMadeProgress({ aliases: 0, claimed: 1 })
+      githubBackfillProcessingMadeProgress({
+        canonicalizationAttempts: 0,
+        claimed: 1,
+      })
     ).toBe(true);
     expect(
-      githubBackfillProcessingMadeProgress({ aliases: 0, claimed: 0 })
+      githubBackfillProcessingMadeProgress({
+        canonicalizationAttempts: 0,
+        claimed: 0,
+      })
     ).toBe(false);
   });
 
@@ -222,6 +235,20 @@ describe("GitHub history backfill requests", () => {
         nowAt + 60 * 60 * 1000,
         nowAt
       )
+    ).toBeNull();
+  });
+
+  test("retries an inconclusive projection read only twice", () => {
+    const nowAt = Date.parse("2026-08-30T00:00:00.000Z");
+    const audits = [auditResult("inconclusive", null)];
+    expect(
+      backfillRetryWaitMillisecondsFrom(audits, nowAt + 60_000, nowAt, 0)
+    ).toBe(1000);
+    expect(
+      backfillRetryWaitMillisecondsFrom(audits, nowAt + 60_000, nowAt, 1)
+    ).toBe(1000);
+    expect(
+      backfillRetryWaitMillisecondsFrom(audits, nowAt + 60_000, nowAt, 2)
     ).toBeNull();
   });
 


### PR DESCRIPTION
## Summary

- decode ref-history fallback timestamps as runtime `Date` values
- count ordinary canonicalization as worker progress and prevent concurrent retries from moving settled watermarks
- preserve unchanged PR observation timestamps so audits do not invent reconciliation backlog
- validate PR membership completeness against expected count and terminal head at read, write, and audit boundaries
- invalidate stale PR-derived aliases before rejecting corrupt membership
- retry transient inconclusive projection reads within the bounded backfill deadline

## Production evidence

- reproduced the deferred ref observation TypeError against its exact production row; correct decoding expands it to 135 SHAs / 34 tracked commits
- observed canonicalization draining eight rows per cron while reporting zero progress, explaining the apparent forever backfill
- identified 11 unchanged open PR versions whose `observed_at` was advanced without a provider change
- compared all current work PR memberships with GitHub: 184/186 were exact and the two defects are now covered by the integrity guard
- matched 28/28 sampled public sources across every rendered August day/repository and 12/12 sampled PRs against GitHub

## Validation

- 242 tests pass
- 14 PostgreSQL integration tests pass
- typecheck, lint, formatting, and production build pass
- independent code review found no remaining blocker