### PR TITLE
fix: recover exact webhook commit lists

### DIFF
--- a/src/lib/github-activity-processor.ts
+++ b/src/lib/github-activity-processor.ts
@@ -1207,7 +1207,7 @@ const newBranchCommitValuesWithToken = async (
   return values.toReversed();
 };
 
-const pushCommitValuesWithToken = async (
+const reachablePushCommitValuesWithToken = async (
   row: GitHubActivityPushObservationReference,
   token: string,
   options: GitHubProviderRequestOptions = {}
@@ -1235,6 +1235,41 @@ const pushCommitValuesWithToken = async (
       throw error;
     }
   }
+};
+
+// An exact webhook/Event payload remains authoritative when later ref changes
+// make GitHub's current compare or reachable history disagree with that push.
+const hasCompleteDurablePushEvidence = (
+  row: GitHubActivityPushObservationReference
+) =>
+  row.expectedCommitCount !== null &&
+  row.expectedCommitCount > 0 &&
+  row.knownShas.length === row.expectedCommitCount &&
+  row.knownShas.at(-1) === row.afterSha &&
+  new Set(row.knownShas).size === row.knownShas.length &&
+  row.knownShas.every((sha) => commitShaFrom(sha) !== null);
+
+const durablePushCommitValuesWithToken = async (
+  row: GitHubActivityPushObservationReference,
+  token: string,
+  options: GitHubProviderRequestOptions = {}
+) => {
+  const values: unknown[] = [];
+  for (const sha of row.knownShas) {
+    const value = await fetchJson(
+      repositoryApiPath(row.repository, `/commits/${encodeURIComponent(sha)}`),
+      token,
+      options
+    );
+    if (!isObject(value) || commitShaFrom(value.sha) !== sha) {
+      throw new ActivityProcessingError(
+        "source_invalid",
+        "GitHub returned a commit that contradicted durable push evidence."
+      );
+    }
+    values.push(value);
+  }
+  return values;
 };
 
 export const validateGitHubPushObservationCommitShas = (
@@ -1357,30 +1392,51 @@ const pushObservationSourceWithToken = async (
   options: GitHubProviderRequestOptions = {}
 ): Promise<GitHubActivityPushObservationSource> => {
   const repository = repositoryReferenceFrom(row);
-  const values = await pushCommitValuesWithToken(row, token, options);
-  const commitShas: string[] = [];
-  const commits: GitHubCommit[] = [];
-  const seen = new Set<string>();
-  for (const value of values) {
-    const sha = isObject(value) ? commitShaFrom(value.sha) : null;
-    if (sha === null) {
-      throw new ActivityProcessingError(
-        "source_invalid",
-        "GitHub returned an invalid pushed commit."
-      );
+  const sourceFromValues = (values: readonly unknown[]) => {
+    const commitShas: string[] = [];
+    const commits: GitHubCommit[] = [];
+    const seen = new Set<string>();
+    for (const value of values) {
+      const sha = isObject(value) ? commitShaFrom(value.sha) : null;
+      if (sha === null) {
+        throw new ActivityProcessingError(
+          "source_invalid",
+          "GitHub returned an invalid pushed commit."
+        );
+      }
+      if (seen.has(sha)) {
+        continue;
+      }
+      seen.add(sha);
+      commitShas.push(sha);
+      const commit = trackedCommitFromPushValue(value, sha, repository);
+      if (commit !== null) {
+        commits.push(commit);
+      }
     }
-    if (seen.has(sha)) {
-      continue;
+    validateGitHubPushObservationCommitShas(row, commitShas);
+    return { commitShas, commits };
+  };
+
+  try {
+    const values = await reachablePushCommitValuesWithToken(
+      row,
+      token,
+      options
+    );
+    return sourceFromValues(values);
+  } catch (error) {
+    const sourceBecameIncomplete =
+      (error instanceof ActivityProcessingError &&
+        error.code === "source_incomplete") ||
+      (error instanceof GitHubResponseError &&
+        [404, 409].includes(error.status));
+    if (!sourceBecameIncomplete || !hasCompleteDurablePushEvidence(row)) {
+      throw error;
     }
-    seen.add(sha);
-    commitShas.push(sha);
-    const commit = trackedCommitFromPushValue(value, sha, repository);
-    if (commit !== null) {
-      commits.push(commit);
-    }
+    const values = await durablePushCommitValuesWithToken(row, token, options);
+    return sourceFromValues(values);
   }
-  validateGitHubPushObservationCommitShas(row, commitShas);
-  return { commitShas, commits };
 };
 
 export const fetchGitHubPushObservationSource = async (

--- a/tests/github-activity-processor.test.mjs
+++ b/tests/github-activity-processor.test.mjs
@@ -310,7 +310,99 @@ describe("GitHub activity commit acquisition", () => {
     expect(source.commits[0]?.author).toBe("f0rr0");
   });
 
-  test("rejects surplus compare commits instead of truncating away the head", async () => {
+  test("recovers an exact durable push when the current compare has surplus commits", async () => {
+    const beforeSha = "1".repeat(40);
+    const firstSha = "2".repeat(40);
+    const surplusSha = "3".repeat(40);
+    const afterSha = "4".repeat(40);
+    const paths = [];
+    env.GITHUB_F0RR0_TOKEN = "test-token";
+    globalThis.fetch = async (input) => {
+      const url =
+        input instanceof Request ? new URL(input.url) : new URL(input);
+      paths.push(url.pathname);
+      if (url.pathname.includes("/compare/")) {
+        return Response.json({
+          ahead_by: 3,
+          total_commits: 3,
+          commits: [
+            pushCommitValue(surplusSha, "octocat", 200),
+            pushCommitValue(firstSha, "f0rr0", 100),
+            pushCommitValue(afterSha, "f0rr0", 100),
+          ],
+        });
+      }
+      const sha = url.pathname.split("/").at(-1);
+      return Response.json(pushCommitValue(sha, "f0rr0", 100));
+    };
+
+    const source = await fetchGitHubPushObservationSource({
+      account: "f0rr0",
+      afterSha,
+      beforeSha,
+      expectedCommitCount: 2,
+      knownShas: [firstSha, afterSha],
+      observedAt: new Date("2026-08-28T12:00:00.000Z"),
+      refName: "refs/heads/main",
+      repository: "example-org/example-repo",
+      repositoryId: "123",
+    });
+
+    expect(paths).toEqual([
+      `/repos/example-org/example-repo/compare/${beforeSha}...${afterSha}`,
+      `/repos/example-org/example-repo/commits/${firstSha}`,
+      `/repos/example-org/example-repo/commits/${afterSha}`,
+    ]);
+    expect(source.commitShas).toEqual([firstSha, afterSha]);
+    expect(source.commits.map(({ sha }) => sha)).toEqual([firstSha, afterSha]);
+  });
+
+  test("recovers durable members when the current compare has the same count and head", async () => {
+    const beforeSha = "1".repeat(40);
+    const firstSha = "2".repeat(40);
+    const otherSha = "3".repeat(40);
+    const afterSha = "4".repeat(40);
+    const paths = [];
+    env.GITHUB_F0RR0_TOKEN = "test-token";
+    globalThis.fetch = async (input) => {
+      const url =
+        input instanceof Request ? new URL(input.url) : new URL(input);
+      paths.push(url.pathname);
+      if (url.pathname.includes("/compare/")) {
+        return Response.json({
+          ahead_by: 2,
+          total_commits: 2,
+          commits: [
+            pushCommitValue(otherSha, "octocat", 200),
+            pushCommitValue(afterSha, "f0rr0", 100),
+          ],
+        });
+      }
+      const sha = url.pathname.split("/").at(-1);
+      return Response.json(pushCommitValue(sha, "f0rr0", 100));
+    };
+
+    const source = await fetchGitHubPushObservationSource({
+      account: "f0rr0",
+      afterSha,
+      beforeSha,
+      expectedCommitCount: 2,
+      knownShas: [firstSha, afterSha],
+      observedAt: new Date("2026-08-28T12:00:00.000Z"),
+      refName: "refs/heads/main",
+      repository: "example-org/example-repo",
+      repositoryId: "123",
+    });
+
+    expect(paths).toEqual([
+      `/repos/example-org/example-repo/compare/${beforeSha}...${afterSha}`,
+      `/repos/example-org/example-repo/commits/${firstSha}`,
+      `/repos/example-org/example-repo/commits/${afterSha}`,
+    ]);
+    expect(source.commitShas).toEqual([firstSha, afterSha]);
+  });
+
+  test("rejects surplus compare commits without complete durable evidence", async () => {
     const beforeSha = "1".repeat(40);
     const firstSha = "2".repeat(40);
     const surplusSha = "3".repeat(40);
@@ -333,7 +425,7 @@ describe("GitHub activity commit acquisition", () => {
         afterSha,
         beforeSha,
         expectedCommitCount: 2,
-        knownShas: [firstSha, afterSha],
+        knownShas: [afterSha],
         observedAt: new Date("2026-08-28T12:00:00.000Z"),
         refName: "refs/heads/main",
         repository: "example-org/example-repo",
@@ -535,6 +627,85 @@ describe("GitHub activity commit acquisition", () => {
     expect(source.commitShas).toEqual([olderSha, afterSha]);
     expect(source.commits.map(({ sha }) => sha)).toEqual([afterSha]);
     expect(source.commits[0]?.committedAt).toBe("2026-08-28T12:01:00.000Z");
+  });
+
+  test("recovers durable members when force-push history has unrelated ancestors", async () => {
+    const beforeSha = "1".repeat(40);
+    const olderSha = "2".repeat(40);
+    const firstSha = "3".repeat(40);
+    const afterSha = "4".repeat(40);
+    const paths = [];
+    env.GITHUB_F0RR0_TOKEN = "test-token";
+    globalThis.fetch = async (input) => {
+      const url =
+        input instanceof Request ? new URL(input.url) : new URL(input);
+      paths.push(url.pathname);
+      if (url.pathname.includes("/compare/")) {
+        return new Response(null, { status: 404 });
+      }
+      if (url.pathname === "/graphql") {
+        return Response.json({
+          data: {
+            repository: {
+              object: {
+                history: {
+                  nodes: [
+                    {
+                      author: { user: { login: "f0rr0" } },
+                      authoredDate: "2026-08-28T12:00:00Z",
+                      committedDate: "2026-08-28T12:01:00Z",
+                      message: "head",
+                      oid: afterSha,
+                      url: `https://github.com/example-org/example-repo/commit/${afterSha}`,
+                    },
+                    {
+                      author: { user: { login: "f0rr0" } },
+                      authoredDate: "2026-08-28T11:00:00Z",
+                      committedDate: "2026-08-28T11:01:00Z",
+                      message: "first",
+                      oid: firstSha,
+                      url: `https://github.com/example-org/example-repo/commit/${firstSha}`,
+                    },
+                    {
+                      author: { user: { login: "octocat" } },
+                      authoredDate: "2026-08-28T10:00:00Z",
+                      committedDate: "2026-08-28T10:01:00Z",
+                      message: "older",
+                      oid: olderSha,
+                      url: `https://github.com/example-org/example-repo/commit/${olderSha}`,
+                    },
+                  ],
+                  pageInfo: { endCursor: null, hasNextPage: false },
+                },
+              },
+            },
+          },
+        });
+      }
+      const sha = url.pathname.split("/").at(-1);
+      return Response.json(pushCommitValue(sha, "f0rr0", 100));
+    };
+
+    const source = await fetchGitHubPushObservationSource({
+      account: "f0rr0",
+      afterSha,
+      beforeSha,
+      expectedCommitCount: 2,
+      historySinceAt: new Date("2026-08-18T00:00:00.000Z"),
+      knownShas: [firstSha, afterSha],
+      observedAt: new Date("2026-08-28T12:34:00.000Z"),
+      refName: "refs/heads/main",
+      repository: "example-org/example-repo",
+      repositoryId: "123",
+    });
+
+    expect(paths).toEqual([
+      `/repos/example-org/example-repo/compare/${beforeSha}...${afterSha}`,
+      "/graphql",
+      `/repos/example-org/example-repo/commits/${firstSha}`,
+      `/repos/example-org/example-repo/commits/${afterSha}`,
+    ]);
+    expect(source.commitShas).toEqual([firstSha, afterSha]);
   });
 
   test("bounds a new branch by the observed count without slicing history", async () => {


### PR DESCRIPTION
## What changed
- recover exact push commit lists from durable GitHub App webhook/Event evidence when later compare or reachable history has moved
- hydrate each recorded SHA from GitHub and verify the provider response
- fail closed when the durable list is incomplete, duplicated, malformed, or does not end at the observed head
- validate count, order, and membership inside the recovery boundary, including force-push history

## Production evidence
- Oliphaunt push observation 2db2fcb2-40c1-46d9-87cb-806614bfba36 recorded exactly 2 introduced SHAs
- the current GitHub compare now returns 3 commits, which previously exhausted retries as source_incomplete
- both recorded SHAs still resolve individually, are authored by f0rr0, and the patched acquisition returns precisely those 2 commits in order

## Verification
- 245 tests passed with 1,534 assertions
- includes same-count contradictory comparison and force-push surplus-history regressions
- typecheck, lint, formatting, and production build passed
- read-only execution against the exact production observation passed