### PR TITLE
fix: configure backfill cursor signing

### DIFF
--- a/.github/workflows/github-activity-backfill.yml
+++ b/.github/workflows/github-activity-backfill.yml
@@ -55,6 +55,7 @@ jobs:
       - name: Discover history and process work
         env:
           ACCOUNT: ${{ inputs.account }}
+          CRON_SECRET: ${{ secrets.ACTIVITY_CRON_SECRET }}
           DATABASE_URL: ${{ secrets.ACTIVITY_DATABASE_URL }}
           END_DATE: ${{ inputs.end_date }}
           GITHUB_F0RR0_TOKEN: ${{ secrets.ACTIVITY_F0RR0_TOKEN }}

--- a/scripts/backfill-github-activity.ts
+++ b/scripts/backfill-github-activity.ts
@@ -42,6 +42,13 @@ interface BackfillArguments {
   startDate: string;
 }
 
+interface BackfillEnvironment {
+  CRON_SECRET?: string;
+  DATABASE_URL?: string;
+  GITHUB_F0RR0_TOKEN?: string;
+  GITHUB_YUPPIESTECHDEV_TOKEN?: string;
+}
+
 const argumentValues = (arguments_: readonly string[]) => {
   const allowed = new Set([
     "account",
@@ -106,18 +113,27 @@ export const backfillArgumentsFrom = (
   };
 };
 
-const requireEnvironment = (input: BackfillArguments) => {
-  if (env.DATABASE_URL === undefined) {
+export const requireBackfillEnvironment = (
+  input: BackfillArguments,
+  environment: BackfillEnvironment = env
+) => {
+  if (environment.DATABASE_URL === undefined) {
     throw new Error("DATABASE_URL is not configured.");
+  }
+  if ((environment.CRON_SECRET?.trim().length ?? 0) < 32) {
+    throw new Error("CRON_SECRET must contain at least 32 characters.");
   }
   const accounts =
     input.account === "all" ? ["f0rr0", "yuppiestechdev"] : [input.account];
-  if (accounts.includes("f0rr0") && env.GITHUB_F0RR0_TOKEN === undefined) {
+  if (
+    accounts.includes("f0rr0") &&
+    environment.GITHUB_F0RR0_TOKEN === undefined
+  ) {
     throw new Error("GITHUB_F0RR0_TOKEN is not configured.");
   }
   if (
     accounts.includes("yuppiestechdev") &&
-    env.GITHUB_YUPPIESTECHDEV_TOKEN === undefined
+    environment.GITHUB_YUPPIESTECHDEV_TOKEN === undefined
   ) {
     throw new Error("GITHUB_YUPPIESTECHDEV_TOKEN is not configured.");
   }
@@ -344,7 +360,7 @@ const runScopedAudits = async (
 
 const main = async () => {
   const input = backfillArgumentsFrom(process.argv.slice(2));
-  requireEnvironment(input);
+  requireBackfillEnvironment(input);
   const request = githubBackfillRequestFrom(requestValue(input));
   if (request === null) {
     throw new TypeError(

--- a/tests/github-backfill.test.mjs
+++ b/tests/github-backfill.test.mjs
@@ -4,6 +4,7 @@ import { setTimeout as delay } from "node:timers/promises";
 import {
   backfillArgumentsFrom,
   backfillRetryWaitMillisecondsFrom,
+  requireBackfillEnvironment,
   runBeforeDeadline,
 } from "../scripts/backfill-github-activity.ts";
 import {
@@ -31,6 +32,41 @@ const auditResult = (status, earliestRetryAt) => ({
 });
 
 describe("GitHub history backfill requests", () => {
+  test("fails before discovery when cursor signing is not configured", () => {
+    const input = backfillArgumentsFrom([
+      "--account",
+      "f0rr0",
+      "--start-date",
+      "2026-08-01",
+      "--end-date",
+      "2026-08-29",
+      "--repository-id",
+      "",
+      "--maximum-minutes",
+      "60",
+    ]);
+    const configured = {
+      CRON_SECRET: "c".repeat(32),
+      DATABASE_URL: "postgresql://activity.example/database",
+      GITHUB_F0RR0_TOKEN: "token",
+    };
+    expect(() => {
+      requireBackfillEnvironment(input, configured);
+    }).not.toThrow();
+    expect(() => {
+      requireBackfillEnvironment(input, {
+        ...configured,
+        CRON_SECRET: undefined,
+      });
+    }).toThrow("CRON_SECRET must contain at least 32 characters");
+    expect(() => {
+      requireBackfillEnvironment(input, {
+        ...configured,
+        CRON_SECRET: `  ${"c".repeat(31)}  `,
+      });
+    }).toThrow("CRON_SECRET must contain at least 32 characters");
+  });
+
   test("rejects duplicate and unknown command arguments", () => {
     expect(() =>
       backfillArgumentsFrom(["--account", "f0rr0", "--account", "f0rr0"])


### PR DESCRIPTION
## Summary
- provide the cursor-signing secret to manual GitHub activity backfills
- fail before provider discovery when cursor signing is unavailable
- cover the startup contract with a regression test

## Causal proof
Against the same August production rows:
- without `CRON_SECRET`: projection `TypeError`, 462 expected / 0 rendered
- with `CRON_SECRET`: projection readable, 462 expected / 462 rendered

## Verification
- 250 tests pass
- typecheck passes
- lint passes
- production build passes