### PR TITLE
fix: harden github activity recovery

### DIFF
--- a/scripts/backfill-github-activity.ts
+++ b/scripts/backfill-github-activity.ts
@@ -30,8 +30,7 @@ import { backfillGitHubCommitsFromCurrentRefs } from "../src/lib/github-direct-b
 import { backfillGitHubPullRequests } from "../src/lib/github-pull-request-backfill";
 
 const MAXIMUM_ACTION_MINUTES = 330;
-const MAXIMUM_INCONCLUSIVE_AUDIT_RETRIES = 2;
-const INCONCLUSIVE_AUDIT_RETRY_MS = 1000;
+const INCONCLUSIVE_AUDIT_RETRY_DELAYS_MS = [2000, 5000, 10_000] as const;
 const WORKER_CLEANUP_MARGIN_MS = 30_000;
 const WORKER_PASS_DURATION_MS = 240_000;
 
@@ -272,9 +271,10 @@ export const backfillRetryWaitMillisecondsFrom = (
     return null;
   }
   if (audits.some(({ status }) => status === "inconclusive")) {
-    return inconclusiveRetries < MAXIMUM_INCONCLUSIVE_AUDIT_RETRIES &&
-      now + INCONCLUSIVE_AUDIT_RETRY_MS + WORKER_CLEANUP_MARGIN_MS < deadlineAt
-      ? INCONCLUSIVE_AUDIT_RETRY_MS
+    const retryDelay = INCONCLUSIVE_AUDIT_RETRY_DELAYS_MS[inconclusiveRetries];
+    return retryDelay !== undefined &&
+      now + retryDelay + WORKER_CLEANUP_MARGIN_MS < deadlineAt
+      ? retryDelay
       : null;
   }
   const retryTimes = audits.flatMap(({ pipeline, status }) => {
@@ -315,6 +315,10 @@ const runScopedAudits = async (
   request: GitHubBackfillRequest,
   deadlineAt: number
 ) => {
+  // Provider discovery can keep this process alive for minutes. Give each
+  // strict projection audit a fresh connection instead of reusing a client
+  // that may have crossed a pooler/network idle boundary.
+  await closeDatabase();
   const auditNow = new Date();
   return await runBeforeDeadline(
     Promise.all(

--- a/src/lib/github-activity-audit.ts
+++ b/src/lib/github-activity-audit.ts
@@ -298,7 +298,12 @@ export interface GitHubActivityAuditEvidence {
   legacyPullRequestMilestones: number;
   pipelineEvidence?: GitHubActivityAuditPipelineEvidence;
   projectionDays: readonly PublicGitHubActivityDay[];
-  projectionError: string | null;
+  projectionError: GitHubActivityAuditProjectionError | null;
+}
+
+export interface GitHubActivityAuditProjectionError {
+  code: string | null;
+  name: string;
 }
 
 export interface GitHubActivityAuditPipelineEvidence {
@@ -435,6 +440,9 @@ export interface GitHubActivityAuditReport {
     };
     providerCompleteness: "not_assessed";
     statement: string;
+  };
+  diagnostics: {
+    projectionError: GitHubActivityAuditProjectionError | null;
   };
   inventory: {
     commitsObserved: number;
@@ -643,6 +651,7 @@ export const buildGitHubActivityAuditReport = (
           ? "Provider completeness is not assessed. The projection comparison is global while pipeline inventory is scoped to the requested account. This audit only verifies evidence already stored in PostgreSQL; deleted or rewritten refs and events never observed by this system can be absent."
           : "Provider completeness is not assessed. Projection and pipeline evidence are scoped to the requested account, repository, and window. This audit only verifies evidence already stored in PostgreSQL; deleted or rewritten refs and events never observed by this system can be absent.",
     },
+    diagnostics: { projectionError: evidence.projectionError },
     inventory: {
       commitsObserved: evidence.commits.length,
       issuesObserved: evidence.issues.length,
@@ -1310,11 +1319,27 @@ export const runGitHubActivityAudit = async (
         request.repositoryId === null ? null : scopedProjectionSourceIds(before)
       );
     } catch (error) {
+      const rawCode =
+        typeof error === "object" &&
+        error !== null &&
+        "code" in error &&
+        typeof error.code === "string"
+          ? error.code
+          : null;
       return buildGitHubActivityAuditReport(request, {
         ...before,
         projectionDays: [],
-        projectionError:
-          error instanceof Error ? error.name : "UnknownProjectionError",
+        projectionError: {
+          code:
+            rawCode !== null && /^[A-Za-z0-9_-]{1,64}$/.test(rawCode)
+              ? rawCode
+              : null,
+          name:
+            error instanceof Error &&
+            /^[A-Za-z][A-Za-z0-9_-]{0,79}$/.test(error.name)
+              ? error.name
+              : "UnknownProjectionError",
+        },
       });
     }
     const after = await readStoredEvidence(request);
@@ -1333,6 +1358,9 @@ export const runGitHubActivityAudit = async (
   return buildGitHubActivityAuditReport(request, {
     ...lastStored,
     projectionDays: lastProjectionDays,
-    projectionError: "ConcurrentStoredEvidenceChange",
+    projectionError: {
+      code: null,
+      name: "ConcurrentStoredEvidenceChange",
+    },
   });
 };

--- a/src/lib/github-activity-processor.ts
+++ b/src/lib/github-activity-processor.ts
@@ -43,6 +43,7 @@ const MAXIMUM_GITHUB_FILE_PAGES = 30;
 const GITHUB_PULL_REQUEST_COMMIT_LIMIT = 250;
 const GITHUB_GRAPHQL_NODE_BATCH_SIZE = 100;
 const GITHUB_GRAPHQL_SECONDARY_LIMIT_WAIT_MS = 60_000;
+const MAXIMUM_DURABLE_PUSH_COMMIT_FALLBACK = 100;
 const ZERO_SHA = "0".repeat(40);
 
 type JsonObject = Record<string, unknown>;
@@ -1207,6 +1208,18 @@ const newBranchCommitValuesWithToken = async (
   return values.toReversed();
 };
 
+// An exact webhook/Event payload remains authoritative when later ref changes
+// make GitHub's current compare or reachable history disagree with that push.
+const hasCompleteDurablePushEvidence = (
+  row: GitHubActivityPushObservationReference
+) =>
+  row.expectedCommitCount !== null &&
+  row.expectedCommitCount > 0 &&
+  row.knownShas.length === row.expectedCommitCount &&
+  row.knownShas.at(-1) === row.afterSha &&
+  new Set(row.knownShas).size === row.knownShas.length &&
+  row.knownShas.every((sha) => commitShaFrom(sha) !== null);
+
 const reachablePushCommitValuesWithToken = async (
   row: GitHubActivityPushObservationReference,
   token: string,
@@ -1224,6 +1237,11 @@ const reachablePushCommitValuesWithToken = async (
     ) {
       throw error;
     }
+    if (hasCompleteDurablePushEvidence(row)) {
+      // Let the outer recovery boundary hydrate the exact durable members
+      // without first walking potentially long reachable branch history.
+      throw error;
+    }
     try {
       return await newBranchCommitValuesWithToken(
         { ...row, beforeSha: ZERO_SHA, expectedCommitCount: null },
@@ -1237,23 +1255,17 @@ const reachablePushCommitValuesWithToken = async (
   }
 };
 
-// An exact webhook/Event payload remains authoritative when later ref changes
-// make GitHub's current compare or reachable history disagree with that push.
-const hasCompleteDurablePushEvidence = (
-  row: GitHubActivityPushObservationReference
-) =>
-  row.expectedCommitCount !== null &&
-  row.expectedCommitCount > 0 &&
-  row.knownShas.length === row.expectedCommitCount &&
-  row.knownShas.at(-1) === row.afterSha &&
-  new Set(row.knownShas).size === row.knownShas.length &&
-  row.knownShas.every((sha) => commitShaFrom(sha) !== null);
-
 const durablePushCommitValuesWithToken = async (
   row: GitHubActivityPushObservationReference,
   token: string,
   options: GitHubProviderRequestOptions = {}
 ) => {
+  if (row.knownShas.length > MAXIMUM_DURABLE_PUSH_COMMIT_FALLBACK) {
+    throw new ActivityProcessingError(
+      "source_incomplete",
+      "Exact durable push recovery exceeds the bounded commit hydration limit."
+    );
+  }
   const values: unknown[] = [];
   for (const sha of row.knownShas) {
     const value = await fetchJson(

--- a/tests/github-activity-audit.test.mjs
+++ b/tests/github-activity-audit.test.mjs
@@ -344,10 +344,14 @@ describe("GitHub activity audit", () => {
       issues: [],
       legacyPullRequestMilestones: 0,
       projectionDays: [],
-      projectionError: "DatabaseError",
+      projectionError: { code: "08006", name: "DatabaseError" },
     });
 
     expect(report.status).toBe("inconclusive");
+    expect(report.diagnostics.projectionError).toEqual({
+      code: "08006",
+      name: "DatabaseError",
+    });
     expect(githubActivityAuditExitCodeFromStatus(report.status)).toBe(2);
     expect(githubActivityAuditExitCodeFromStatus("mismatch")).toBe(1);
     expect(

--- a/tests/github-activity-processor.test.mjs
+++ b/tests/github-activity-processor.test.mjs
@@ -629,9 +629,8 @@ describe("GitHub activity commit acquisition", () => {
     expect(source.commits[0]?.committedAt).toBe("2026-08-28T12:01:00.000Z");
   });
 
-  test("recovers durable members when force-push history has unrelated ancestors", async () => {
+  test("bypasses reachable history when exact durable members survive a force-push", async () => {
     const beforeSha = "1".repeat(40);
-    const olderSha = "2".repeat(40);
     const firstSha = "3".repeat(40);
     const afterSha = "4".repeat(40);
     const paths = [];
@@ -643,45 +642,7 @@ describe("GitHub activity commit acquisition", () => {
       if (url.pathname.includes("/compare/")) {
         return new Response(null, { status: 404 });
       }
-      if (url.pathname === "/graphql") {
-        return Response.json({
-          data: {
-            repository: {
-              object: {
-                history: {
-                  nodes: [
-                    {
-                      author: { user: { login: "f0rr0" } },
-                      authoredDate: "2026-08-28T12:00:00Z",
-                      committedDate: "2026-08-28T12:01:00Z",
-                      message: "head",
-                      oid: afterSha,
-                      url: `https://github.com/example-org/example-repo/commit/${afterSha}`,
-                    },
-                    {
-                      author: { user: { login: "f0rr0" } },
-                      authoredDate: "2026-08-28T11:00:00Z",
-                      committedDate: "2026-08-28T11:01:00Z",
-                      message: "first",
-                      oid: firstSha,
-                      url: `https://github.com/example-org/example-repo/commit/${firstSha}`,
-                    },
-                    {
-                      author: { user: { login: "octocat" } },
-                      authoredDate: "2026-08-28T10:00:00Z",
-                      committedDate: "2026-08-28T10:01:00Z",
-                      message: "older",
-                      oid: olderSha,
-                      url: `https://github.com/example-org/example-repo/commit/${olderSha}`,
-                    },
-                  ],
-                  pageInfo: { endCursor: null, hasNextPage: false },
-                },
-              },
-            },
-          },
-        });
-      }
+      expect(url.pathname).not.toBe("/graphql");
       const sha = url.pathname.split("/").at(-1);
       return Response.json(pushCommitValue(sha, "f0rr0", 100));
     };
@@ -701,11 +662,45 @@ describe("GitHub activity commit acquisition", () => {
 
     expect(paths).toEqual([
       `/repos/example-org/example-repo/compare/${beforeSha}...${afterSha}`,
-      "/graphql",
       `/repos/example-org/example-repo/commits/${firstSha}`,
       `/repos/example-org/example-repo/commits/${afterSha}`,
     ]);
     expect(source.commitShas).toEqual([firstSha, afterSha]);
+  });
+
+  test("rejects an over-cap durable fallback before commit hydration", async () => {
+    const beforeSha = "f".repeat(40);
+    const knownShas = Array.from({ length: 101 }, (_, index) =>
+      (index + 1).toString(16).padStart(40, "0")
+    );
+    const afterSha = knownShas.at(-1);
+    const paths = [];
+    env.GITHUB_F0RR0_TOKEN = "test-token";
+    globalThis.fetch = async (input) => {
+      const url =
+        input instanceof Request ? new URL(input.url) : new URL(input);
+      paths.push(url.pathname);
+      return new Response(null, { status: 404 });
+    };
+
+    await expect(
+      fetchGitHubPushObservationSource({
+        account: "f0rr0",
+        afterSha,
+        beforeSha,
+        expectedCommitCount: knownShas.length,
+        historySinceAt: new Date("2026-08-18T00:00:00.000Z"),
+        knownShas,
+        observedAt: new Date("2026-08-28T12:34:00.000Z"),
+        refName: "refs/heads/main",
+        repository: "example-org/example-repo",
+        repositoryId: "123",
+      })
+    ).rejects.toMatchObject({ code: "source_incomplete" });
+
+    expect(paths).toEqual([
+      `/repos/example-org/example-repo/compare/${beforeSha}...${afterSha}`,
+    ]);
   });
 
   test("bounds a new branch by the observed count without slicing history", async () => {

--- a/tests/github-backfill.test.mjs
+++ b/tests/github-backfill.test.mjs
@@ -238,17 +238,20 @@ describe("GitHub history backfill requests", () => {
     ).toBeNull();
   });
 
-  test("retries an inconclusive projection read only twice", () => {
+  test("retries an inconclusive projection read with bounded backoff", () => {
     const nowAt = Date.parse("2026-08-30T00:00:00.000Z");
     const audits = [auditResult("inconclusive", null)];
     expect(
       backfillRetryWaitMillisecondsFrom(audits, nowAt + 60_000, nowAt, 0)
-    ).toBe(1000);
+    ).toBe(2000);
     expect(
       backfillRetryWaitMillisecondsFrom(audits, nowAt + 60_000, nowAt, 1)
-    ).toBe(1000);
+    ).toBe(5000);
     expect(
       backfillRetryWaitMillisecondsFrom(audits, nowAt + 60_000, nowAt, 2)
+    ).toBe(10_000);
+    expect(
+      backfillRetryWaitMillisecondsFrom(audits, nowAt + 60_000, nowAt, 3)
     ).toBeNull();
   });
 


### PR DESCRIPTION
## What changed
- open a fresh PostgreSQL connection for every strict post-discovery audit
- retry inconclusive projection reads on a bounded 2s, 5s, and 10s schedule without weakening the audit
- emit only sanitized projection error name/code diagnostics
- bypass reachable-history walks when exact durable push evidence can be hydrated directly
- cap exact sequential recovery at 100 commits so a maximum-size stale push becomes an explicit gap instead of starving every worker run

## Production evidence
- the August backfill completed discovery in 19 minutes with zero pending queues, then three projection reads on one long-lived client returned inconclusive
- replaying the exact failed snapshot succeeded with all 456 sources through both transaction and session poolers
- after exact webhook recovery, the strict August audit passes 459/459 with zero coverage gaps and every queue settled
- the live August 31 page renders 2 unique repository headers for 2 repositories and contains no merge milestones or PR-work labels

## Verification
- 246 tests passed with 1,540 assertions
- typecheck, lint, formatting, production build, and diff check passed
- focused exact-push tests cover compare contradictions, 404 bypass, and over-cap rejection before commit hydration