### PR TITLE
fix: canonicalize duplicate GitHub work

### DIFF
--- a/drizzle/0012_empty_wendell_vaughn.sql
+++ b/drizzle/0012_empty_wendell_vaughn.sql
@@ -1,0 +1,203 @@
+CREATE INDEX IF NOT EXISTS "github_commits_exact_authored_change_idx" ON "github_commits" USING btree ("repository_id","change_fingerprint","author_user_id") WHERE "github_commits"."fingerprint_complete" AND "github_commits"."change_fingerprint" IS NOT NULL AND "github_commits"."author_user_id" IS NOT NULL;
+--> statement-breakpoint
+DO $$
+DECLARE
+	"affected_repository_id" text;
+BEGIN
+	FOR "affected_repository_id" IN
+		SELECT DISTINCT "duplicate_cohorts"."repository_id"
+		FROM (
+			SELECT "github_commits"."repository_id"
+			FROM "github_commits"
+			INNER JOIN "github_public_activities"
+				ON "github_public_activities"."public_id" = "github_commits"."activity_public_id"
+				AND "github_public_activities"."kind" = 'commit'
+				AND "github_public_activities"."repository_id" = "github_commits"."repository_id"
+				AND "github_public_activities"."source_node_id" = "github_commits"."sha"
+			WHERE "github_commits"."fingerprint_complete" = true
+				AND "github_commits"."change_fingerprint" IS NOT NULL
+				AND "github_commits"."author_user_id" IS NOT NULL
+				AND "github_commits"."enrichment_state" = 'complete'
+				AND "github_commits"."canonicalized_at" IS NOT NULL
+				AND "github_commits"."parent_shas" IS NOT NULL
+				AND jsonb_array_length("github_commits"."parent_shas") <= 1
+				AND "github_public_activities"."published_at" IS NOT NULL
+				AND "github_public_activities"."canonical_public_id" IS NULL
+				AND "github_public_activities"."hidden_at" IS NULL
+			GROUP BY
+				"github_commits"."repository_id",
+				"github_commits"."change_fingerprint",
+				"github_commits"."author_user_id"
+			HAVING count(*) > 1
+		) AS "duplicate_cohorts"
+		ORDER BY "duplicate_cohorts"."repository_id"
+	LOOP
+		PERFORM pg_advisory_xact_lock(
+			hashtextextended("affected_repository_id", 0)
+		);
+	END LOOP;
+END $$;
+--> statement-breakpoint
+WITH RECURSIVE "ranked_roots" AS (
+	SELECT
+		"github_public_activities"."public_id",
+		"github_commits"."repository_id",
+		"github_commits"."change_fingerprint",
+		"github_commits"."author_user_id",
+		"github_commits"."sha",
+		row_number() OVER (
+			PARTITION BY
+				"github_commits"."repository_id",
+				"github_commits"."change_fingerprint",
+				"github_commits"."author_user_id"
+			ORDER BY
+				coalesce(
+					"github_commits"."committer_at",
+					"github_commits"."first_observed_at"
+				),
+				"github_commits"."first_observed_at",
+				"github_commits"."sha"
+		) AS "root_rank",
+		count(*) OVER (
+			PARTITION BY
+				"github_commits"."repository_id",
+				"github_commits"."change_fingerprint",
+				"github_commits"."author_user_id"
+		) AS "cohort_size"
+	FROM "github_commits"
+	INNER JOIN "github_public_activities"
+		ON "github_public_activities"."public_id" = "github_commits"."activity_public_id"
+		AND "github_public_activities"."kind" = 'commit'
+		AND "github_public_activities"."repository_id" = "github_commits"."repository_id"
+		AND "github_public_activities"."source_node_id" = "github_commits"."sha"
+	WHERE "github_commits"."fingerprint_complete" = true
+		AND "github_commits"."change_fingerprint" IS NOT NULL
+		AND "github_commits"."author_user_id" IS NOT NULL
+		AND "github_commits"."enrichment_state" = 'complete'
+		AND "github_commits"."canonicalized_at" IS NOT NULL
+		AND "github_commits"."parent_shas" IS NOT NULL
+		AND jsonb_array_length("github_commits"."parent_shas") <= 1
+		AND "github_public_activities"."published_at" IS NOT NULL
+		AND "github_public_activities"."canonical_public_id" IS NULL
+		AND "github_public_activities"."hidden_at" IS NULL
+),
+"losers" AS (
+	SELECT
+		"loser"."public_id" AS "loser_public_id",
+		"winner"."public_id" AS "winner_public_id",
+		"winner"."sha" AS "winner_sha"
+	FROM "ranked_roots" AS "loser"
+	INNER JOIN "ranked_roots" AS "winner"
+		ON "winner"."repository_id" = "loser"."repository_id"
+		AND "winner"."change_fingerprint" = "loser"."change_fingerprint"
+		AND "winner"."author_user_id" = "loser"."author_user_id"
+		AND "winner"."root_rank" = 1
+	WHERE "loser"."cohort_size" > 1
+		AND "loser"."root_rank" > 1
+),
+"alias_descendants" AS (
+	SELECT
+		"descendant"."public_id" AS "descendant_public_id",
+		"losers"."winner_public_id"
+	FROM "losers"
+	INNER JOIN "github_public_activities" AS "descendant"
+		ON "descendant"."canonical_public_id" = "losers"."loser_public_id"
+	UNION
+	SELECT
+		"descendant"."public_id" AS "descendant_public_id",
+		"parent"."winner_public_id"
+	FROM "alias_descendants" AS "parent"
+	INNER JOIN "github_public_activities" AS "descendant"
+		ON "descendant"."canonical_public_id" = "parent"."descendant_public_id"
+)
+UPDATE "github_public_activities"
+SET "canonical_public_id" = "alias_descendants"."winner_public_id"
+FROM "alias_descendants"
+WHERE "github_public_activities"."public_id" = "alias_descendants"."descendant_public_id"
+	AND "github_public_activities"."public_id" <> "alias_descendants"."winner_public_id";
+--> statement-breakpoint
+WITH "ranked_roots" AS (
+	SELECT
+		"github_public_activities"."public_id",
+		"github_commits"."repository_id",
+		"github_commits"."change_fingerprint",
+		"github_commits"."author_user_id",
+		"github_commits"."sha",
+		row_number() OVER (
+			PARTITION BY
+				"github_commits"."repository_id",
+				"github_commits"."change_fingerprint",
+				"github_commits"."author_user_id"
+			ORDER BY
+				coalesce(
+					"github_commits"."committer_at",
+					"github_commits"."first_observed_at"
+				),
+				"github_commits"."first_observed_at",
+				"github_commits"."sha"
+		) AS "root_rank",
+		count(*) OVER (
+			PARTITION BY
+				"github_commits"."repository_id",
+				"github_commits"."change_fingerprint",
+				"github_commits"."author_user_id"
+		) AS "cohort_size"
+	FROM "github_commits"
+	INNER JOIN "github_public_activities"
+		ON "github_public_activities"."public_id" = "github_commits"."activity_public_id"
+		AND "github_public_activities"."kind" = 'commit'
+		AND "github_public_activities"."repository_id" = "github_commits"."repository_id"
+		AND "github_public_activities"."source_node_id" = "github_commits"."sha"
+	WHERE "github_commits"."fingerprint_complete" = true
+		AND "github_commits"."change_fingerprint" IS NOT NULL
+		AND "github_commits"."author_user_id" IS NOT NULL
+		AND "github_commits"."enrichment_state" = 'complete'
+		AND "github_commits"."canonicalized_at" IS NOT NULL
+		AND "github_commits"."parent_shas" IS NOT NULL
+		AND jsonb_array_length("github_commits"."parent_shas") <= 1
+		AND "github_public_activities"."published_at" IS NOT NULL
+		AND "github_public_activities"."canonical_public_id" IS NULL
+		AND "github_public_activities"."hidden_at" IS NULL
+),
+"losers" AS (
+	SELECT
+		"loser"."public_id" AS "loser_public_id",
+		"loser"."change_fingerprint",
+		"winner"."public_id" AS "winner_public_id",
+		"winner"."sha" AS "winner_sha"
+	FROM "ranked_roots" AS "loser"
+	INNER JOIN "ranked_roots" AS "winner"
+		ON "winner"."repository_id" = "loser"."repository_id"
+		AND "winner"."change_fingerprint" = "loser"."change_fingerprint"
+		AND "winner"."author_user_id" = "loser"."author_user_id"
+		AND "winner"."root_rank" = 1
+	WHERE "loser"."cohort_size" > 1
+		AND "loser"."root_rank" > 1
+)
+UPDATE "github_public_activities"
+SET
+	"alias_evidence" = jsonb_build_object(
+		'fingerprint', "losers"."change_fingerprint",
+		'fingerprintComplete', true,
+		'directMergeParent', false,
+		'pullRequestNodeId', null,
+		'sourceSha', "losers"."winner_sha"
+	),
+	"alias_reason" = 'same_authored_exact_copy',
+	"canonical_public_id" = "losers"."winner_public_id",
+	"hidden_at" = coalesce("github_public_activities"."hidden_at", current_timestamp)
+FROM "losers"
+WHERE "github_public_activities"."public_id" = "losers"."loser_public_id";
+--> statement-breakpoint
+UPDATE "github_summary_attempts"
+SET
+	"completed_at" = current_timestamp,
+	"error_code" = 'canonical_alias',
+	"lease_token" = NULL,
+	"lease_until" = NULL,
+	"state" = 'indeterminate'
+FROM "github_public_activities"
+WHERE "github_summary_attempts"."activity_public_id" = "github_public_activities"."public_id"
+	AND "github_public_activities"."alias_reason" = 'same_authored_exact_copy'
+	AND "github_public_activities"."canonical_public_id" IS NOT NULL
+	AND "github_summary_attempts"."state" IN ('pending', 'processing');

--- a/drizzle/meta/0012_snapshot.json
+++ b/drizzle/meta/0012_snapshot.json
@@ -1,0 +1,2772 @@
+{
+  "id": "1defc86e-ec49-453d-8698-3458cafac713",
+  "prevId": "ba994443-532b-4c79-9777-3ac5b75fb5a4",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.github_account_checkpoints": {
+      "name": "github_account_checkpoints",
+      "schema": "",
+      "columns": {
+        "account": {
+          "name": "account",
+          "type": "varchar(39)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "events_etag": {
+          "name": "events_etag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "events_last_attempted_at": {
+          "name": "events_last_attempted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "events_last_succeeded_at": {
+          "name": "events_last_succeeded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "events_next_poll_at": {
+          "name": "events_next_poll_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gap_detected_at": {
+          "name": "gap_detected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gap_expected_event_id": {
+          "name": "gap_expected_event_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gap_oldest_available_event_id": {
+          "name": "gap_oldest_available_event_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gap_state": {
+          "name": "gap_state",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'clear'"
+        },
+        "latest_event_id": {
+          "name": "latest_event_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "paused": {
+          "name": "paused",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "head_ref_cursor_repository_id": {
+          "name": "head_ref_cursor_repository_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "head_ref_cycle_started_at": {
+          "name": "head_ref_cycle_started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "head_ref_last_attempted_at": {
+          "name": "head_ref_last_attempted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "head_ref_last_succeeded_at": {
+          "name": "head_ref_last_succeeded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "head_ref_lease_token": {
+          "name": "head_ref_lease_token",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "head_ref_lease_until": {
+          "name": "head_ref_lease_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "head_ref_next_page": {
+          "name": "head_ref_next_page",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "head_ref_scan_started_at": {
+          "name": "head_ref_scan_started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ref_backfill_since_at": {
+          "name": "ref_backfill_since_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "tag_ref_cursor_repository_id": {
+          "name": "tag_ref_cursor_repository_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tag_ref_cycle_started_at": {
+          "name": "tag_ref_cycle_started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tag_ref_last_attempted_at": {
+          "name": "tag_ref_last_attempted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tag_ref_last_succeeded_at": {
+          "name": "tag_ref_last_succeeded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tag_ref_lease_token": {
+          "name": "tag_ref_lease_token",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tag_ref_lease_until": {
+          "name": "tag_ref_lease_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tag_ref_next_page": {
+          "name": "tag_ref_next_page",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tag_ref_scan_started_at": {
+          "name": "tag_ref_scan_started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "github_account_checkpoints_tracked_account": {
+          "name": "github_account_checkpoints_tracked_account",
+          "value": "\"github_account_checkpoints\".\"account\" IN ('f0rr0', 'yuppiestechdev')"
+        },
+        "github_account_checkpoints_event_id_shape": {
+          "name": "github_account_checkpoints_event_id_shape",
+          "value": "(\"github_account_checkpoints\".\"latest_event_id\" IS NULL OR \"github_account_checkpoints\".\"latest_event_id\" ~ '^[0-9]{1,64}$') AND (\"github_account_checkpoints\".\"gap_expected_event_id\" IS NULL OR \"github_account_checkpoints\".\"gap_expected_event_id\" ~ '^[0-9]{1,64}$') AND (\"github_account_checkpoints\".\"gap_oldest_available_event_id\" IS NULL OR \"github_account_checkpoints\".\"gap_oldest_available_event_id\" ~ '^[0-9]{1,64}$')"
+        },
+        "github_account_checkpoints_gap_state": {
+          "name": "github_account_checkpoints_gap_state",
+          "value": "\"github_account_checkpoints\".\"gap_state\" IN ('clear', 'detected')"
+        },
+        "github_account_checkpoints_gap_details": {
+          "name": "github_account_checkpoints_gap_details",
+          "value": "(\"github_account_checkpoints\".\"gap_state\" = 'detected' AND \"github_account_checkpoints\".\"gap_detected_at\" IS NOT NULL) OR (\"github_account_checkpoints\".\"gap_state\" = 'clear' AND \"github_account_checkpoints\".\"gap_detected_at\" IS NULL AND \"github_account_checkpoints\".\"gap_expected_event_id\" IS NULL AND \"github_account_checkpoints\".\"gap_oldest_available_event_id\" IS NULL)"
+        },
+        "github_account_checkpoints_ref_cursor_shape": {
+          "name": "github_account_checkpoints_ref_cursor_shape",
+          "value": "(\"github_account_checkpoints\".\"head_ref_cursor_repository_id\" IS NULL OR \"github_account_checkpoints\".\"head_ref_cursor_repository_id\" ~ '^[0-9]{1,32}$') AND (\"github_account_checkpoints\".\"tag_ref_cursor_repository_id\" IS NULL OR \"github_account_checkpoints\".\"tag_ref_cursor_repository_id\" ~ '^[0-9]{1,32}$')"
+        },
+        "github_account_checkpoints_ref_leases": {
+          "name": "github_account_checkpoints_ref_leases",
+          "value": "(\"github_account_checkpoints\".\"head_ref_lease_token\" IS NULL) = (\"github_account_checkpoints\".\"head_ref_lease_until\" IS NULL) AND (\"github_account_checkpoints\".\"tag_ref_lease_token\" IS NULL) = (\"github_account_checkpoints\".\"tag_ref_lease_until\" IS NULL)"
+        },
+        "github_account_checkpoints_ref_scans": {
+          "name": "github_account_checkpoints_ref_scans",
+          "value": "(\"github_account_checkpoints\".\"head_ref_next_page\" IS NULL AND \"github_account_checkpoints\".\"head_ref_scan_started_at\" IS NULL OR \"github_account_checkpoints\".\"head_ref_next_page\" >= 2 AND \"github_account_checkpoints\".\"head_ref_scan_started_at\" IS NOT NULL) AND (\"github_account_checkpoints\".\"tag_ref_next_page\" IS NULL AND \"github_account_checkpoints\".\"tag_ref_scan_started_at\" IS NULL OR \"github_account_checkpoints\".\"tag_ref_next_page\" >= 2 AND \"github_account_checkpoints\".\"tag_ref_scan_started_at\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.github_commits": {
+      "name": "github_commits",
+      "schema": "",
+      "columns": {
+        "activity_public_id": {
+          "name": "activity_public_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "additions": {
+          "name": "additions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_login": {
+          "name": "author_login",
+          "type": "varchar(39)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "authored_at": {
+          "name": "authored_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_user_id": {
+          "name": "author_user_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canonicalized_at": {
+          "name": "canonicalized_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "changed_files": {
+          "name": "changed_files",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "change_fingerprint": {
+          "name": "change_fingerprint",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "committed_at": {
+          "name": "committed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "committer_at": {
+          "name": "committer_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "committer_user_id": {
+          "name": "committer_user_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deletions": {
+          "name": "deletions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enrichment_error": {
+          "name": "enrichment_error",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enrichment_attempts": {
+          "name": "enrichment_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "enrichment_lease_token": {
+          "name": "enrichment_lease_token",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enrichment_lease_until": {
+          "name": "enrichment_lease_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enrichment_state": {
+          "name": "enrichment_state",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "fingerprint_complete": {
+          "name": "fingerprint_complete",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "first_observed_at": {
+          "name": "first_observed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "full_message": {
+          "name": "full_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "languages": {
+          "name": "languages",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_shas": {
+          "name": "parent_shas",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_file_cap_reached": {
+          "name": "provider_file_cap_reached",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "pr_discovery_error": {
+          "name": "pr_discovery_error",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_discovery_attempts": {
+          "name": "pr_discovery_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "pr_discovery_lease_token": {
+          "name": "pr_discovery_lease_token",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_discovery_lease_until": {
+          "name": "pr_discovery_lease_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_discovery_state": {
+          "name": "pr_discovery_state",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "repository": {
+          "name": "repository",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository_owner_avatar_url": {
+          "name": "repository_owner_avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repository_owner_login": {
+          "name": "repository_owner_login",
+          "type": "varchar(39)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repository_owner_type": {
+          "name": "repository_owner_type",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repository_private": {
+          "name": "repository_private",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sha": {
+          "name": "sha",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "substantive_loc": {
+          "name": "substantive_loc",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary_attempted_at": {
+          "name": "summary_attempted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary_error": {
+          "name": "summary_error",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary_headline": {
+          "name": "summary_headline",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary_input_hash": {
+          "name": "summary_input_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary_model": {
+          "name": "summary_model",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary_recipe": {
+          "name": "summary_recipe",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary_short": {
+          "name": "summary_short",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tree_sha": {
+          "name": "tree_sha",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "github_commits_activity_public_id_unique": {
+          "name": "github_commits_activity_public_id_unique",
+          "columns": [
+            {
+              "expression": "activity_public_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_commits_activity_cursor_idx": {
+          "name": "github_commits_activity_cursor_idx",
+          "columns": [
+            {
+              "expression": "committed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "activity_public_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_commits_committed_at_idx": {
+          "name": "github_commits_committed_at_idx",
+          "columns": [
+            {
+              "expression": "committed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_commits_summary_pending_idx": {
+          "name": "github_commits_summary_pending_idx",
+          "columns": [
+            {
+              "expression": "summary_attempted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "committed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_commits_enrichment_pending_idx": {
+          "name": "github_commits_enrichment_pending_idx",
+          "columns": [
+            {
+              "expression": "enrichment_state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "enrichment_lease_until",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "committed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_commits_canonicalization_pending_idx": {
+          "name": "github_commits_canonicalization_pending_idx",
+          "columns": [
+            {
+              "expression": "canonicalized_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "first_observed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_commits_pr_discovery_pending_idx": {
+          "name": "github_commits_pr_discovery_pending_idx",
+          "columns": [
+            {
+              "expression": "pr_discovery_state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pr_discovery_lease_until",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "first_observed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_commits_exact_authored_change_idx": {
+          "name": "github_commits_exact_authored_change_idx",
+          "columns": [
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "change_fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "author_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"github_commits\".\"fingerprint_complete\" AND \"github_commits\".\"change_fingerprint\" IS NOT NULL AND \"github_commits\".\"author_user_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "github_commits_repository_id_sha_pk": {
+          "name": "github_commits_repository_id_sha_pk",
+          "columns": ["repository_id", "sha"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "github_commits_sha_shape": {
+          "name": "github_commits_sha_shape",
+          "value": "\"github_commits\".\"sha\" ~ '^[a-f0-9]{40}$'"
+        },
+        "github_commits_tree_sha_shape": {
+          "name": "github_commits_tree_sha_shape",
+          "value": "\"github_commits\".\"tree_sha\" IS NULL OR \"github_commits\".\"tree_sha\" ~ '^[a-f0-9]{40}$'"
+        },
+        "github_commits_fingerprint_shape": {
+          "name": "github_commits_fingerprint_shape",
+          "value": "\"github_commits\".\"change_fingerprint\" IS NULL OR \"github_commits\".\"change_fingerprint\" ~ '^[a-f0-9]{64}$'"
+        },
+        "github_commits_fingerprint_completeness": {
+          "name": "github_commits_fingerprint_completeness",
+          "value": "NOT \"github_commits\".\"fingerprint_complete\" OR \"github_commits\".\"change_fingerprint\" IS NOT NULL"
+        },
+        "github_commits_parent_shas_array": {
+          "name": "github_commits_parent_shas_array",
+          "value": "\"github_commits\".\"parent_shas\" IS NULL OR jsonb_typeof(\"github_commits\".\"parent_shas\") = 'array'"
+        },
+        "github_commits_enrichment_state": {
+          "name": "github_commits_enrichment_state",
+          "value": "\"github_commits\".\"enrichment_state\" IN ('pending', 'processing', 'complete', 'unavailable')"
+        },
+        "github_commits_enrichment_lease": {
+          "name": "github_commits_enrichment_lease",
+          "value": "(\"github_commits\".\"enrichment_state\" = 'processing') = (\"github_commits\".\"enrichment_lease_token\" IS NOT NULL) AND (\"github_commits\".\"enrichment_state\" <> 'processing' OR \"github_commits\".\"enrichment_lease_until\" IS NOT NULL) AND (\"github_commits\".\"enrichment_state\" NOT IN ('complete', 'unavailable') OR \"github_commits\".\"enrichment_lease_until\" IS NULL)"
+        },
+        "github_commits_pr_discovery_state": {
+          "name": "github_commits_pr_discovery_state",
+          "value": "\"github_commits\".\"pr_discovery_state\" IN ('pending', 'processing', 'complete', 'unavailable')"
+        },
+        "github_commits_pr_discovery_lease": {
+          "name": "github_commits_pr_discovery_lease",
+          "value": "(\"github_commits\".\"pr_discovery_state\" = 'processing') = (\"github_commits\".\"pr_discovery_lease_token\" IS NOT NULL) AND (\"github_commits\".\"pr_discovery_state\" <> 'processing' OR \"github_commits\".\"pr_discovery_lease_until\" IS NOT NULL) AND (\"github_commits\".\"pr_discovery_state\" NOT IN ('complete', 'unavailable') OR \"github_commits\".\"pr_discovery_lease_until\" IS NULL)"
+        },
+        "github_commits_tracked_author": {
+          "name": "github_commits_tracked_author",
+          "value": "\"github_commits\".\"author_login\" IN ('f0rr0', 'yuppiestechdev')"
+        },
+        "github_commits_nonnegative_activity_counts": {
+          "name": "github_commits_nonnegative_activity_counts",
+          "value": "(\"github_commits\".\"changed_files\" IS NULL OR \"github_commits\".\"changed_files\" >= 0) AND (\"github_commits\".\"additions\" IS NULL OR \"github_commits\".\"additions\" >= 0) AND (\"github_commits\".\"deletions\" IS NULL OR \"github_commits\".\"deletions\" >= 0) AND (\"github_commits\".\"substantive_loc\" IS NULL OR \"github_commits\".\"substantive_loc\" >= 0)"
+        },
+        "github_commits_nonnegative_attempts": {
+          "name": "github_commits_nonnegative_attempts",
+          "value": "\"github_commits\".\"enrichment_attempts\" >= 0 AND \"github_commits\".\"pr_discovery_attempts\" >= 0"
+        },
+        "github_commits_owner_type": {
+          "name": "github_commits_owner_type",
+          "value": "\"github_commits\".\"repository_owner_type\" IS NULL OR \"github_commits\".\"repository_owner_type\" IN ('Organization', 'User')"
+        },
+        "github_commits_summary_hash_shape": {
+          "name": "github_commits_summary_hash_shape",
+          "value": "\"github_commits\".\"summary_input_hash\" IS NULL OR \"github_commits\".\"summary_input_hash\" ~ '^[a-f0-9]{64}$'"
+        },
+        "github_commits_summary_pair": {
+          "name": "github_commits_summary_pair",
+          "value": "(\"github_commits\".\"summary_headline\" IS NULL) = (\"github_commits\".\"summary_short\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.github_issues": {
+      "name": "github_issues",
+      "schema": "",
+      "columns": {
+        "account": {
+          "name": "account",
+          "type": "varchar(39)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_login": {
+          "name": "author_login",
+          "type": "varchar(39)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_user_id": {
+          "name": "author_user_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_observed_at": {
+          "name": "first_observed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "varchar(128)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "number": {
+          "name": "number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title_snapshot": {
+          "name": "title_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url_snapshot": {
+          "name": "url_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "github_issues_repository_number_unique": {
+          "name": "github_issues_repository_number_unique",
+          "columns": [
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_issues_author_idx": {
+          "name": "github_issues_author_idx",
+          "columns": [
+            {
+              "expression": "author_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_issues_repository_id_github_repositories_id_fk": {
+          "name": "github_issues_repository_id_github_repositories_id_fk",
+          "tableFrom": "github_issues",
+          "tableTo": "github_repositories",
+          "columnsFrom": ["repository_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "github_issues_tracked_account": {
+          "name": "github_issues_tracked_account",
+          "value": "\"github_issues\".\"account\" IN ('f0rr0', 'yuppiestechdev')"
+        },
+        "github_issues_positive_number": {
+          "name": "github_issues_positive_number",
+          "value": "\"github_issues\".\"number\" > 0"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.github_public_activities": {
+      "name": "github_public_activities",
+      "schema": "",
+      "columns": {
+        "alias_evidence": {
+          "name": "alias_evidence",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alias_reason": {
+          "name": "alias_reason",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canonical_public_id": {
+          "name": "canonical_public_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "hidden_at": {
+          "name": "hidden_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_id": {
+          "name": "public_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revision": {
+          "name": "revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "source_node_id": {
+          "name": "source_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "github_public_activities_source_unique": {
+          "name": "github_public_activities_source_unique",
+          "columns": [
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_public_activities_cursor_idx": {
+          "name": "github_public_activities_cursor_idx",
+          "columns": [
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "public_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_public_activities_canonical_idx": {
+          "name": "github_public_activities_canonical_idx",
+          "columns": [
+            {
+              "expression": "canonical_public_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_public_activities_canonical_fk": {
+          "name": "github_public_activities_canonical_fk",
+          "tableFrom": "github_public_activities",
+          "tableTo": "github_public_activities",
+          "columnsFrom": ["canonical_public_id"],
+          "columnsTo": ["public_id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "github_public_activities_kind": {
+          "name": "github_public_activities_kind",
+          "value": "\"github_public_activities\".\"kind\" IN ('commit', 'pull_request', 'issue')"
+        },
+        "github_public_activities_not_self_canonical": {
+          "name": "github_public_activities_not_self_canonical",
+          "value": "\"github_public_activities\".\"canonical_public_id\" IS NULL OR \"github_public_activities\".\"canonical_public_id\" <> \"github_public_activities\".\"public_id\""
+        },
+        "github_public_activities_positive_revision": {
+          "name": "github_public_activities_positive_revision",
+          "value": "\"github_public_activities\".\"revision\" > 0"
+        },
+        "github_public_activities_alias_audit": {
+          "name": "github_public_activities_alias_audit",
+          "value": "(\"github_public_activities\".\"canonical_public_id\" IS NULL AND \"github_public_activities\".\"alias_reason\" IS NULL AND \"github_public_activities\".\"alias_evidence\" IS NULL) OR (\"github_public_activities\".\"canonical_public_id\" IS NOT NULL AND \"github_public_activities\".\"alias_reason\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.github_pull_request_memberships": {
+      "name": "github_pull_request_memberships",
+      "schema": "",
+      "columns": {
+        "commit_repository_id": {
+          "name": "commit_repository_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "commit_sha": {
+          "name": "commit_sha",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_head": {
+          "name": "is_head",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version_id": {
+          "name": "version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "github_pull_request_memberships_position_unique": {
+          "name": "github_pull_request_memberships_position_unique",
+          "columns": [
+            {
+              "expression": "version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_pull_request_memberships_commit_lookup_idx": {
+          "name": "github_pull_request_memberships_commit_lookup_idx",
+          "columns": [
+            {
+              "expression": "commit_repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "commit_sha",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gh_pr_memberships_version_fk": {
+          "name": "gh_pr_memberships_version_fk",
+          "tableFrom": "github_pull_request_memberships",
+          "tableTo": "github_pull_request_versions",
+          "columnsFrom": ["version_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "gh_pr_memberships_pk": {
+          "name": "gh_pr_memberships_pk",
+          "columns": ["version_id", "commit_repository_id", "commit_sha"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "github_pull_request_memberships_sha_shape": {
+          "name": "github_pull_request_memberships_sha_shape",
+          "value": "\"github_pull_request_memberships\".\"commit_sha\" ~ '^[a-f0-9]{40}$'"
+        },
+        "github_pull_request_memberships_nonnegative_position": {
+          "name": "github_pull_request_memberships_nonnegative_position",
+          "value": "\"github_pull_request_memberships\".\"position\" >= 0"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.github_pull_request_signals": {
+      "name": "github_pull_request_signals",
+      "schema": "",
+      "columns": {
+        "account": {
+          "name": "account",
+          "type": "varchar(39)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "lease_token": {
+          "name": "lease_token",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lease_until": {
+          "name": "lease_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "number": {
+          "name": "number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "observed_at": {
+          "name": "observed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository_name_snapshot": {
+          "name": "repository_name_snapshot",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        }
+      },
+      "indexes": {
+        "github_pull_request_signals_event_unique": {
+          "name": "github_pull_request_signals_event_unique",
+          "columns": [
+            {
+              "expression": "account",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_pull_request_signals_pending_idx": {
+          "name": "github_pull_request_signals_pending_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lease_until",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "observed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "github_pull_request_signals_account": {
+          "name": "github_pull_request_signals_account",
+          "value": "\"github_pull_request_signals\".\"account\" IN ('f0rr0', 'yuppiestechdev')"
+        },
+        "github_pull_request_signals_event_id": {
+          "name": "github_pull_request_signals_event_id",
+          "value": "\"github_pull_request_signals\".\"event_id\" ~ '^[0-9]{1,64}$'"
+        },
+        "github_pull_request_signals_repository_id": {
+          "name": "github_pull_request_signals_repository_id",
+          "value": "\"github_pull_request_signals\".\"repository_id\" ~ '^[0-9]{1,32}$'"
+        },
+        "github_pull_request_signals_state": {
+          "name": "github_pull_request_signals_state",
+          "value": "\"github_pull_request_signals\".\"state\" IN ('pending', 'processing', 'complete', 'unavailable')"
+        },
+        "github_pull_request_signals_lease": {
+          "name": "github_pull_request_signals_lease",
+          "value": "(\"github_pull_request_signals\".\"state\" = 'processing') = (\"github_pull_request_signals\".\"lease_token\" IS NOT NULL) AND (\"github_pull_request_signals\".\"state\" <> 'processing' OR \"github_pull_request_signals\".\"lease_until\" IS NOT NULL)"
+        },
+        "github_pull_request_signals_values": {
+          "name": "github_pull_request_signals_values",
+          "value": "\"github_pull_request_signals\".\"number\" > 0 AND \"github_pull_request_signals\".\"attempt_count\" >= 0"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.github_pull_request_versions": {
+      "name": "github_pull_request_versions",
+      "schema": "",
+      "columns": {
+        "base_ref_name": {
+          "name": "base_ref_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_repository_id": {
+          "name": "base_repository_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_sha": {
+          "name": "base_sha",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "commit_count": {
+          "name": "commit_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "head_ref_name": {
+          "name": "head_ref_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "head_repository_id": {
+          "name": "head_repository_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "head_sha": {
+          "name": "head_sha",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "is_current": {
+          "name": "is_current",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "membership_complete": {
+          "name": "membership_complete",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "merge_snapshot": {
+          "name": "merge_snapshot",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "observed_at": {
+          "name": "observed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "provider_updated_at": {
+          "name": "provider_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pull_request_node_id": {
+          "name": "pull_request_node_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "github_pull_request_versions_head_unique": {
+          "name": "github_pull_request_versions_head_unique",
+          "columns": [
+            {
+              "expression": "pull_request_node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "head_sha",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_pull_request_versions_current_unique": {
+          "name": "github_pull_request_versions_current_unique",
+          "columns": [
+            {
+              "expression": "pull_request_node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"github_pull_request_versions\".\"is_current\"",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gh_pr_versions_pull_request_fk": {
+          "name": "gh_pr_versions_pull_request_fk",
+          "tableFrom": "github_pull_request_versions",
+          "tableTo": "github_pull_requests",
+          "columnsFrom": ["pull_request_node_id"],
+          "columnsTo": ["node_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "github_pull_request_versions_sha_shapes": {
+          "name": "github_pull_request_versions_sha_shapes",
+          "value": "\"github_pull_request_versions\".\"base_sha\" ~ '^[a-f0-9]{40}$' AND \"github_pull_request_versions\".\"head_sha\" ~ '^[a-f0-9]{40}$'"
+        },
+        "github_pull_request_versions_nonnegative_count": {
+          "name": "github_pull_request_versions_nonnegative_count",
+          "value": "\"github_pull_request_versions\".\"commit_count\" IS NULL OR \"github_pull_request_versions\".\"commit_count\" >= 0"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.github_pull_requests": {
+      "name": "github_pull_requests",
+      "schema": "",
+      "columns": {
+        "account": {
+          "name": "account",
+          "type": "varchar(39)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "additions": {
+          "name": "additions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_login": {
+          "name": "author_login",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_user_id": {
+          "name": "author_user_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "base_ref_name": {
+          "name": "base_ref_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_repository_id": {
+          "name": "base_repository_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_sha": {
+          "name": "base_sha",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body_snapshot": {
+          "name": "body_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "changed_files": {
+          "name": "changed_files",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commit_count": {
+          "name": "commit_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deletions": {
+          "name": "deletions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "draft": {
+          "name": "draft",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "first_observed_at": {
+          "name": "first_observed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "head_ref_name": {
+          "name": "head_ref_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "head_repository_id": {
+          "name": "head_repository_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "head_sha": {
+          "name": "head_sha",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_reconciled_at": {
+          "name": "last_reconciled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "merged_at": {
+          "name": "merged_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "merge_sha": {
+          "name": "merge_sha",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "merge_sha_verified_at": {
+          "name": "merge_sha_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_reconcile_at": {
+          "name": "next_reconcile_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "varchar(128)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "number": {
+          "name": "number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_file_cap_reached": {
+          "name": "provider_file_cap_reached",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "provider_updated_at": {
+          "name": "provider_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reconcile_attempts": {
+          "name": "reconcile_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reconcile_error": {
+          "name": "reconcile_error",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "terminal_at": {
+          "name": "terminal_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title_snapshot": {
+          "name": "title_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "github_pull_requests_repository_number_unique": {
+          "name": "github_pull_requests_repository_number_unique",
+          "columns": [
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_pull_requests_reconciliation_idx": {
+          "name": "github_pull_requests_reconciliation_idx",
+          "columns": [
+            {
+              "expression": "account",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_reconcile_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_pull_requests_author_idx": {
+          "name": "github_pull_requests_author_idx",
+          "columns": [
+            {
+              "expression": "author_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_pull_requests_repository_id_github_repositories_id_fk": {
+          "name": "github_pull_requests_repository_id_github_repositories_id_fk",
+          "tableFrom": "github_pull_requests",
+          "tableTo": "github_repositories",
+          "columnsFrom": ["repository_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "github_pull_requests_tracked_account": {
+          "name": "github_pull_requests_tracked_account",
+          "value": "\"github_pull_requests\".\"account\" IN ('f0rr0', 'yuppiestechdev')"
+        },
+        "github_pull_requests_state": {
+          "name": "github_pull_requests_state",
+          "value": "\"github_pull_requests\".\"state\" IN ('open', 'closed', 'merged')"
+        },
+        "github_pull_requests_terminal_state": {
+          "name": "github_pull_requests_terminal_state",
+          "value": "(\"github_pull_requests\".\"state\" = 'open' AND \"github_pull_requests\".\"terminal_at\" IS NULL) OR (\"github_pull_requests\".\"state\" IN ('closed', 'merged') AND \"github_pull_requests\".\"terminal_at\" IS NOT NULL)"
+        },
+        "github_pull_requests_merged_state": {
+          "name": "github_pull_requests_merged_state",
+          "value": "(\"github_pull_requests\".\"state\" = 'merged') = (\"github_pull_requests\".\"merged_at\" IS NOT NULL)"
+        },
+        "github_pull_requests_sha_shapes": {
+          "name": "github_pull_requests_sha_shapes",
+          "value": "(\"github_pull_requests\".\"base_sha\" IS NULL OR \"github_pull_requests\".\"base_sha\" ~ '^[a-f0-9]{40}$') AND (\"github_pull_requests\".\"head_sha\" IS NULL OR \"github_pull_requests\".\"head_sha\" ~ '^[a-f0-9]{40}$') AND (\"github_pull_requests\".\"merge_sha\" IS NULL OR \"github_pull_requests\".\"merge_sha\" ~ '^[a-f0-9]{40}$')"
+        },
+        "github_pull_requests_verified_merge_sha": {
+          "name": "github_pull_requests_verified_merge_sha",
+          "value": "(\"github_pull_requests\".\"merge_sha\" IS NULL AND \"github_pull_requests\".\"merge_sha_verified_at\" IS NULL) OR (\"github_pull_requests\".\"state\" = 'merged' AND \"github_pull_requests\".\"merge_sha_verified_at\" IS NOT NULL)"
+        },
+        "github_pull_requests_positive_number": {
+          "name": "github_pull_requests_positive_number",
+          "value": "\"github_pull_requests\".\"number\" > 0"
+        },
+        "github_pull_requests_nonnegative_counts": {
+          "name": "github_pull_requests_nonnegative_counts",
+          "value": "(\"github_pull_requests\".\"changed_files\" IS NULL OR \"github_pull_requests\".\"changed_files\" >= 0) AND (\"github_pull_requests\".\"additions\" IS NULL OR \"github_pull_requests\".\"additions\" >= 0) AND (\"github_pull_requests\".\"deletions\" IS NULL OR \"github_pull_requests\".\"deletions\" >= 0) AND (\"github_pull_requests\".\"commit_count\" IS NULL OR \"github_pull_requests\".\"commit_count\" >= 0)"
+        },
+        "github_pull_requests_nonnegative_attempts": {
+          "name": "github_pull_requests_nonnegative_attempts",
+          "value": "\"github_pull_requests\".\"reconcile_attempts\" >= 0"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.github_push_observation_commits": {
+      "name": "github_push_observation_commits",
+      "schema": "",
+      "columns": {
+        "observation_id": {
+          "name": "observation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sha": {
+          "name": "sha",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "github_push_observation_commits_position_unique": {
+          "name": "github_push_observation_commits_position_unique",
+          "columns": [
+            {
+              "expression": "observation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gh_push_observation_commits_observation_fk": {
+          "name": "gh_push_observation_commits_observation_fk",
+          "tableFrom": "github_push_observation_commits",
+          "tableTo": "github_push_observations",
+          "columnsFrom": ["observation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "gh_push_observation_commits_pk": {
+          "name": "gh_push_observation_commits_pk",
+          "columns": ["observation_id", "repository_id", "sha"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "github_push_observation_commits_sha_shape": {
+          "name": "github_push_observation_commits_sha_shape",
+          "value": "\"github_push_observation_commits\".\"sha\" ~ '^[a-f0-9]{40}$'"
+        },
+        "github_push_observation_commits_nonnegative_position": {
+          "name": "github_push_observation_commits_nonnegative_position",
+          "value": "\"github_push_observation_commits\".\"position\" >= 0"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.github_push_observations": {
+      "name": "github_push_observations",
+      "schema": "",
+      "columns": {
+        "account": {
+          "name": "account",
+          "type": "varchar(39)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "after_sha": {
+          "name": "after_sha",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "before_sha": {
+          "name": "before_sha",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expected_commit_count": {
+          "name": "expected_commit_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "history_since_at": {
+          "name": "history_since_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "history_until_at": {
+          "name": "history_until_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "lease_token": {
+          "name": "lease_token",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lease_until": {
+          "name": "lease_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "observed_at": {
+          "name": "observed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "provider_created_at": {
+          "name": "provider_created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ref_name": {
+          "name": "ref_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository_name_snapshot": {
+          "name": "repository_name_snapshot",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        }
+      },
+      "indexes": {
+        "github_push_observations_source_unique": {
+          "name": "github_push_observations_source_unique",
+          "columns": [
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_push_observations_push_unique": {
+          "name": "github_push_observations_push_unique",
+          "columns": [
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ref_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "before_sha",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "after_sha",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"github_push_observations\".\"source\" <> 'backfill'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_push_observations_pending_idx": {
+          "name": "github_push_observations_pending_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lease_until",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "observed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_push_observations_account_idx": {
+          "name": "github_push_observations_account_idx",
+          "columns": [
+            {
+              "expression": "account",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "observed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gh_push_observations_repository_fk": {
+          "name": "gh_push_observations_repository_fk",
+          "tableFrom": "github_push_observations",
+          "tableTo": "github_repositories",
+          "columnsFrom": ["repository_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "github_push_observations_tracked_account": {
+          "name": "github_push_observations_tracked_account",
+          "value": "\"github_push_observations\".\"account\" IN ('f0rr0', 'yuppiestechdev')"
+        },
+        "github_push_observations_source": {
+          "name": "github_push_observations_source",
+          "value": "\"github_push_observations\".\"source\" IN ('webhook', 'events', 'refs', 'backfill')"
+        },
+        "github_push_observations_sha_shape": {
+          "name": "github_push_observations_sha_shape",
+          "value": "\"github_push_observations\".\"before_sha\" ~ '^[a-f0-9]{40}$' AND \"github_push_observations\".\"after_sha\" ~ '^[a-f0-9]{40}$'"
+        },
+        "github_push_observations_nonnegative_count": {
+          "name": "github_push_observations_nonnegative_count",
+          "value": "\"github_push_observations\".\"attempt_count\" >= 0 AND (\"github_push_observations\".\"expected_commit_count\" IS NULL OR \"github_push_observations\".\"expected_commit_count\" >= 0)"
+        },
+        "github_push_observations_history_bounds": {
+          "name": "github_push_observations_history_bounds",
+          "value": "(\"github_push_observations\".\"source\" <> 'backfill' AND \"github_push_observations\".\"history_since_at\" IS NULL AND \"github_push_observations\".\"history_until_at\" IS NULL) OR (\"github_push_observations\".\"source\" = 'backfill' AND \"github_push_observations\".\"history_since_at\" IS NOT NULL AND \"github_push_observations\".\"history_until_at\" IS NOT NULL AND \"github_push_observations\".\"history_since_at\" <= \"github_push_observations\".\"history_until_at\" AND \"github_push_observations\".\"expected_commit_count\" IS NULL AND \"github_push_observations\".\"before_sha\" = repeat('0', 40))"
+        },
+        "github_push_observations_state": {
+          "name": "github_push_observations_state",
+          "value": "\"github_push_observations\".\"state\" IN ('pending', 'processing', 'complete', 'deferred', 'unavailable')"
+        },
+        "github_push_observations_lease": {
+          "name": "github_push_observations_lease",
+          "value": "(\"github_push_observations\".\"state\" = 'processing') = (\"github_push_observations\".\"lease_token\" IS NOT NULL) AND (\"github_push_observations\".\"state\" <> 'processing' OR \"github_push_observations\".\"lease_until\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.github_repositories": {
+      "name": "github_repositories",
+      "schema": "",
+      "columns": {
+        "default_branch": {
+          "name": "default_branch",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_observed_at": {
+          "name": "first_observed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "homepage_url": {
+          "name": "homepage_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "heads_last_reconciled_at": {
+          "name": "heads_last_reconciled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "html_url": {
+          "name": "html_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar(32)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "last_observed_at": {
+          "name": "last_observed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "owner_avatar_url": {
+          "name": "owner_avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_login": {
+          "name": "owner_login",
+          "type": "varchar(39)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_type": {
+          "name": "owner_type",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "topics": {
+          "name": "topics",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags_last_reconciled_at": {
+          "name": "tags_last_reconciled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "github_repositories_full_name_idx": {
+          "name": "github_repositories_full_name_idx",
+          "columns": [
+            {
+              "expression": "full_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "github_repositories_owner_type": {
+          "name": "github_repositories_owner_type",
+          "value": "\"github_repositories\".\"owner_type\" IS NULL OR \"github_repositories\".\"owner_type\" IN ('Organization', 'User')"
+        },
+        "github_repositories_visibility": {
+          "name": "github_repositories_visibility",
+          "value": "\"github_repositories\".\"visibility\" IS NULL OR \"github_repositories\".\"visibility\" IN ('public', 'private', 'internal')"
+        },
+        "github_repositories_topics_array": {
+          "name": "github_repositories_topics_array",
+          "value": "\"github_repositories\".\"topics\" IS NULL OR jsonb_typeof(\"github_repositories\".\"topics\") = 'array'"
+        },
+        "github_repositories_observation_order": {
+          "name": "github_repositories_observation_order",
+          "value": "\"github_repositories\".\"last_observed_at\" >= \"github_repositories\".\"first_observed_at\""
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.github_repository_refs": {
+      "name": "github_repository_refs",
+      "schema": "",
+      "columns": {
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "first_observed_at": {
+          "name": "first_observed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "head_sha": {
+          "name": "head_sha",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_observed_at": {
+          "name": "last_observed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ref_name": {
+          "name": "ref_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "github_repository_refs_active_idx": {
+          "name": "github_repository_refs_active_idx",
+          "columns": [
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_repository_refs_repository_fk": {
+          "name": "github_repository_refs_repository_fk",
+          "tableFrom": "github_repository_refs",
+          "tableTo": "github_repositories",
+          "columnsFrom": ["repository_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "github_repository_refs_repository_id_ref_name_pk": {
+          "name": "github_repository_refs_repository_id_ref_name_pk",
+          "columns": ["repository_id", "ref_name"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "github_repository_refs_kind": {
+          "name": "github_repository_refs_kind",
+          "value": "\"github_repository_refs\".\"kind\" IN ('head', 'tag')"
+        },
+        "github_repository_refs_name": {
+          "name": "github_repository_refs_name",
+          "value": "(\"github_repository_refs\".\"kind\" = 'head' AND \"github_repository_refs\".\"ref_name\" LIKE 'refs/heads/%') OR (\"github_repository_refs\".\"kind\" = 'tag' AND \"github_repository_refs\".\"ref_name\" LIKE 'refs/tags/%')"
+        },
+        "github_repository_refs_sha_shape": {
+          "name": "github_repository_refs_sha_shape",
+          "value": "\"github_repository_refs\".\"head_sha\" ~ '^[a-f0-9]{40}$'"
+        },
+        "github_repository_refs_observation_order": {
+          "name": "github_repository_refs_observation_order",
+          "value": "\"github_repository_refs\".\"last_observed_at\" >= \"github_repository_refs\".\"first_observed_at\""
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.github_summary_attempts": {
+      "name": "github_summary_attempts",
+      "schema": "",
+      "columns": {
+        "activity_public_id": {
+          "name": "activity_public_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "attempted_at": {
+          "name": "attempted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_hash": {
+          "name": "input_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lease_token": {
+          "name": "lease_token",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lease_until": {
+          "name": "lease_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recipe": {
+          "name": "recipe",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revision": {
+          "name": "revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "summary_headline": {
+          "name": "summary_headline",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary_short": {
+          "name": "summary_short",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "github_summary_attempts_pending_idx": {
+          "name": "github_summary_attempts_pending_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gh_summary_attempts_activity_fk": {
+          "name": "gh_summary_attempts_activity_fk",
+          "tableFrom": "github_summary_attempts",
+          "tableTo": "github_public_activities",
+          "columnsFrom": ["activity_public_id"],
+          "columnsTo": ["public_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "gh_summary_attempts_pk": {
+          "name": "gh_summary_attempts_pk",
+          "columns": ["activity_public_id", "revision"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "github_summary_attempts_state": {
+          "name": "github_summary_attempts_state",
+          "value": "\"github_summary_attempts\".\"state\" IN ('pending', 'processing', 'complete', 'failed', 'indeterminate')"
+        },
+        "github_summary_attempts_positive_revision": {
+          "name": "github_summary_attempts_positive_revision",
+          "value": "\"github_summary_attempts\".\"revision\" > 0 AND \"github_summary_attempts\".\"attempt_count\" >= 0"
+        },
+        "github_summary_attempts_input_hash_shape": {
+          "name": "github_summary_attempts_input_hash_shape",
+          "value": "\"github_summary_attempts\".\"input_hash\" IS NULL OR \"github_summary_attempts\".\"input_hash\" ~ '^[a-f0-9]{64}$'"
+        },
+        "github_summary_attempts_summary_pair": {
+          "name": "github_summary_attempts_summary_pair",
+          "value": "(\"github_summary_attempts\".\"summary_headline\" IS NULL) = (\"github_summary_attempts\".\"summary_short\" IS NULL)"
+        },
+        "github_summary_attempts_complete_output": {
+          "name": "github_summary_attempts_complete_output",
+          "value": "\"github_summary_attempts\".\"state\" <> 'complete' OR (\"github_summary_attempts\".\"summary_headline\" IS NOT NULL AND \"github_summary_attempts\".\"completed_at\" IS NOT NULL)"
+        },
+        "github_summary_attempts_lease": {
+          "name": "github_summary_attempts_lease",
+          "value": "(\"github_summary_attempts\".\"state\" = 'processing') = (\"github_summary_attempts\".\"lease_token\" IS NOT NULL) AND (\"github_summary_attempts\".\"state\" <> 'processing' OR \"github_summary_attempts\".\"lease_until\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.github_webhook_deliveries": {
+      "name": "github_webhook_deliveries",
+      "schema": "",
+      "columns": {
+        "accepted": {
+          "name": "accepted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account": {
+          "name": "account",
+          "type": "varchar(39)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_id": {
+          "name": "delivery_id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event": {
+          "name": "event",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "observed_at": {
+          "name": "observed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "github_webhook_deliveries_audit_idx": {
+          "name": "github_webhook_deliveries_audit_idx",
+          "columns": [
+            {
+              "expression": "event",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "observed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "github_webhook_deliveries_id_shape": {
+          "name": "github_webhook_deliveries_id_shape",
+          "value": "\"github_webhook_deliveries\".\"delivery_id\" ~ '^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$'"
+        },
+        "github_webhook_deliveries_event_shape": {
+          "name": "github_webhook_deliveries_event_shape",
+          "value": "\"github_webhook_deliveries\".\"event\" ~ '^[a-z][a-z0-9_]{0,39}$'"
+        },
+        "github_webhook_deliveries_action_shape": {
+          "name": "github_webhook_deliveries_action_shape",
+          "value": "\"github_webhook_deliveries\".\"action\" IS NULL OR \"github_webhook_deliveries\".\"action\" ~ '^[a-z][a-z0-9_]{0,39}$'"
+        },
+        "github_webhook_deliveries_repository_id_shape": {
+          "name": "github_webhook_deliveries_repository_id_shape",
+          "value": "\"github_webhook_deliveries\".\"repository_id\" IS NULL OR \"github_webhook_deliveries\".\"repository_id\" ~ '^[0-9]{1,32}$'"
+        },
+        "github_webhook_deliveries_tracked_account": {
+          "name": "github_webhook_deliveries_tracked_account",
+          "value": "\"github_webhook_deliveries\".\"account\" IS NULL OR \"github_webhook_deliveries\".\"account\" IN ('f0rr0', 'yuppiestechdev')"
+        }
+      },
+      "isRLSEnabled": true
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -85,6 +85,13 @@
       "when": 1788087185472,
       "tag": "0011_vengeful_reavers",
       "breakpoints": true
+    },
+    {
+      "idx": 12,
+      "version": "7",
+      "when": 1788178833117,
+      "tag": "0012_empty_wendell_vaughn",
+      "breakpoints": true
     }
   ]
 }

--- a/src/components/github-activity-days.tsx
+++ b/src/components/github-activity-days.tsx
@@ -225,13 +225,18 @@ function CommitDisclosure({
   commit,
   headingLevel,
   occurredAt,
+  title,
+  url,
 }: Readonly<{
   commit: PublicGitHubActivityCommit;
   headingLevel: "h4" | "h5";
   occurredAt?: string;
+  title?: string;
+  url?: string | null;
 }>) {
   const Heading = headingLevel;
   const nested = headingLevel === "h5";
+  const visibleTitle = title ?? commit.headline;
   return (
     <details className="group/disclosure">
       <summary
@@ -243,7 +248,19 @@ function CommitDisclosure({
         )}
       >
         <Heading className="min-w-0 max-w-[50rem] overflow-hidden text-ellipsis whitespace-nowrap wrap-anywhere font-sans text-base font-normal leading-[1.625] tracking-normal text-foreground">
-          <InlineSummary>{commit.headline}</InlineSummary>
+          {url === undefined || url === null ? (
+            <InlineSummary>{visibleTitle}</InlineSummary>
+          ) : (
+            <a
+              className="rounded-[0.125rem] text-inherit transition-[color] duration-[160ms] ease-[ease] hover:text-brand-hover focus-visible:outline-2 focus-visible:outline-offset-[0.2rem] focus-visible:outline-ring motion-reduce:transition-none"
+              href={url}
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              <InlineSummary>{visibleTitle}</InlineSummary>
+              <span className="sr-only"> (opens on GitHub in a new tab)</span>
+            </a>
+          )}
         </Heading>
         <CommitLoc commit={commit} />
         {occurredAt === undefined ? null : (
@@ -383,6 +400,20 @@ function RepositoryActivityItem({
   }
 
   if (item.kind === "pull-request-commits") {
+    const [onlyCommit] = item.commits;
+    if (item.commits.length === 1 && onlyCommit !== undefined) {
+      return (
+        <li className="py-[0.45rem]">
+          <CommitDisclosure
+            commit={onlyCommit}
+            headingLevel="h4"
+            occurredAt={item.occurredAt}
+            title={item.title}
+            url={item.repository.url}
+          />
+        </li>
+      );
+    }
     return (
       <li className="py-[0.45rem]">
         <div className="grid grid-cols-[minmax(0,1fr)_auto] items-end gap-3">

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -132,6 +132,11 @@ export const githubCommits = pgTable(
       table.pullRequestDiscoveryLeaseUntil,
       table.firstObservedAt
     ),
+    index("github_commits_exact_authored_change_idx")
+      .on(table.repositoryId, table.changeFingerprint, table.authorUserId)
+      .where(
+        sql`${table.fingerprintComplete} AND ${table.changeFingerprint} IS NOT NULL AND ${table.authorUserId} IS NOT NULL`
+      ),
     check("github_commits_sha_shape", sql`${table.sha} ~ '^[a-f0-9]{40}$'`),
     check(
       "github_commits_tree_sha_shape",

--- a/src/lib/github-activity-audit.ts
+++ b/src/lib/github-activity-audit.ts
@@ -267,17 +267,22 @@ export const auditPublicGitHubActivityDays = (
 interface StoredCommitAuditRow {
   activityPublicId: string | null;
   additions: number | null;
+  authorUserId?: string | null;
   canonicalPublicId: string | null;
   canonicalizedAt: Date | null;
   changedFiles: number | null;
+  changeFingerprint?: string | null;
   deletions: number | null;
   enrichmentState: string;
   enrichmentRetryAt?: Date | null;
+  fingerprintComplete?: boolean;
+  hasExactDuplicateRoot?: boolean;
   hiddenAt: Date | null;
   parentShas: readonly string[] | null;
   publishedAt: Date | null;
   pullRequestDiscoveryState: string;
   pullRequestDiscoveryRetryAt?: Date | null;
+  repositoryId?: string;
   substantiveLoc: number | null;
   summaryAttemptExists?: boolean;
   summaryComplete: boolean;
@@ -290,6 +295,12 @@ interface StoredIssueAuditRow {
   hiddenAt: Date | null;
   publishedAt: Date | null;
 }
+
+const exactAuthoredChangeKey = (
+  repositoryId: string,
+  changeFingerprint: string,
+  authorUserId: string
+) => JSON.stringify([repositoryId, changeFingerprint, authorUserId]);
 
 export interface GitHubActivityAuditEvidence {
   commits: readonly StoredCommitAuditRow[];
@@ -519,6 +530,9 @@ export const buildGitHubActivityAuditReport = (
       commit.parentShas !== null &&
       commit.parentShas.length > 1
   ).length;
+  const exactFingerprintViolations = stableCommits.filter(
+    (commit) => commit.hasExactDuplicateRoot === true
+  ).length;
   const checks = [
     {
       id: "public_projection_readable",
@@ -540,6 +554,11 @@ export const buildGitHubActivityAuditReport = (
       id: "no_integration_commits",
       ok: integrationCommitViolations === 0,
       violations: integrationCommitViolations,
+    },
+    {
+      id: "unique_complete_change_fingerprints",
+      ok: exactFingerprintViolations === 0,
+      violations: exactFingerprintViolations,
     },
     {
       id: "complete_published_commit_sources",
@@ -983,23 +1002,28 @@ const readStoredEvidence = async (
     pullRequestSignalRows,
     pullRequestRows,
     summaryAttemptRows,
+    duplicateFingerprintCohorts,
   ] = await Promise.all([
     database
       .select({
         activityPublicId: githubPublicActivities.publicId,
         additions: githubCommits.additions,
+        authorUserId: githubCommits.authorUserId,
         canonicalPublicId: githubPublicActivities.canonicalPublicId,
         canonicalizedAt: githubCommits.canonicalizedAt,
         changedFiles: githubCommits.changedFiles,
+        changeFingerprint: githubCommits.changeFingerprint,
         deletions: githubCommits.deletions,
         enrichmentState: githubCommits.enrichmentState,
         enrichmentRetryAt: githubCommits.enrichmentLeaseUntil,
+        fingerprintComplete: githubCommits.fingerprintComplete,
         hiddenAt: githubPublicActivities.hiddenAt,
         parentShas: githubCommits.parentShas,
         publishedAt: githubPublicActivities.publishedAt,
         pullRequestDiscoveryState: githubCommits.pullRequestDiscoveryState,
         pullRequestDiscoveryRetryAt:
           githubCommits.pullRequestDiscoveryLeaseUntil,
+        repositoryId: githubCommits.repositoryId,
         substantiveLoc: githubCommits.substantiveLoc,
         summaryAttemptExists,
         summaryComplete,
@@ -1173,9 +1197,73 @@ const readStoredEvidence = async (
               AND jsonb_array_length(${githubCommits.parentShas}) <= 1`
         )
       ),
+    database
+      .select({
+        authorUserId: githubCommits.authorUserId,
+        changeFingerprint: githubCommits.changeFingerprint,
+        repositoryId: githubCommits.repositoryId,
+      })
+      .from(githubCommits)
+      .innerJoin(githubPublicActivities, commitActivityIdentity)
+      .where(
+        and(
+          eq(githubCommits.author, request.account),
+          request.repositoryId === null
+            ? undefined
+            : eq(githubCommits.repositoryId, request.repositoryId),
+          eq(githubCommits.fingerprintComplete, true),
+          isNotNull(githubCommits.changeFingerprint),
+          isNotNull(githubCommits.authorUserId),
+          eq(githubCommits.enrichmentState, "complete"),
+          isNotNull(githubCommits.canonicalizedAt),
+          lte(githubCommits.canonicalizedAt, request.snapshotAt),
+          sql<boolean>`${githubCommits.parentShas} IS NOT NULL
+              AND jsonb_array_length(${githubCommits.parentShas}) <= 1`,
+          isNotNull(githubPublicActivities.publishedAt),
+          lte(githubPublicActivities.publishedAt, request.snapshotAt),
+          isNull(githubPublicActivities.hiddenAt),
+          isNull(githubPublicActivities.canonicalPublicId)
+        )
+      )
+      .groupBy(
+        githubCommits.repositoryId,
+        githubCommits.changeFingerprint,
+        githubCommits.authorUserId
+      )
+      .having(sql`count(*) > 1`),
   ]);
+  const duplicateFingerprintKeys = new Set(
+    duplicateFingerprintCohorts.flatMap((cohort) =>
+      cohort.changeFingerprint === null || cohort.authorUserId === null
+        ? []
+        : [
+            exactAuthoredChangeKey(
+              cohort.repositoryId,
+              cohort.changeFingerprint,
+              cohort.authorUserId
+            ),
+          ]
+    )
+  );
+  const auditedCommits = commits.map((commit) => ({
+    ...commit,
+    hasExactDuplicateRoot:
+      commit.fingerprintComplete &&
+      commit.repositoryId !== undefined &&
+      commit.changeFingerprint !== undefined &&
+      commit.changeFingerprint !== null &&
+      commit.authorUserId !== undefined &&
+      commit.authorUserId !== null &&
+      duplicateFingerprintKeys.has(
+        exactAuthoredChangeKey(
+          commit.repositoryId,
+          commit.changeFingerprint,
+          commit.authorUserId
+        )
+      ),
+  }));
   const scopedProjectionSourceIds = [
-    ...commits
+    ...auditedCommits
       .filter((commit) => commitPassesCanonicalGate(commit, request.snapshotAt))
       .map((commit) => commit.activityPublicId),
     ...issues
@@ -1183,7 +1271,7 @@ const readStoredEvidence = async (
       .map((issue) => issue.activityPublicId),
   ].filter((publicId): publicId is string => publicId !== null);
   const pipelineEvidence = pipelineEvidenceFrom(
-    commits,
+    auditedCommits,
     pushObservationRows,
     pullRequestSignalRows,
     pullRequestRows,
@@ -1191,7 +1279,7 @@ const readStoredEvidence = async (
     request.snapshotAt
   );
   return {
-    commits,
+    commits: auditedCommits,
     globalProjectionSourceIds:
       request.repositoryId === null
         ? globalProjectionRows.map(({ publicId }) => publicId)
@@ -1272,6 +1360,7 @@ export const githubActivityAuditEvidenceFingerprint = (
           deletions: commit.deletions,
           enrichmentState: commit.enrichmentState,
           enrichmentRetryAt: serializedDate(commit.enrichmentRetryAt ?? null),
+          hasExactDuplicateRoot: commit.hasExactDuplicateRoot ?? false,
           hiddenAt: serializedDate(commit.hiddenAt),
           parentShas: commit.parentShas,
           publishedAt: serializedDate(commit.publishedAt),

--- a/src/lib/github-activity-feed.ts
+++ b/src/lib/github-activity-feed.ts
@@ -21,7 +21,7 @@ const readCachedActivity = unstable_cache(
       cursor,
       PUBLIC_GITHUB_ACTIVITY_DAY_PAGE_SIZE
     ),
-  ["public-github-activity-v13"],
+  ["public-github-activity-v14"],
   { revalidate: 900, tags: ["github-activity"] }
 );
 

--- a/src/lib/github-activity-store.ts
+++ b/src/lib/github-activity-store.ts
@@ -201,11 +201,14 @@ const publicCommit = (
 };
 
 interface PullRequestAssociation {
+  isCurrent: boolean;
   nodeId: string;
   position: number;
   repositoryId: string;
   title: string;
   url: string;
+  versionId: string;
+  versionObservedAt: Date;
 }
 
 interface IssueProjection {
@@ -219,6 +222,8 @@ interface PullRequestGroup {
   commits: {
     commit: PublicGitHubActivityCommit;
     position: number;
+    versionId: string;
+    versionObservedAt: Date;
   }[];
   nodeId: string;
   occurredAt: string;
@@ -358,7 +363,14 @@ const addCommitActivity = (
   const existing = accumulator.pullRequestGroups.get(association.nodeId);
   if (existing === undefined) {
     accumulator.pullRequestGroups.set(association.nodeId, {
-      commits: [{ commit: projected, position: association.position }],
+      commits: [
+        {
+          commit: projected,
+          position: association.position,
+          versionId: association.versionId,
+          versionObservedAt: association.versionObservedAt,
+        },
+      ],
       nodeId: association.nodeId,
       occurredAt: activity.occurredAt.toISOString(),
       repositoryId: association.repositoryId,
@@ -370,6 +382,8 @@ const addCommitActivity = (
   existing.commits.push({
     commit: projected,
     position: association.position,
+    versionId: association.versionId,
+    versionObservedAt: association.versionObservedAt,
   });
   if (activity.occurredAt.toISOString() > existing.occurredAt) {
     existing.occurredAt = activity.occurredAt.toISOString();
@@ -426,9 +440,25 @@ const buildPublicActivityDays = (
     for (const group of accumulator.pullRequestGroups.values()) {
       const commits = group.commits
         .toSorted((left, right) => {
+          if (left.versionId === right.versionId) {
+            const byPosition = left.position - right.position;
+            return byPosition === 0
+              ? left.commit.id.localeCompare(right.commit.id)
+              : byPosition;
+          }
+          const byVersion =
+            left.versionObservedAt.getTime() -
+            right.versionObservedAt.getTime();
+          if (byVersion !== 0) {
+            return byVersion;
+          }
+          const byVersionId = left.versionId.localeCompare(right.versionId);
+          if (byVersionId !== 0) {
+            return byVersionId;
+          }
           const byPosition = left.position - right.position;
           return byPosition === 0
-            ? left.commit.committedAt.localeCompare(right.commit.committedAt)
+            ? left.commit.id.localeCompare(right.commit.id)
             : byPosition;
         })
         .map(({ commit }) => commit);
@@ -650,22 +680,24 @@ const readPublicGitHubActivityPageInTransaction = async (
     const associationSelection = {
       activityPublicId: githubPublicActivities.publicId,
       createdAt: githubPullRequests.createdAt,
+      isCurrent: githubPullRequestVersions.isCurrent,
       nodeId: githubPullRequests.nodeId,
       position: githubPullRequestMemberships.position,
       repositoryId: githubPullRequests.repositoryId,
       title: githubPullRequests.title,
       url: githubPullRequests.url,
+      versionId: githubPullRequestVersions.id,
+      versionObservedAt: githubPullRequestVersions.observedAt,
     };
-    const currentCompleteMembership = and(
+    const completeMembership = and(
       eq(githubPullRequestMemberships.versionId, githubPullRequestVersions.id),
-      eq(githubPullRequestVersions.isCurrent, true),
       eq(githubPullRequestVersions.membershipComplete, true)
     );
     const [directAssociations, aliasAssociations] = await Promise.all([
       database
         .select(associationSelection)
         .from(githubPullRequestMemberships)
-        .innerJoin(githubPullRequestVersions, currentCompleteMembership)
+        .innerJoin(githubPullRequestVersions, completeMembership)
         .innerJoin(
           githubPullRequests,
           eq(
@@ -696,7 +728,7 @@ const readPublicGitHubActivityPageInTransaction = async (
           activityPublicId: githubPublicActivities.canonicalPublicId,
         })
         .from(githubPullRequestMemberships)
-        .innerJoin(githubPullRequestVersions, currentCompleteMembership)
+        .innerJoin(githubPullRequestVersions, completeMembership)
         .innerJoin(
           githubPullRequests,
           eq(
@@ -729,12 +761,24 @@ const readPublicGitHubActivityPageInTransaction = async (
       ...directAssociations,
       ...aliasAssociations,
     ].toSorted((left, right) => {
+      if (left.isCurrent !== right.isCurrent) {
+        return left.isCurrent ? -1 : 1;
+      }
       const byCreatedAt = left.createdAt.getTime() - right.createdAt.getTime();
       if (byCreatedAt !== 0) {
         return byCreatedAt;
       }
       const byNodeId = left.nodeId.localeCompare(right.nodeId);
-      return byNodeId === 0 ? left.position - right.position : byNodeId;
+      if (byNodeId !== 0) {
+        return byNodeId;
+      }
+      const byObservedAt =
+        right.versionObservedAt.getTime() - left.versionObservedAt.getTime();
+      if (byObservedAt !== 0) {
+        return byObservedAt;
+      }
+      const byVersionId = left.versionId.localeCompare(right.versionId);
+      return byVersionId === 0 ? left.position - right.position : byVersionId;
     });
     for (const association of associationRows) {
       if (association.activityPublicId === null) {

--- a/src/lib/github-activity-worker-store.ts
+++ b/src/lib/github-activity-worker-store.ts
@@ -1045,6 +1045,7 @@ export const completeGitHubCommitEnrichment = async (
           and(
             eq(githubCommits.repositoryId, commit.repositoryId),
             eq(githubCommits.changeFingerprint, fingerprint.digest),
+            eq(githubCommits.authorUserId, source.authorUserId),
             eq(githubCommits.fingerprintComplete, true),
             eq(githubCommits.enrichmentState, "complete")
           )
@@ -2371,6 +2372,24 @@ const setCanonicalAlias = async (
   if (updated === undefined) {
     return false;
   }
+  await transaction.execute(sql`
+    WITH RECURSIVE alias_descendants(public_id) AS (
+      SELECT ${githubPublicActivities.publicId}
+      FROM ${githubPublicActivities}
+      WHERE ${githubPublicActivities.canonicalPublicId} = ${candidatePublicId}
+      UNION
+      SELECT descendant.public_id
+      FROM ${githubPublicActivities} AS descendant
+      INNER JOIN alias_descendants AS parent
+        ON descendant.canonical_public_id = parent.public_id
+    )
+    UPDATE ${githubPublicActivities}
+    SET canonical_public_id = ${canonicalPublicId}
+    WHERE ${githubPublicActivities.publicId} IN (
+      SELECT public_id FROM alias_descendants
+    )
+      AND ${githubPublicActivities.publicId} <> ${canonicalPublicId}
+  `);
   await transaction
     .update(githubSummaryAttempts)
     .set({
@@ -2465,11 +2484,9 @@ export const canonicalizeGitHubCommitActivity = async (
     );
     const [candidate] = await transaction
       .select({
+        authorUserId: githubCommits.authorUserId,
         changeFingerprint: githubCommits.changeFingerprint,
-        committerAt: githubCommits.committerAt,
         fingerprintComplete: githubCommits.fingerprintComplete,
-        firstObservedAt: githubCommits.firstObservedAt,
-        fullMessage: githubCommits.fullMessage,
         parentShas: githubCommits.parentShas,
         publicId: githubPublicActivities.publicId,
       })
@@ -2558,17 +2575,17 @@ export const canonicalizeGitHubCommitActivity = async (
     }
 
     if (
+      candidate.authorUserId === null ||
       !candidate.fingerprintComplete ||
-      candidate.changeFingerprint === null
+      candidate.changeFingerprint === null ||
+      candidate.parentShas === null
     ) {
       await markGitHubCommitCanonicalized(transaction, repositoryId, sha, now);
       return { aliased: false, aliases: 0, publicId: candidate.publicId };
     }
     const copies = await transaction
       .select({
-        canonicalPublicId: githubPublicActivities.canonicalPublicId,
-        committerAt: githubCommits.committerAt,
-        firstObservedAt: githubCommits.firstObservedAt,
+        fullMessage: githubCommits.fullMessage,
         publicId: githubPublicActivities.publicId,
         sha: githubCommits.sha,
       })
@@ -2578,121 +2595,126 @@ export const canonicalizeGitHubCommitActivity = async (
         and(
           eq(githubCommits.repositoryId, repositoryId),
           eq(githubCommits.changeFingerprint, candidate.changeFingerprint),
+          eq(githubCommits.authorUserId, candidate.authorUserId),
           eq(githubCommits.fingerprintComplete, true),
           eq(githubCommits.enrichmentState, "complete"),
+          inArray(githubCommits.pullRequestDiscoveryState, [
+            "complete",
+            "unavailable",
+          ]),
           isNonMergeCommit,
-          or(
-            isNull(githubPublicActivities.hiddenAt),
-            isNotNull(githubPublicActivities.canonicalPublicId)
-          ),
-          or(
-            isNull(githubPublicActivities.canonicalPublicId),
-            sql<boolean>`EXISTS (
-              SELECT 1
-              FROM ${githubPublicActivities} AS canonical_activity
-              INNER JOIN ${githubCommits} AS canonical_commit
-                ON canonical_commit.activity_public_id = canonical_activity.public_id
-                AND canonical_commit.repository_id = canonical_activity.repository_id
-                AND canonical_commit.sha = canonical_activity.source_node_id
-              WHERE canonical_activity.public_id = ${githubPublicActivities.canonicalPublicId}
-                AND canonical_activity.kind = 'commit'
-                AND canonical_activity.canonical_public_id IS NULL
-                AND canonical_activity.hidden_at IS NULL
-                AND canonical_commit.parent_shas IS NOT NULL
-                AND jsonb_array_length(canonical_commit.parent_shas) <= 1
-            )`
-          )
+          isNull(githubPublicActivities.canonicalPublicId),
+          isNull(githubPublicActivities.hiddenAt)
         )
       )
-      .orderBy(asc(githubCommits.firstObservedAt), asc(githubCommits.sha));
-    const cherryPickSource =
-      /^\(cherry picked from commit ([a-f0-9]{40})\)\r?$/imu.exec(
-        candidate.fullMessage ?? ""
-      )?.[1];
-    const candidatePullRequests = await pullRequestMembershipsForCommit(
+      .orderBy(
+        asc(sql`${githubPublicActivities.publishedAt} IS NULL`),
+        asc(
+          sql`coalesce(${githubCommits.committerAt}, ${githubCommits.firstObservedAt})`
+        ),
+        asc(githubCommits.firstObservedAt),
+        asc(githubCommits.sha)
+      );
+    const [winner] = copies;
+    if (winner === undefined) {
+      await markGitHubCommitCanonicalized(transaction, repositoryId, sha, now);
+      return { aliased: false, aliases: 0, publicId: candidate.publicId };
+    }
+
+    const winnerPullRequests = await pullRequestMembershipsForCommit(
       transaction,
       repositoryId,
-      sha
+      winner.sha
     );
+    let candidateAliased = false;
+    let aliases = 0;
     for (const copy of copies) {
-      if (copy.sha === sha) {
+      if (copy.publicId === winner.publicId) {
         continue;
       }
-      const canonicalPublicId = copy.canonicalPublicId ?? copy.publicId;
-      if (canonicalPublicId === candidate.publicId) {
-        continue;
-      }
-      const explicitCherryPick = copy.sha === cherryPickSource;
-      const directMergeParent =
-        (candidate.parentShas?.length ?? 0) > 1 &&
-        candidate.parentShas?.includes(copy.sha) === true;
-      const candidateOrder =
-        candidate.committerAt?.getTime() ?? candidate.firstObservedAt.getTime();
-      const copyOrder =
-        copy.committerAt?.getTime() ?? copy.firstObservedAt.getTime();
-      if (
-        !explicitCherryPick &&
-        !directMergeParent &&
-        (copyOrder > candidateOrder ||
-          (copyOrder === candidateOrder &&
-            (copy.firstObservedAt > candidate.firstObservedAt ||
-              (copy.firstObservedAt.getTime() ===
-                candidate.firstObservedAt.getTime() &&
-                copy.sha > sha))))
-      ) {
-        continue;
-      }
+      const cherryPickSource =
+        /^\(cherry picked from commit ([a-f0-9]{40})\)\r?$/imu.exec(
+          copy.fullMessage ?? ""
+        )?.[1];
+      const explicitCherryPick = cherryPickSource === winner.sha;
       const copyPullRequests = await pullRequestMembershipsForCommit(
         transaction,
         repositoryId,
         copy.sha
       );
-      const sharedPullRequest = [...candidatePullRequests].find(
-        ([nodeId, candidateVersions]) => {
-          const copyVersions = copyPullRequests.get(nodeId);
+      const sharedPullRequest = [...copyPullRequests].find(
+        ([nodeId, copyVersions]) => {
+          const winnerVersions = winnerPullRequests.get(nodeId);
           return (
-            copyVersions !== undefined &&
-            [...candidateVersions].every(
-              (versionId) => !copyVersions.has(versionId)
+            winnerVersions !== undefined &&
+            [...copyVersions].every(
+              (versionId) => !winnerVersions.has(versionId)
             )
           );
         }
       )?.[0];
-      if (
-        !explicitCherryPick &&
-        !directMergeParent &&
-        sharedPullRequest === undefined
-      ) {
-        continue;
-      }
-      const reason = directMergeParent
-        ? "direct_parent_merge"
-        : explicitCherryPick
-          ? "cherry_pick"
+      const reason = explicitCherryPick
+        ? "cherry_pick"
+        : sharedPullRequest === undefined
+          ? "same_authored_exact_copy"
           : "pr_history_exact_copy";
       const aliased = await setCanonicalAlias(
         transaction,
-        candidate.publicId,
-        canonicalPublicId,
+        copy.publicId,
+        winner.publicId,
         reason,
         {
           fingerprint: candidate.changeFingerprint,
           fingerprintComplete: true,
-          directMergeParent,
+          directMergeParent: false,
           pullRequestNodeId: sharedPullRequest ?? null,
-          sourceSha: copy.sha,
+          sourceSha: winner.sha,
         },
         now
       );
-      await markGitHubCommitCanonicalized(transaction, repositoryId, sha, now);
-      return {
-        aliased,
-        aliases: aliased ? 1 : 0,
-        publicId: candidate.publicId,
-      };
+      aliases += aliased ? 1 : 0;
+      candidateAliased ||= aliased && copy.publicId === candidate.publicId;
+      await markGitHubCommitCanonicalized(
+        transaction,
+        repositoryId,
+        copy.sha,
+        now
+      );
     }
-    await markGitHubCommitCanonicalized(transaction, repositoryId, sha, now);
-    return { aliased: false, aliases: 0, publicId: candidate.publicId };
+    await markGitHubCommitCanonicalized(
+      transaction,
+      repositoryId,
+      winner.sha,
+      now
+    );
+
+    if (candidate.parentShas.length > 1) {
+      const aliased = await setCanonicalAlias(
+        transaction,
+        candidate.publicId,
+        winner.publicId,
+        candidate.parentShas.includes(winner.sha)
+          ? "direct_parent_merge"
+          : "same_authored_exact_copy",
+        {
+          fingerprint: candidate.changeFingerprint,
+          fingerprintComplete: true,
+          directMergeParent: candidate.parentShas.includes(winner.sha),
+          pullRequestNodeId: null,
+          sourceSha: winner.sha,
+        },
+        now
+      );
+      aliases += aliased ? 1 : 0;
+      candidateAliased ||= aliased;
+      await markGitHubCommitCanonicalized(transaction, repositoryId, sha, now);
+    }
+
+    return {
+      aliased: candidateAliased,
+      aliases,
+      publicId: candidate.publicId,
+    };
   });
 
 export const canonicalizePendingGitHubActivities = async (

--- a/tests/github-activity-audit.test.mjs
+++ b/tests/github-activity-audit.test.mjs
@@ -394,6 +394,15 @@ describe("GitHub activity audit", () => {
         globalProjectionSourceIds: [commit.id],
       })
     ).not.toBe(githubActivityAuditEvidenceFingerprint(forward));
+    expect(
+      githubActivityAuditEvidenceFingerprint({
+        ...forward,
+        commits: [
+          healthyCommitEvidence,
+          { ...secondCommit, hasExactDuplicateRoot: true },
+        ],
+      })
+    ).not.toBe(githubActivityAuditEvidenceFingerprint(forward));
   });
 
   test("reports a mismatch when an uncanonicalized commit reaches the projection", () => {
@@ -413,6 +422,24 @@ describe("GitHub activity audit", () => {
         { id: "exact_stored_activity_sources", ok: false, violations: 1 },
       ])
     );
+  });
+
+  test("rejects a complete authored fingerprint duplicated by a root outside the audit window", () => {
+    const report = buildGitHubActivityAuditReport(request, {
+      commits: [{ ...healthyCommitEvidence, hasExactDuplicateRoot: true }],
+      globalProjectionSourceIds: [commit.id],
+      issues: [],
+      legacyPullRequestMilestones: 0,
+      projectionDays: [healthyDay],
+      projectionError: null,
+    });
+
+    expect(report.status).toBe("mismatch");
+    expect(report.checks).toContainEqual({
+      id: "unique_complete_change_fingerprints",
+      ok: false,
+      violations: 1,
+    });
   });
 
   test("fails readiness when stored work is still waiting for the pipeline", () => {

--- a/tests/github-activity-feed-postgres.test.mjs
+++ b/tests/github-activity-feed-postgres.test.mjs
@@ -88,6 +88,7 @@ describe.skipIf(!dockerAvailable)(
     let ensureGitHubEvidenceIntegrity;
     let ensureMissingGitHubSummaryAttempts;
     let getDatabase;
+    let githubActivityAuditRequestFrom;
     let inspectGitHubEvidenceRecovery;
     let originalCronSecret;
     let originalDatabaseUrl;
@@ -111,6 +112,7 @@ describe.skipIf(!dockerAvailable)(
     let releaseGitHubSummaryAttempt;
     let repairLegacyGitHubEvidence;
     let runGitHubActivityWorker;
+    let runGitHubActivityAudit;
 
     beforeAll(async () => {
       originalCronSecret = env.CRON_SECRET;
@@ -183,6 +185,8 @@ describe.skipIf(!dockerAvailable)(
         await import("../src/lib/github-commits-core.ts"));
       ({ readPublicGitHubActivityPage } =
         await import("../src/lib/github-activity-store.ts"));
+      ({ githubActivityAuditRequestFrom, runGitHubActivityAudit } =
+        await import("../src/lib/github-activity-audit.ts"));
       ({
         canonicalizeGitHubCommitActivity,
         claimDueGitHubPullRequests,
@@ -263,6 +267,576 @@ describe.skipIf(!dockerAvailable)(
         accessMode: "read only",
         isolationLevel: "repeatable read",
       });
+    });
+
+    test("groups complete historical and current PR memberships without changing work totals", async () => {
+      const repositoryId = "606";
+      const repository = "f0rr0/historical-pr-projection";
+      const pullRequestNodeId = "PR_historical_projection_606";
+      const activityIds = [
+        "00000000-0000-4000-8000-000000000606",
+        "00000000-0000-4000-8000-000000000607",
+        "00000000-0000-4000-8000-000000000608",
+      ];
+      const commitShas = [
+        `${"a".repeat(39)}6`,
+        `${"b".repeat(39)}6`,
+        `${"c".repeat(39)}6`,
+      ];
+      const historicalVersionId = "10000000-0000-4000-8000-000000000606";
+      const currentVersionId = "10000000-0000-4000-8000-000000000608";
+
+      try {
+        await admin`
+          insert into github_repositories (
+            id, full_name, html_url, owner_id, owner_login, owner_type,
+            visibility
+          ) values (
+            ${repositoryId}, ${repository},
+            ${`https://github.com/${repository}`}, '101', 'f0rr0', 'User',
+            'public'
+          )
+        `;
+        await admin`
+          insert into github_public_activities (
+            public_id, kind, occurred_at, published_at, repository_id,
+            revision, source_node_id
+          ) values
+            (
+              ${activityIds[0]}, 'commit', '2026-08-24T08:00:00.000Z',
+              '2026-08-24T11:01:00.000Z', ${repositoryId}, 1,
+              ${commitShas[0]}
+            ),
+            (
+              ${activityIds[1]}, 'commit', '2026-08-24T09:00:00.000Z',
+              '2026-08-24T11:01:00.000Z', ${repositoryId}, 1,
+              ${commitShas[1]}
+            ),
+            (
+              ${activityIds[2]}, 'commit', '2026-08-24T10:00:00.000Z',
+              '2026-08-24T11:01:00.000Z', ${repositoryId}, 1,
+              ${commitShas[2]}
+            )
+        `;
+        await admin`
+          insert into github_commits (
+            activity_public_id, additions, author_login, authored_at,
+            author_user_id, canonicalized_at, changed_files, committed_at,
+            committer_at, deletions, enrichment_state, fingerprint_complete,
+            first_observed_at, full_message, languages, message, parent_shas,
+            pr_discovery_state, repository, repository_id, sha, substantive_loc
+          ) values
+            (
+              ${activityIds[0]}, 10, 'f0rr0', '2026-08-24T07:00:00.000Z',
+              '101', '2026-08-24T11:00:00.000Z', 1,
+              '2026-08-24T08:00:00.000Z', '2026-08-24T08:00:00.000Z', 1,
+              'complete', false, '2026-08-24T08:00:00.000Z',
+              'Start the historical version', '[]'::jsonb,
+              'Start the historical version', ${JSON.stringify([
+                "1".repeat(40),
+              ])}::jsonb, 'complete', ${repository}, ${repositoryId},
+              ${commitShas[0]}, 11
+            ),
+            (
+              ${activityIds[1]}, 20, 'f0rr0', '2026-08-24T07:30:00.000Z',
+              '101', '2026-08-24T11:00:00.000Z', 2,
+              '2026-08-24T09:00:00.000Z', '2026-08-24T09:00:00.000Z', 2,
+              'complete', false, '2026-08-24T09:00:00.000Z',
+              'Finish the historical version', '[]'::jsonb,
+              'Finish the historical version', ${JSON.stringify([
+                commitShas[0],
+              ])}::jsonb, 'complete', ${repository}, ${repositoryId},
+              ${commitShas[1]}, 22
+            ),
+            (
+              ${activityIds[2]}, 30, 'f0rr0', '2026-08-24T08:00:00.000Z',
+              '101', '2026-08-24T11:00:00.000Z', 3,
+              '2026-08-24T10:00:00.000Z', '2026-08-24T10:00:00.000Z', 3,
+              'complete', false, '2026-08-24T10:00:00.000Z',
+              'Replace the PR head', '[]'::jsonb, 'Replace the PR head',
+              ${JSON.stringify(["2".repeat(40)])}::jsonb, 'complete',
+              ${repository}, ${repositoryId}, ${commitShas[2]}, 33
+            )
+        `;
+        await admin`
+          insert into github_summary_attempts (
+            activity_public_id, completed_at, revision, state,
+            summary_headline, summary_short
+          ) values
+            (
+              ${activityIds[0]}, '2026-08-24T11:01:00.000Z', 1, 'complete',
+              'Old version, first commit', 'Starts the historical version.'
+            ),
+            (
+              ${activityIds[1]}, '2026-08-24T11:01:00.000Z', 1, 'complete',
+              'Old version, second commit', 'Finishes the historical version.'
+            ),
+            (
+              ${activityIds[2]}, '2026-08-24T11:01:00.000Z', 1, 'complete',
+              'Current version commit', 'Replaces the pull request head.'
+            )
+        `;
+        await admin`
+          insert into github_pull_requests (
+            account, author_login, author_user_id, created_at, node_id, number,
+            provider_updated_at, repository_id, state, title, title_snapshot,
+            url
+          ) values (
+            'f0rr0', 'f0rr0', '101', '2026-08-24T06:00:00.000Z',
+            ${pullRequestNodeId}, 606, '2026-08-24T10:30:00.000Z',
+            ${repositoryId}, 'open', 'Preserve all meaningful PR work',
+            'Preserve all meaningful PR work',
+            ${`https://github.com/${repository}/pull/606`}
+          )
+        `;
+        await admin`
+          insert into github_pull_request_versions (
+            base_sha, head_sha, id, is_current, membership_complete,
+            merge_snapshot, observed_at, provider_updated_at,
+            pull_request_node_id
+          ) values
+            (
+              ${"1".repeat(40)}, ${commitShas[1]}, ${historicalVersionId},
+              false, true, false, '2026-08-24T09:30:00.000Z',
+              '2026-08-24T09:30:00.000Z', ${pullRequestNodeId}
+            ),
+            (
+              ${"1".repeat(40)}, ${commitShas[2]}, ${currentVersionId},
+              true, true, false, '2026-08-24T10:30:00.000Z',
+              '2026-08-24T10:30:00.000Z', ${pullRequestNodeId}
+            )
+        `;
+        await admin`
+          insert into github_pull_request_memberships (
+            commit_repository_id, commit_sha, is_head, position, version_id
+          ) values
+            (${repositoryId}, ${commitShas[0]}, false, 0, ${historicalVersionId}),
+            (${repositoryId}, ${commitShas[1]}, true, 1, ${historicalVersionId}),
+            (${repositoryId}, ${commitShas[2]}, true, 0, ${currentVersionId})
+        `;
+
+        const page = await readPublicGitHubActivityPage(
+          {
+            beforeDay: "2026-08-25",
+            snapshotAt: "2026-08-30T12:00:00.000Z",
+            version: 1,
+          },
+          1
+        );
+
+        expect(page.days).toHaveLength(1);
+        expect(page.days[0]).toMatchObject({
+          day: "2026-08-24",
+          items: [
+            {
+              commits: [
+                { headline: "Old version, first commit" },
+                { headline: "Old version, second commit" },
+                { headline: "Current version commit" },
+              ],
+              kind: "pull-request-commits",
+              title: "Preserve all meaningful PR work",
+            },
+          ],
+          totals: {
+            additions: 60,
+            deletions: 6,
+            issuesOpened: 0,
+            repositories: 1,
+          },
+        });
+      } finally {
+        await admin`
+          delete from github_pull_requests
+          where node_id = ${pullRequestNodeId}
+        `;
+        await admin`
+          delete from github_public_activities
+          where repository_id = ${repositoryId}
+        `;
+        await admin`
+          delete from github_commits
+          where repository_id = ${repositoryId}
+        `;
+        await admin`
+          delete from github_repositories
+          where id = ${repositoryId}
+        `;
+      }
+    });
+
+    test("audits exact authored roots against peers outside the requested day", async () => {
+      const repositoryId = "607";
+      const repository = "f0rr0/audit-boundary";
+      const activityIds = [
+        "00000000-0000-4000-8000-000000000671",
+        "00000000-0000-4000-8000-000000000672",
+      ];
+      const commitShas = [`${"d".repeat(39)}7`, `${"e".repeat(39)}7`];
+
+      try {
+        await admin`
+          insert into github_repositories (
+            id, full_name, html_url, owner_id, owner_login, owner_type,
+            visibility
+          ) values (
+            ${repositoryId}, ${repository},
+            ${`https://github.com/${repository}`}, '101', 'f0rr0', 'User',
+            'public'
+          )
+        `;
+        await admin`
+          insert into github_public_activities (
+            public_id, kind, occurred_at, published_at, repository_id,
+            revision, source_node_id
+          ) values
+            (
+              ${activityIds[0]}, 'commit', '2026-08-22T10:00:00.000Z',
+              '2026-08-22T11:00:00.000Z', ${repositoryId}, 1,
+              ${commitShas[0]}
+            ),
+            (
+              ${activityIds[1]}, 'commit', '2026-08-23T10:00:00.000Z',
+              '2026-08-23T11:00:00.000Z', ${repositoryId}, 1,
+              ${commitShas[1]}
+            )
+        `;
+        await admin`
+          insert into github_commits (
+            activity_public_id, additions, author_login, author_user_id,
+            canonicalized_at, changed_files, change_fingerprint, committed_at,
+            committer_at, deletions, enrichment_state, fingerprint_complete,
+            first_observed_at, full_message, languages, message, parent_shas,
+            pr_discovery_state, repository, repository_id, sha, substantive_loc
+          ) values
+            (
+              ${activityIds[0]}, 8, 'f0rr0', '101',
+              '2026-08-22T10:30:00.000Z', 1, ${"7".repeat(64)},
+              '2026-08-22T10:00:00.000Z', '2026-08-22T10:00:00.000Z', 2,
+              'complete', true, '2026-08-22T10:00:00.000Z',
+              'Original exact change', '[]'::jsonb, 'Original exact change',
+              ${JSON.stringify(["1".repeat(40)])}::jsonb, 'complete',
+              ${repository}, ${repositoryId}, ${commitShas[0]}, 10
+            ),
+            (
+              ${activityIds[1]}, 8, 'f0rr0', '101',
+              '2026-08-23T10:30:00.000Z', 1, ${"7".repeat(64)},
+              '2026-08-23T10:00:00.000Z', '2026-08-23T10:00:00.000Z', 2,
+              'complete', true, '2026-08-23T10:00:00.000Z',
+              'Rebased exact change', '[]'::jsonb, 'Rebased exact change',
+              ${JSON.stringify(["2".repeat(40)])}::jsonb, 'complete',
+              ${repository}, ${repositoryId}, ${commitShas[1]}, 10
+            )
+        `;
+        await admin`
+          insert into github_summary_attempts (
+            activity_public_id, completed_at, revision, state,
+            summary_headline, summary_short
+          ) values
+            (
+              ${activityIds[0]}, '2026-08-22T11:00:00.000Z', 1, 'complete',
+              'Original exact change', 'Implements the exact change.'
+            ),
+            (
+              ${activityIds[1]}, '2026-08-23T11:00:00.000Z', 1, 'complete',
+              'Rebased exact change', 'Reimplements the exact change.'
+            )
+        `;
+        await admin`
+          insert into github_summary_attempts (
+            activity_public_id, revision, state
+          ) values (${activityIds[1]}, 2, 'pending')
+        `;
+
+        const request = githubActivityAuditRequestFrom(
+          {
+            account: "f0rr0",
+            endDate: "2026-08-23",
+            startDate: "2026-08-23",
+          },
+          new Date("2026-08-24T12:00:00.000Z")
+        );
+        expect(request).not.toBeNull();
+        const report = await runGitHubActivityAudit(request);
+
+        expect(report.status).toBe("mismatch");
+        expect(report.projection).toMatchObject({
+          expectedActivitySources: 1,
+          renderedActivitySources: 1,
+        });
+        expect(report.checks.filter((check) => check.ok === false)).toEqual([
+          {
+            id: "unique_complete_change_fingerprints",
+            ok: false,
+            violations: 1,
+          },
+        ]);
+
+        const migrationSql = await Bun.file(
+          new URL("../drizzle/0012_empty_wendell_vaughn.sql", import.meta.url)
+        ).text();
+        await admin.unsafe(migrationSql);
+        expect(
+          await admin`
+            select alias_reason, canonical_public_id, public_id
+            from github_public_activities
+            where repository_id = ${repositoryId}
+            order by public_id
+          `
+        ).toEqual([
+          {
+            alias_reason: null,
+            canonical_public_id: null,
+            public_id: activityIds[0],
+          },
+          {
+            alias_reason: "same_authored_exact_copy",
+            canonical_public_id: activityIds[0],
+            public_id: activityIds[1],
+          },
+        ]);
+        expect(
+          await admin`
+            select error_code, lease_token, lease_until, state
+            from github_summary_attempts
+            where activity_public_id = ${activityIds[1]}
+              and revision = 2
+          `
+        ).toEqual([
+          {
+            error_code: "canonical_alias",
+            lease_token: null,
+            lease_until: null,
+            state: "indeterminate",
+          },
+        ]);
+
+        const repairedReport = await runGitHubActivityAudit(request);
+        expect(repairedReport.status).toBe("stored_projection_verified");
+        expect(repairedReport.projection).toMatchObject({
+          expectedActivitySources: 0,
+          renderedActivitySources: 0,
+        });
+
+        await admin.unsafe(migrationSql);
+        const [repairedAlias] = await admin`
+          select alias_reason, canonical_public_id
+          from github_public_activities
+          where public_id = ${activityIds[1]}
+        `;
+        expect(repairedAlias).toEqual({
+          alias_reason: "same_authored_exact_copy",
+          canonical_public_id: activityIds[0],
+        });
+      } finally {
+        await admin`
+          delete from github_public_activities
+          where repository_id = ${repositoryId}
+        `;
+        await admin`
+          delete from github_commits
+          where repository_id = ${repositoryId}
+        `;
+        await admin`
+          delete from github_repositories
+          where id = ${repositoryId}
+        `;
+      }
+    });
+
+    test("keeps published work visible when an earlier historical copy settles later", async () => {
+      const repositoryId = "608";
+      const repository = "f0rr0/readiness-aware-canonicalization";
+      const historicalActivityId = "00000000-0000-4000-8000-000000000681";
+      const publishedActivityId = "00000000-0000-4000-8000-000000000682";
+      const historicalSha = `${"a".repeat(39)}8`;
+      const publishedSha = `${"b".repeat(39)}8`;
+      const fingerprint = "8".repeat(64);
+
+      try {
+        await admin`
+          insert into github_repositories (
+            id, full_name, html_url, owner_id, owner_login, owner_type,
+            visibility
+          ) values (
+            ${repositoryId}, ${repository},
+            ${`https://github.com/${repository}`}, '101', 'f0rr0', 'User',
+            'public'
+          )
+        `;
+        await admin`
+          insert into github_public_activities (
+            public_id, kind, occurred_at, published_at, repository_id,
+            revision, source_node_id
+          ) values
+            (
+              ${historicalActivityId}, 'commit',
+              '2026-08-20T08:00:00.000Z', null, ${repositoryId}, 1,
+              ${historicalSha}
+            ),
+            (
+              ${publishedActivityId}, 'commit',
+              '2026-08-23T08:00:00.000Z',
+              '2026-08-23T09:00:00.000Z', ${repositoryId}, 1,
+              ${publishedSha}
+            )
+        `;
+        await admin`
+          insert into github_commits (
+            activity_public_id, additions, author_login, author_user_id,
+            canonicalized_at, changed_files, change_fingerprint, committed_at,
+            committer_at, deletions, enrichment_state, fingerprint_complete,
+            first_observed_at, full_message, languages, message, parent_shas,
+            pr_discovery_state, repository, repository_id, sha, substantive_loc
+          ) values
+            (
+              ${historicalActivityId}, 12, 'f0rr0', '101', null, 2,
+              ${fingerprint}, '2026-08-20T08:00:00.000Z',
+              '2026-08-20T08:00:00.000Z', 3, 'complete', true,
+              '2026-08-24T10:00:00.000Z', 'Historical exact copy',
+              '[]'::jsonb, 'Historical exact copy',
+              ${JSON.stringify(["1".repeat(40)])}::jsonb, 'pending',
+              ${repository}, ${repositoryId}, ${historicalSha}, 15
+            ),
+            (
+              ${publishedActivityId}, 12, 'f0rr0', '101', null, 2,
+              ${fingerprint}, '2026-08-23T08:00:00.000Z',
+              '2026-08-23T08:00:00.000Z', 3, 'complete', true,
+              '2026-08-23T08:30:00.000Z', 'Published exact change',
+              '[]'::jsonb, 'Published exact change',
+              ${JSON.stringify(["2".repeat(40)])}::jsonb, 'complete',
+              ${repository}, ${repositoryId}, ${publishedSha}, 15
+            )
+        `;
+        await admin`
+          insert into github_summary_attempts (
+            activity_public_id, completed_at, revision, state,
+            summary_headline, summary_short
+          ) values (
+            ${publishedActivityId}, '2026-08-23T09:00:00.000Z', 1,
+            'complete', 'Published exact change',
+            'Keeps the already published exact change visible.'
+          )
+        `;
+
+        expect(
+          await canonicalizeGitHubCommitActivity(
+            repositoryId,
+            publishedSha,
+            new Date("2026-08-24T10:05:00.000Z")
+          )
+        ).toEqual({
+          aliased: false,
+          aliases: 0,
+          publicId: publishedActivityId,
+        });
+        expect(
+          await admin`
+            select canonical_public_id, hidden_at, public_id
+            from github_public_activities
+            where repository_id = ${repositoryId}
+            order by public_id
+          `
+        ).toEqual([
+          {
+            canonical_public_id: null,
+            hidden_at: null,
+            public_id: historicalActivityId,
+          },
+          {
+            canonical_public_id: null,
+            hidden_at: null,
+            public_id: publishedActivityId,
+          },
+        ]);
+
+        await admin`
+          update github_commits
+          set pr_discovery_state = 'unavailable'
+          where repository_id = ${repositoryId} and sha = ${historicalSha}
+        `;
+        await admin`
+          insert into github_summary_attempts (
+            activity_public_id, completed_at, error_code, revision, state
+          ) values (
+            ${historicalActivityId}, '2026-08-24T10:06:00.000Z',
+            'provider_unavailable', 1, 'indeterminate'
+          )
+        `;
+        expect(
+          await canonicalizeGitHubCommitActivity(
+            repositoryId,
+            historicalSha,
+            new Date("2026-08-24T10:07:00.000Z")
+          )
+        ).toEqual({
+          aliased: true,
+          aliases: 1,
+          publicId: historicalActivityId,
+        });
+
+        const page = await readPublicGitHubActivityPage(
+          {
+            beforeDay: "2026-08-24",
+            snapshotAt: "2026-08-24T10:08:00.000Z",
+            version: 1,
+          },
+          1
+        );
+        expect(page.days).toHaveLength(1);
+        expect(page.days[0]).toMatchObject({
+          day: "2026-08-23",
+          items: [
+            {
+              commit: {
+                additions: 12,
+                deletions: 3,
+                headline: "Published exact change",
+                id: publishedActivityId,
+              },
+              kind: "commit",
+            },
+          ],
+          totals: {
+            additions: 12,
+            deletions: 3,
+            issuesOpened: 0,
+            repositories: 1,
+          },
+        });
+        expect(
+          await admin`
+            select alias_reason, canonical_public_id, public_id
+            from github_public_activities
+            where repository_id = ${repositoryId}
+            order by public_id
+          `
+        ).toEqual([
+          {
+            alias_reason: "same_authored_exact_copy",
+            canonical_public_id: publishedActivityId,
+            public_id: historicalActivityId,
+          },
+          {
+            alias_reason: null,
+            canonical_public_id: null,
+            public_id: publishedActivityId,
+          },
+        ]);
+      } finally {
+        await admin`
+          delete from github_public_activities
+          where repository_id = ${repositoryId}
+        `;
+        await admin`
+          delete from github_commits
+          where repository_id = ${repositoryId}
+        `;
+        await admin`
+          delete from github_repositories
+          where id = ${repositoryId}
+        `;
+      }
     });
 
     test("persists tracked PR member commits before completing live reconciliation", async () => {
@@ -441,7 +1015,7 @@ describe.skipIf(!dockerAvailable)(
       }
     });
 
-    test("re-invalidates prior-version members when delayed PR membership arrives", async () => {
+    test("re-invalidates prior-version members without discarding exact-copy evidence", async () => {
       const repositoryId = "602";
       const repository = "f0rr0/versioned-membership-invalidation";
       const pullRequestNodeId = "PR_versioned_membership_invalidation";
@@ -612,8 +1186,8 @@ describe.skipIf(!dockerAvailable)(
             new Date("2026-08-30T10:30:00.000Z")
           )
         ).toEqual({
-          aliased: false,
-          aliases: 0,
+          aliased: true,
+          aliases: 1,
           publicId: oldActivityId,
         });
         expect(
@@ -647,7 +1221,9 @@ describe.skipIf(!dockerAvailable)(
         expect(storedVersionTwo.versionId).not.toBe(storedVersionOne.versionId);
 
         // A retry can canonicalize the V1 member before V2's member list has
-        // arrived. Persisting V2 membership must invalidate that stale result.
+        // arrived. The complete fingerprint already hid the exact copy, so
+        // the retry is a no-op; persisting V2 membership must still invalidate
+        // that stale result.
         expect(
           await canonicalizeGitHubCommitActivity(
             repositoryId,
@@ -657,7 +1233,7 @@ describe.skipIf(!dockerAvailable)(
         ).toEqual({
           aliased: false,
           aliases: 0,
-          publicId: oldActivityId,
+          publicId: null,
         });
         expect(
           await persistGitHubPullRequestMembership(
@@ -686,9 +1262,9 @@ describe.skipIf(!dockerAvailable)(
             new Date("2026-08-30T11:02:00.000Z")
           )
         ).toEqual({
-          aliased: true,
-          aliases: 1,
-          publicId: oldActivityId,
+          aliased: false,
+          aliases: 0,
+          publicId: null,
         });
         expect(
           await canonicalizeGitHubCommitActivity(
@@ -710,7 +1286,7 @@ describe.skipIf(!dockerAvailable)(
           `
         ).toEqual([
           {
-            alias_reason: "pr_history_exact_copy",
+            alias_reason: "same_authored_exact_copy",
             canonical_public_id: newActivityId,
             public_id: oldActivityId,
           },
@@ -753,10 +1329,10 @@ describe.skipIf(!dockerAvailable)(
           `
         ).toEqual([
           {
-            alias_reason: null,
-            canonical_public_id: null,
+            alias_reason: "same_authored_exact_copy",
+            canonical_public_id: newActivityId,
             canonicalized_at: null,
-            hidden_at: null,
+            hidden_at: "2026-08-30 10:30:00+00",
             public_id: oldActivityId,
             published_at: null,
           },
@@ -3355,11 +3931,14 @@ describe.skipIf(!dockerAvailable)(
       const exactCopyIds = {
         controlCandidate: "00000000-0000-4000-8000-000000000014",
         controlSource: "00000000-0000-4000-8000-000000000013",
+        headlineAlias: "00000000-0000-4000-8000-000000000029",
+        headlineAliasAncestor: "00000000-0000-4000-8000-000000000030",
         headlineCandidate: "00000000-0000-4000-8000-000000000017",
         headlineSource: "00000000-0000-4000-8000-000000000016",
         merge: "00000000-0000-4000-8000-000000000012",
         mergeParent: "00000000-0000-4000-8000-000000000011",
         mergeRoot: "00000000-0000-4000-8000-000000000015",
+        otherAuthor: "00000000-0000-4000-8000-000000000028",
         rebased: "00000000-0000-4000-8000-000000000010",
         rebasedAlias: "00000000-0000-4000-8000-000000000021",
         rebasedAliasAncestor: "00000000-0000-4000-8000-000000000022",
@@ -3373,6 +3952,7 @@ describe.skipIf(!dockerAvailable)(
         merge: `${"4".repeat(39)}a`,
         mergeParent: `${"3".repeat(39)}a`,
         mergeRoot: `${"7".repeat(39)}a`,
+        otherAuthor: `${"4".repeat(39)}c`,
         rebased: `${"2".repeat(39)}a`,
         // Intentionally sorts after the rebased SHA: committer time, not SHA,
         // must select the original when both were observed at the same time.
@@ -3444,6 +4024,21 @@ describe.skipIf(!dockerAvailable)(
             ${exactCopyIds.headlineCandidate}, 'commit',
             '2026-08-28T10:30:00.000Z', '303', 1,
             ${exactCopyShas.headlineCandidate}
+          ),
+          (
+            ${exactCopyIds.otherAuthor}, 'commit',
+            '2026-08-28T11:30:00.000Z', '303', 1,
+            ${exactCopyShas.otherAuthor}
+          ),
+          (
+            ${exactCopyIds.headlineAlias}, 'commit',
+            '2026-08-28T11:45:00.000Z', '303', 1,
+            ${`${"5".repeat(39)}c`}
+          ),
+          (
+            ${exactCopyIds.headlineAliasAncestor}, 'commit',
+            '2026-08-28T12:15:00.000Z', '303', 1,
+            ${`${"6".repeat(39)}c`}
           )
       `;
       await admin`
@@ -3537,6 +4132,15 @@ describe.skipIf(!dockerAvailable)(
             'Ship the squash-safe feature', 'Ship the squash-safe feature',
             ${JSON.stringify(["2".repeat(40)])}::jsonb, 'complete',
             'f0rr0/exact-copies', '303', ${exactCopyShas.headlineCandidate}
+          ),
+          (
+            ${exactCopyIds.otherAuthor}, 'f0rr0',
+            '2026-08-28T07:30:00.000Z', '202', ${"d".repeat(64)},
+            '2026-08-28T11:30:00.000Z', '2026-08-28T11:30:00.000Z',
+            'complete', true, '2026-08-28T15:30:00.000Z',
+            'Ship the squash-safe feature', 'Ship the squash-safe feature',
+            ${JSON.stringify(["3".repeat(40)])}::jsonb, 'complete',
+            'f0rr0/exact-copies', '303', ${exactCopyShas.otherAuthor}
           )
       `;
       await admin`
@@ -3563,6 +4167,24 @@ describe.skipIf(!dockerAvailable)(
           canonical_public_id = ${exactCopyIds.rebasedAlias},
           hidden_at = '2026-08-28T15:42:00.000Z'
         where public_id = ${exactCopyIds.rebasedAliasAncestor}
+      `;
+      await admin`
+        update github_public_activities
+        set
+          alias_evidence = '{"preexistingHeadlineAlias":true}'::jsonb,
+          alias_reason = 'same_authored_exact_copy',
+          canonical_public_id = ${exactCopyIds.headlineCandidate},
+          hidden_at = '2026-08-28T15:43:00.000Z'
+        where public_id = ${exactCopyIds.headlineAlias}
+      `;
+      await admin`
+        update github_public_activities
+        set
+          alias_evidence = '{"preexistingHeadlineAncestor":true}'::jsonb,
+          alias_reason = 'same_authored_exact_copy',
+          canonical_public_id = ${exactCopyIds.headlineAlias},
+          hidden_at = '2026-08-28T15:44:00.000Z'
+        where public_id = ${exactCopyIds.headlineAliasAncestor}
       `;
       await admin`
         insert into github_summary_attempts (
@@ -3608,8 +4230,8 @@ describe.skipIf(!dockerAvailable)(
           new Date("2026-08-28T16:01:30.000Z")
         )
       ).toEqual({
-        aliased: false,
-        aliases: 0,
+        aliased: true,
+        aliases: 1,
         publicId: exactCopyIds.headlineCandidate,
       });
       expect(
@@ -3619,9 +4241,20 @@ describe.skipIf(!dockerAvailable)(
           new Date("2026-08-28T16:02:00.000Z")
         )
       ).toEqual({
+        aliased: true,
+        aliases: 1,
+        publicId: exactCopyIds.controlCandidate,
+      });
+      expect(
+        await canonicalizeGitHubCommitActivity(
+          "303",
+          exactCopyShas.otherAuthor,
+          new Date("2026-08-28T16:02:30.000Z")
+        )
+      ).toEqual({
         aliased: false,
         aliases: 0,
-        publicId: exactCopyIds.controlCandidate,
+        publicId: exactCopyIds.otherAuthor,
       });
 
       const exactCopyAliases = await admin`
@@ -3630,7 +4263,8 @@ describe.skipIf(!dockerAvailable)(
         where public_id in (
           ${exactCopyIds.rebasedSource}, ${exactCopyIds.rebased},
           ${exactCopyIds.merge},
-          ${exactCopyIds.controlCandidate}, ${exactCopyIds.headlineCandidate}
+          ${exactCopyIds.controlCandidate}, ${exactCopyIds.headlineCandidate},
+          ${exactCopyIds.otherAuthor}
         )
         order by public_id
       `;
@@ -3649,27 +4283,45 @@ describe.skipIf(!dockerAvailable)(
         },
         {
           alias_evidence: {
-            directMergeParent: true,
+            directMergeParent: false,
             fingerprint: "b".repeat(64),
             fingerprintComplete: true,
             pullRequestNodeId: null,
-            sourceSha: exactCopyShas.mergeParent,
+            sourceSha: exactCopyShas.mergeRoot,
           },
-          alias_reason: "direct_parent_merge",
+          alias_reason: "same_authored_exact_copy",
           canonical_public_id: exactCopyIds.mergeRoot,
           public_id: exactCopyIds.merge,
         },
         {
-          alias_evidence: null,
-          alias_reason: null,
-          canonical_public_id: null,
+          alias_evidence: {
+            directMergeParent: false,
+            fingerprint: "c".repeat(64),
+            fingerprintComplete: true,
+            pullRequestNodeId: null,
+            sourceSha: exactCopyShas.controlSource,
+          },
+          alias_reason: "same_authored_exact_copy",
+          canonical_public_id: exactCopyIds.controlSource,
           public_id: exactCopyIds.controlCandidate,
+        },
+        {
+          alias_evidence: {
+            directMergeParent: false,
+            fingerprint: "d".repeat(64),
+            fingerprintComplete: true,
+            pullRequestNodeId: null,
+            sourceSha: exactCopyShas.headlineSource,
+          },
+          alias_reason: "same_authored_exact_copy",
+          canonical_public_id: exactCopyIds.headlineSource,
+          public_id: exactCopyIds.headlineCandidate,
         },
         {
           alias_evidence: null,
           alias_reason: null,
           canonical_public_id: null,
-          public_id: exactCopyIds.headlineCandidate,
+          public_id: exactCopyIds.otherAuthor,
         },
       ]);
 
@@ -3678,7 +4330,9 @@ describe.skipIf(!dockerAvailable)(
         from github_public_activities
         where public_id in (
           ${exactCopyIds.rebasedAlias},
-          ${exactCopyIds.rebasedAliasAncestor}
+          ${exactCopyIds.rebasedAliasAncestor},
+          ${exactCopyIds.headlineAlias},
+          ${exactCopyIds.headlineAliasAncestor}
         )
         order by public_id
       `;
@@ -3692,6 +4346,16 @@ describe.skipIf(!dockerAvailable)(
           alias_evidence: { preexistingAlias: true },
           canonical_public_id: exactCopyIds.rebasedAlias,
           public_id: exactCopyIds.rebasedAliasAncestor,
+        },
+        {
+          alias_evidence: { preexistingHeadlineAlias: true },
+          canonical_public_id: exactCopyIds.headlineSource,
+          public_id: exactCopyIds.headlineAlias,
+        },
+        {
+          alias_evidence: { preexistingHeadlineAncestor: true },
+          canonical_public_id: exactCopyIds.headlineSource,
+          public_id: exactCopyIds.headlineAliasAncestor,
         },
       ]);
       const [supersededSummaryAttempt] = await admin`
@@ -3724,6 +4388,12 @@ describe.skipIf(!dockerAvailable)(
         set canonicalized_at = null, full_message = 'First intentional edit',
           message = 'First intentional edit'
         where activity_public_id = ${exactCopyIds.controlCandidate}
+      `;
+      await admin`
+        update github_public_activities
+        set alias_evidence = null, alias_reason = null,
+          canonical_public_id = null, hidden_at = null
+        where public_id = ${exactCopyIds.controlCandidate}
       `;
       expect(
         await canonicalizeGitHubCommitActivity(

--- a/tests/github-activity-feed.test.mjs
+++ b/tests/github-activity-feed.test.mjs
@@ -151,7 +151,9 @@ describe("public GitHub activity projection", () => {
     );
 
     expect(html).toContain("Build daily GitHub activity");
-    expect(html).toContain("Add the daily projection");
+    expect(html.match(/Build daily GitHub activity/gu)).toHaveLength(1);
+    expect(html).not.toContain("Add the daily projection");
+    expect(html).toContain("Builds complete UTC-day activity pages.");
     expect(html).toContain("Polish repository activity rows");
     expect(html).toContain("Document the worker contract");
     expect(html).toContain("Issue opened");
@@ -180,7 +182,6 @@ describe("public GitHub activity projection", () => {
     for (const work of [
       "Track daily activity",
       "Build daily GitHub activity",
-      "Add the daily projection",
       "Polish repository activity rows",
     ]) {
       expect(html.indexOf(work)).toBeGreaterThan(portfolioGroupIndex);
@@ -198,6 +199,70 @@ describe("public GitHub activity projection", () => {
     ]) {
       expect(html).toContain(occurredAt);
     }
+  });
+
+  test("uses the PR title once for a singleton but keeps commit titles in a multi-commit PR", () => {
+    const pullRequestRepository = {
+      avatarUrl: null,
+      key: "public:portfolio",
+      label: "f0rr0/portfolio",
+      url: "https://github.com/f0rr0/portfolio/pull/12",
+    };
+    const html = renderToStaticMarkup(
+      createElement(GitHubActivityDays, {
+        days: [
+          {
+            day: "2026-08-28",
+            items: [
+              {
+                commits: [
+                  {
+                    additions: 4,
+                    changedFiles: 1,
+                    committedAt: "2026-08-28T08:00:00.000Z",
+                    deletions: 1,
+                    headline: "Add deterministic projection",
+                    id: "first-commit-public-id",
+                    languages: [],
+                    providerFileCapReached: false,
+                    summary: "Adds the projection contract.",
+                  },
+                  {
+                    additions: 2,
+                    changedFiles: 1,
+                    committedAt: "2026-08-28T09:00:00.000Z",
+                    deletions: 0,
+                    headline: "Test historical PR revisions",
+                    id: "second-commit-public-id",
+                    languages: [],
+                    providerFileCapReached: false,
+                    summary: "Covers old and current PR versions.",
+                  },
+                ],
+                id: "pr-slice-public-id",
+                kind: "pull-request-commits",
+                occurredAt: "2026-08-28T09:00:00.000Z",
+                repository: pullRequestRepository,
+                title: "Make GitHub work deterministic",
+              },
+            ],
+            totals: {
+              additions: 6,
+              deletions: 1,
+              issuesOpened: 0,
+              repositories: 1,
+            },
+          },
+        ],
+      })
+    );
+
+    expect(html.match(/Make GitHub work deterministic/gu)).toHaveLength(1);
+    expect(html).toContain("Add deterministic projection");
+    expect(html).toContain("Test historical PR revisions");
+    expect(html.indexOf("Add deterministic projection")).toBeLessThan(
+      html.indexOf("Test historical PR revisions")
+    );
   });
 
   test("shows public owners while concealing private names and owners", () => {

--- a/tests/github-activity-schema.test.mjs
+++ b/tests/github-activity-schema.test.mjs
@@ -41,6 +41,9 @@ describe("GitHub activity persistence schema", () => {
       "github_commits_canonicalization_pending_idx"
     );
     expect(indexNames(githubCommits)).toContain(
+      "github_commits_exact_authored_change_idx"
+    );
+    expect(indexNames(githubCommits)).toContain(
       "github_commits_pr_discovery_pending_idx"
     );
     expect(checkNames(githubCommits)).toEqual(


### PR DESCRIPTION
## Summary

- canonicalize each complete authored patch once per repository and immutable author
- keep published live work ahead of unfinished historical backfill
- audit and migrate duplicate roots without inflating totals or orphaning summary work
- group commits across complete PR revisions and render singleton PR titles once

## Verification

- `bun test` (255 passing)
- `bun run typecheck`
- `bun run lint`
- `bun run format:check`
- `bun run build`
- read-only August production slices and authenticated GitHub PR reconciliation