### PR TITLE
fix: preserve github provider fallback errors

### DIFF
--- a/src/lib/github-activity-processor.ts
+++ b/src/lib/github-activity-processor.ts
@@ -1446,6 +1446,15 @@ const pushObservationSourceWithToken = async (
     if (!sourceBecameIncomplete || !hasCompleteDurablePushEvidence(row)) {
       throw error;
     }
+    if (
+      row.knownShas.length > MAXIMUM_DURABLE_PUSH_COMMIT_FALLBACK &&
+      (error instanceof GitHubGraphQlResponseError ||
+        (error instanceof GitHubResponseError && error.status === 404))
+    ) {
+      // Preserve provider error typing so another configured token can still
+      // read a private comparison and retryable GraphQL metadata is not lost.
+      throw error;
+    }
     const values = await durablePushCommitValuesWithToken(row, token, options);
     return sourceFromValues(values);
   }

--- a/tests/github-activity-processor.test.mjs
+++ b/tests/github-activity-processor.test.mjs
@@ -696,11 +696,119 @@ describe("GitHub activity commit acquisition", () => {
         repository: "example-org/example-repo",
         repositoryId: "123",
       })
-    ).rejects.toMatchObject({ code: "source_incomplete" });
+    ).rejects.toMatchObject({ status: 404 });
 
     expect(paths).toEqual([
       `/repos/example-org/example-repo/compare/${beforeSha}...${afterSha}`,
     ]);
+  });
+
+  test("lets another token settle an over-cap exact comparison", async () => {
+    const beforeSha = "f".repeat(40);
+    const knownShas = Array.from({ length: 101 }, (_, index) =>
+      (index + 1).toString(16).padStart(40, "0")
+    );
+    const afterSha = knownShas.at(-1);
+    let calls = 0;
+    env.GITHUB_F0RR0_TOKEN = "first-token";
+    env.GITHUB_YUPPIESTECHDEV_TOKEN = "second-token";
+    globalThis.fetch = async () => {
+      calls += 1;
+      if (calls === 1) {
+        return new Response(null, { status: 404 });
+      }
+      return Response.json({
+        ahead_by: knownShas.length,
+        commits: knownShas.map((sha) => pushCommitValue(sha, "f0rr0", 100)),
+        total_commits: knownShas.length,
+      });
+    };
+
+    const source = await fetchGitHubPushObservationSource({
+      account: "f0rr0",
+      afterSha,
+      beforeSha,
+      expectedCommitCount: knownShas.length,
+      historySinceAt: new Date("2026-08-18T00:00:00.000Z"),
+      knownShas,
+      observedAt: new Date("2026-08-28T12:34:00.000Z"),
+      refName: "refs/heads/main",
+      repository: "example-org/example-repo",
+      repositoryId: "123",
+    });
+
+    expect(calls).toBe(2);
+    expect(source.commitShas).toEqual(knownShas);
+  });
+
+  test("turns an over-cap comparison conflict into a bounded evidence gap", async () => {
+    const knownShas = Array.from({ length: 101 }, (_, index) =>
+      (index + 1).toString(16).padStart(40, "0")
+    );
+    const afterSha = knownShas.at(-1);
+    let calls = 0;
+    env.GITHUB_F0RR0_TOKEN = "test-token";
+    globalThis.fetch = async () => {
+      calls += 1;
+      return new Response(null, { status: 409 });
+    };
+
+    await expect(
+      fetchGitHubPushObservationSource({
+        account: "f0rr0",
+        afterSha,
+        beforeSha: "f".repeat(40),
+        expectedCommitCount: knownShas.length,
+        historySinceAt: new Date("2026-08-18T00:00:00.000Z"),
+        knownShas,
+        observedAt: new Date("2026-08-28T12:34:00.000Z"),
+        refName: "refs/heads/main",
+        repository: "example-org/example-repo",
+        repositoryId: "123",
+      })
+    ).rejects.toMatchObject({ code: "source_incomplete" });
+
+    expect(calls).toBe(1);
+  });
+
+  test("preserves retryable GraphQL metadata for an over-cap exact new branch", async () => {
+    const knownShas = Array.from({ length: 101 }, (_, index) =>
+      (index + 1).toString(16).padStart(40, "0")
+    );
+    const afterSha = knownShas.at(-1);
+    env.GITHUB_F0RR0_TOKEN = "test-token";
+    globalThis.fetch = async () =>
+      Response.json(
+        {
+          errors: [
+            {
+              extensions: { code: "RATE_LIMITED" },
+              message: "rate limited",
+            },
+          ],
+        },
+        { headers: { "retry-after": "120" } }
+      );
+
+    await expect(
+      fetchGitHubPushObservationSource({
+        account: "f0rr0",
+        afterSha,
+        beforeSha: "0".repeat(40),
+        expectedCommitCount: knownShas.length,
+        historySinceAt: new Date("2026-08-18T00:00:00.000Z"),
+        knownShas,
+        observedAt: new Date("2026-08-28T12:34:00.000Z"),
+        refName: "refs/heads/main",
+        repository: "example-org/example-repo",
+        repositoryId: "123",
+      })
+    ).rejects.toMatchObject({
+      code: "source_incomplete",
+      kind: "rate_limited",
+      retryable: true,
+      retryAt: expect.any(Date),
+    });
   });
 
   test("bounds a new branch by the observed count without slicing history", async () => {


### PR DESCRIPTION
## What changed
- preserve a private-repository 404 when exact durable recovery is over the bounded cap so another configured token can try the normal comparison
- preserve typed retryable GraphQL errors and retry timestamps instead of replacing them with a terminal plain error
- keep 409 and deterministic incomplete evidence on the bounded explicit-gap path

## Why
The 100-commit liveness cap prevented unbounded recovery, but the first version could suppress token rotation or rate-limit metadata at that boundary. This keeps both boundedness and provider retry semantics.

## Verification
- 249 tests passed with 1,545 assertions
- focused provider suite 42/42
- typecheck, lint, formatting, and diff check passed
- independent re-review found no blocker