### PR TITLE
fix: make GitHub backfills deterministic

### DIFF
--- a/drizzle/0014_friendly_crusher_hogan.sql
+++ b/drizzle/0014_friendly_crusher_hogan.sql
@@ -1,0 +1,52 @@
+ALTER TABLE "github_account_checkpoints" ADD COLUMN "pull_request_backfill_digest" varchar(64);--> statement-breakpoint
+ALTER TABLE "github_repositories" ADD COLUMN "inventory_verified_at" timestamp with time zone;--> statement-breakpoint
+INSERT INTO "github_repositories" (
+	"id",
+	"full_name",
+	"html_url",
+	"owner_avatar_url",
+	"owner_login",
+	"owner_type",
+	"visibility",
+	"first_observed_at",
+	"last_observed_at"
+)
+SELECT DISTINCT ON (c."repository_id")
+	c."repository_id",
+	c."repository",
+	'https://github.com/' || c."repository",
+	c."repository_owner_avatar_url",
+	c."repository_owner_login",
+	c."repository_owner_type",
+	CASE
+		WHEN c."repository_private" IS TRUE THEN 'private'
+		WHEN c."repository_private" IS FALSE THEN 'public'
+		ELSE NULL
+	END,
+	MIN(c."committed_at") OVER (PARTITION BY c."repository_id"),
+	MAX(c."committed_at") OVER (PARTITION BY c."repository_id")
+FROM "github_commits" AS c
+LEFT JOIN "github_repositories" AS r
+	ON r."id" = c."repository_id"
+WHERE r."id" IS NULL
+ORDER BY c."repository_id", c."committed_at" DESC, c."sha" DESC
+ON CONFLICT ("id") DO NOTHING;--> statement-breakpoint
+ALTER TABLE "github_commits" ADD CONSTRAINT "github_commits_repository_fk" FOREIGN KEY ("repository_id") REFERENCES "public"."github_repositories"("id") ON DELETE no action ON UPDATE no action NOT VALID;--> statement-breakpoint
+ALTER TABLE "github_commits" VALIDATE CONSTRAINT "github_commits_repository_fk";--> statement-breakpoint
+ALTER TABLE "github_commits" ALTER COLUMN "repository" DROP NOT NULL;--> statement-breakpoint
+ALTER TABLE "github_account_checkpoints" ADD CONSTRAINT "github_account_checkpoints_pr_backfill_digest" CHECK ("github_account_checkpoints"."pull_request_backfill_digest" IS NULL OR "github_account_checkpoints"."pull_request_backfill_digest" ~ '^[a-f0-9]{64}$');--> statement-breakpoint
+UPDATE "github_repositories"
+SET "inventory_verified_at" = "last_observed_at"
+WHERE "topics" IS NOT NULL;--> statement-breakpoint
+UPDATE "github_repository_inventory_heads" AS h
+SET "completed_at" = '1970-01-01 00:00:00+00',
+	"updated_at" = '1970-01-01 00:00:00+00'
+WHERE EXISTS (
+	SELECT 1
+	FROM "github_account_repository_catalogs" AS c
+	INNER JOIN "github_repositories" AS r ON r."id" = c."repository_id"
+	WHERE c."account_user_id" = h."account_user_id"
+		AND c."active_access"
+		AND c."inventory_generation" = h."generation"
+		AND r."inventory_verified_at" IS NULL
+);

--- a/drizzle/meta/0014_snapshot.json
+++ b/drizzle/meta/0014_snapshot.json
@@ -1,0 +1,3638 @@
+{
+  "id": "38dedfcc-8fca-4b8f-b69d-09f5dc7202ef",
+  "prevId": "5228dc52-19c7-4956-a387-1f28b8cbc396",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.github_account_checkpoints": {
+      "name": "github_account_checkpoints",
+      "schema": "",
+      "columns": {
+        "account": {
+          "name": "account",
+          "type": "varchar(39)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "events_etag": {
+          "name": "events_etag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "events_last_attempted_at": {
+          "name": "events_last_attempted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "events_last_succeeded_at": {
+          "name": "events_last_succeeded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "events_next_poll_at": {
+          "name": "events_next_poll_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gap_detected_at": {
+          "name": "gap_detected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gap_expected_event_id": {
+          "name": "gap_expected_event_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gap_oldest_available_event_id": {
+          "name": "gap_oldest_available_event_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gap_state": {
+          "name": "gap_state",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'clear'"
+        },
+        "latest_event_id": {
+          "name": "latest_event_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "paused": {
+          "name": "paused",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "pull_request_backfill_digest": {
+          "name": "pull_request_backfill_digest",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "head_ref_cursor_repository_id": {
+          "name": "head_ref_cursor_repository_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "head_ref_cycle_started_at": {
+          "name": "head_ref_cycle_started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "head_ref_last_attempted_at": {
+          "name": "head_ref_last_attempted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "head_ref_last_succeeded_at": {
+          "name": "head_ref_last_succeeded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "head_ref_lease_token": {
+          "name": "head_ref_lease_token",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "head_ref_lease_until": {
+          "name": "head_ref_lease_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "head_ref_next_page": {
+          "name": "head_ref_next_page",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "head_ref_scan_started_at": {
+          "name": "head_ref_scan_started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ref_backfill_since_at": {
+          "name": "ref_backfill_since_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "tag_ref_cursor_repository_id": {
+          "name": "tag_ref_cursor_repository_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tag_ref_cycle_started_at": {
+          "name": "tag_ref_cycle_started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tag_ref_last_attempted_at": {
+          "name": "tag_ref_last_attempted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tag_ref_last_succeeded_at": {
+          "name": "tag_ref_last_succeeded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tag_ref_lease_token": {
+          "name": "tag_ref_lease_token",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tag_ref_lease_until": {
+          "name": "tag_ref_lease_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tag_ref_next_page": {
+          "name": "tag_ref_next_page",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tag_ref_scan_started_at": {
+          "name": "tag_ref_scan_started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "github_account_checkpoints_tracked_account": {
+          "name": "github_account_checkpoints_tracked_account",
+          "value": "\"github_account_checkpoints\".\"account\" IN ('f0rr0', 'yuppiestechdev')"
+        },
+        "github_account_checkpoints_event_id_shape": {
+          "name": "github_account_checkpoints_event_id_shape",
+          "value": "(\"github_account_checkpoints\".\"latest_event_id\" IS NULL OR \"github_account_checkpoints\".\"latest_event_id\" ~ '^[0-9]{1,64}$') AND (\"github_account_checkpoints\".\"gap_expected_event_id\" IS NULL OR \"github_account_checkpoints\".\"gap_expected_event_id\" ~ '^[0-9]{1,64}$') AND (\"github_account_checkpoints\".\"gap_oldest_available_event_id\" IS NULL OR \"github_account_checkpoints\".\"gap_oldest_available_event_id\" ~ '^[0-9]{1,64}$')"
+        },
+        "github_account_checkpoints_gap_state": {
+          "name": "github_account_checkpoints_gap_state",
+          "value": "\"github_account_checkpoints\".\"gap_state\" IN ('clear', 'detected')"
+        },
+        "github_account_checkpoints_gap_details": {
+          "name": "github_account_checkpoints_gap_details",
+          "value": "(\"github_account_checkpoints\".\"gap_state\" = 'detected' AND \"github_account_checkpoints\".\"gap_detected_at\" IS NOT NULL) OR (\"github_account_checkpoints\".\"gap_state\" = 'clear' AND \"github_account_checkpoints\".\"gap_detected_at\" IS NULL AND \"github_account_checkpoints\".\"gap_expected_event_id\" IS NULL AND \"github_account_checkpoints\".\"gap_oldest_available_event_id\" IS NULL)"
+        },
+        "github_account_checkpoints_ref_cursor_shape": {
+          "name": "github_account_checkpoints_ref_cursor_shape",
+          "value": "(\"github_account_checkpoints\".\"head_ref_cursor_repository_id\" IS NULL OR \"github_account_checkpoints\".\"head_ref_cursor_repository_id\" ~ '^[0-9]{1,32}$') AND (\"github_account_checkpoints\".\"tag_ref_cursor_repository_id\" IS NULL OR \"github_account_checkpoints\".\"tag_ref_cursor_repository_id\" ~ '^[0-9]{1,32}$')"
+        },
+        "github_account_checkpoints_ref_leases": {
+          "name": "github_account_checkpoints_ref_leases",
+          "value": "(\"github_account_checkpoints\".\"head_ref_lease_token\" IS NULL) = (\"github_account_checkpoints\".\"head_ref_lease_until\" IS NULL) AND (\"github_account_checkpoints\".\"tag_ref_lease_token\" IS NULL) = (\"github_account_checkpoints\".\"tag_ref_lease_until\" IS NULL)"
+        },
+        "github_account_checkpoints_ref_scans": {
+          "name": "github_account_checkpoints_ref_scans",
+          "value": "(\"github_account_checkpoints\".\"head_ref_next_page\" IS NULL AND \"github_account_checkpoints\".\"head_ref_scan_started_at\" IS NULL OR \"github_account_checkpoints\".\"head_ref_next_page\" >= 2 AND \"github_account_checkpoints\".\"head_ref_scan_started_at\" IS NOT NULL) AND (\"github_account_checkpoints\".\"tag_ref_next_page\" IS NULL AND \"github_account_checkpoints\".\"tag_ref_scan_started_at\" IS NULL OR \"github_account_checkpoints\".\"tag_ref_next_page\" >= 2 AND \"github_account_checkpoints\".\"tag_ref_scan_started_at\" IS NOT NULL)"
+        },
+        "github_account_checkpoints_pr_backfill_digest": {
+          "name": "github_account_checkpoints_pr_backfill_digest",
+          "value": "\"github_account_checkpoints\".\"pull_request_backfill_digest\" IS NULL OR \"github_account_checkpoints\".\"pull_request_backfill_digest\" ~ '^[a-f0-9]{64}$'"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.github_account_repository_catalogs": {
+      "name": "github_account_repository_catalogs",
+      "schema": "",
+      "columns": {
+        "account_user_id": {
+          "name": "account_user_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active_access": {
+          "name": "active_access",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "inventory_generation": {
+          "name": "inventory_generation",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "observed_at": {
+          "name": "observed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "gh_account_repo_catalogs_current_idx": {
+          "name": "gh_account_repo_catalogs_current_idx",
+          "columns": [
+            {
+              "expression": "account_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "inventory_generation",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "active_access",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gh_account_repo_catalogs_account_fk": {
+          "name": "gh_account_repo_catalogs_account_fk",
+          "tableFrom": "github_account_repository_catalogs",
+          "tableTo": "github_repository_inventory_heads",
+          "columnsFrom": ["account_user_id"],
+          "columnsTo": ["account_user_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gh_account_repo_catalogs_repository_fk": {
+          "name": "gh_account_repo_catalogs_repository_fk",
+          "tableFrom": "github_account_repository_catalogs",
+          "tableTo": "github_repositories",
+          "columnsFrom": ["repository_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "gh_account_repo_catalogs_pk": {
+          "name": "gh_account_repo_catalogs_pk",
+          "columns": ["account_user_id", "repository_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "gh_account_repo_catalogs_generation": {
+          "name": "gh_account_repo_catalogs_generation",
+          "value": "\"github_account_repository_catalogs\".\"inventory_generation\" > 0"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.github_commit_pull_request_associations": {
+      "name": "github_commit_pull_request_associations",
+      "schema": "",
+      "columns": {
+        "commit_repository_id": {
+          "name": "commit_repository_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "commit_sha": {
+          "name": "commit_sha",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pull_request_node_id": {
+          "name": "pull_request_node_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "gh_commit_pr_associations_commit_fk": {
+          "name": "gh_commit_pr_associations_commit_fk",
+          "tableFrom": "github_commit_pull_request_associations",
+          "tableTo": "github_commits",
+          "columnsFrom": ["commit_repository_id", "commit_sha"],
+          "columnsTo": ["repository_id", "sha"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gh_commit_pr_associations_pr_fk": {
+          "name": "gh_commit_pr_associations_pr_fk",
+          "tableFrom": "github_commit_pull_request_associations",
+          "tableTo": "github_pull_requests",
+          "columnsFrom": ["pull_request_node_id"],
+          "columnsTo": ["node_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "gh_commit_pr_associations_pk": {
+          "name": "gh_commit_pr_associations_pk",
+          "columns": [
+            "commit_repository_id",
+            "commit_sha",
+            "pull_request_node_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "gh_commit_pr_associations_sha_shape": {
+          "name": "gh_commit_pr_associations_sha_shape",
+          "value": "\"github_commit_pull_request_associations\".\"commit_sha\" ~ '^[a-f0-9]{40}$'"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.github_commits": {
+      "name": "github_commits",
+      "schema": "",
+      "columns": {
+        "additions": {
+          "name": "additions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_login": {
+          "name": "author_login",
+          "type": "varchar(39)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "authored_at": {
+          "name": "authored_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_user_id": {
+          "name": "author_user_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "changed_files": {
+          "name": "changed_files",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "committed_at": {
+          "name": "committed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "committer_at": {
+          "name": "committer_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "committer_user_id": {
+          "name": "committer_user_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deletions": {
+          "name": "deletions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enrichment_error": {
+          "name": "enrichment_error",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enrichment_attempts": {
+          "name": "enrichment_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "enrichment_lease_token": {
+          "name": "enrichment_lease_token",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enrichment_lease_until": {
+          "name": "enrichment_lease_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enrichment_state": {
+          "name": "enrichment_state",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "file_facts": {
+          "name": "file_facts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_facts_complete": {
+          "name": "file_facts_complete",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "first_observed_at": {
+          "name": "first_observed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_shas": {
+          "name": "parent_shas",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_file_cap_reached": {
+          "name": "provider_file_cap_reached",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "pr_discovery_error": {
+          "name": "pr_discovery_error",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_discovery_attempts": {
+          "name": "pr_discovery_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "pr_discovery_lease_token": {
+          "name": "pr_discovery_lease_token",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_discovery_lease_until": {
+          "name": "pr_discovery_lease_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_discovery_state": {
+          "name": "pr_discovery_state",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "repository": {
+          "name": "repository",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository_owner_avatar_url": {
+          "name": "repository_owner_avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repository_owner_login": {
+          "name": "repository_owner_login",
+          "type": "varchar(39)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repository_owner_type": {
+          "name": "repository_owner_type",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repository_private": {
+          "name": "repository_private",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sha": {
+          "name": "sha",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "github_commits_committed_at_idx": {
+          "name": "github_commits_committed_at_idx",
+          "columns": [
+            {
+              "expression": "committed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_commits_enrichment_pending_idx": {
+          "name": "github_commits_enrichment_pending_idx",
+          "columns": [
+            {
+              "expression": "enrichment_state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "enrichment_lease_until",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "committed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_commits_pr_discovery_pending_idx": {
+          "name": "github_commits_pr_discovery_pending_idx",
+          "columns": [
+            {
+              "expression": "pr_discovery_state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pr_discovery_lease_until",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "first_observed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_commits_repository_fk": {
+          "name": "github_commits_repository_fk",
+          "tableFrom": "github_commits",
+          "tableTo": "github_repositories",
+          "columnsFrom": ["repository_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "github_commits_repository_id_sha_pk": {
+          "name": "github_commits_repository_id_sha_pk",
+          "columns": ["repository_id", "sha"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "github_commits_sha_shape": {
+          "name": "github_commits_sha_shape",
+          "value": "\"github_commits\".\"sha\" ~ '^[a-f0-9]{40}$'"
+        },
+        "github_commits_parent_shas_array": {
+          "name": "github_commits_parent_shas_array",
+          "value": "\"github_commits\".\"parent_shas\" IS NULL OR jsonb_typeof(\"github_commits\".\"parent_shas\") = 'array'"
+        },
+        "github_commits_file_facts_array": {
+          "name": "github_commits_file_facts_array",
+          "value": "\"github_commits\".\"file_facts\" IS NULL OR jsonb_typeof(\"github_commits\".\"file_facts\") = 'array'"
+        },
+        "github_commits_file_facts_completeness": {
+          "name": "github_commits_file_facts_completeness",
+          "value": "NOT \"github_commits\".\"file_facts_complete\" OR (\"github_commits\".\"file_facts\" IS NOT NULL AND NOT \"github_commits\".\"provider_file_cap_reached\")"
+        },
+        "github_commits_enrichment_state": {
+          "name": "github_commits_enrichment_state",
+          "value": "\"github_commits\".\"enrichment_state\" IN ('pending', 'processing', 'complete', 'unavailable')"
+        },
+        "github_commits_enrichment_lease": {
+          "name": "github_commits_enrichment_lease",
+          "value": "(\"github_commits\".\"enrichment_state\" = 'processing') = (\"github_commits\".\"enrichment_lease_token\" IS NOT NULL) AND (\"github_commits\".\"enrichment_state\" <> 'processing' OR \"github_commits\".\"enrichment_lease_until\" IS NOT NULL) AND (\"github_commits\".\"enrichment_state\" NOT IN ('complete', 'unavailable') OR \"github_commits\".\"enrichment_lease_until\" IS NULL)"
+        },
+        "github_commits_pr_discovery_state": {
+          "name": "github_commits_pr_discovery_state",
+          "value": "\"github_commits\".\"pr_discovery_state\" IN ('pending', 'processing', 'complete', 'unavailable')"
+        },
+        "github_commits_pr_discovery_lease": {
+          "name": "github_commits_pr_discovery_lease",
+          "value": "(\"github_commits\".\"pr_discovery_state\" = 'processing') = (\"github_commits\".\"pr_discovery_lease_token\" IS NOT NULL) AND (\"github_commits\".\"pr_discovery_state\" <> 'processing' OR \"github_commits\".\"pr_discovery_lease_until\" IS NOT NULL) AND (\"github_commits\".\"pr_discovery_state\" NOT IN ('complete', 'unavailable') OR \"github_commits\".\"pr_discovery_lease_until\" IS NULL)"
+        },
+        "github_commits_tracked_author": {
+          "name": "github_commits_tracked_author",
+          "value": "\"github_commits\".\"author_login\" IN ('f0rr0', 'yuppiestechdev')"
+        },
+        "github_commits_nonnegative_activity_counts": {
+          "name": "github_commits_nonnegative_activity_counts",
+          "value": "(\"github_commits\".\"changed_files\" IS NULL OR \"github_commits\".\"changed_files\" >= 0) AND (\"github_commits\".\"additions\" IS NULL OR \"github_commits\".\"additions\" >= 0) AND (\"github_commits\".\"deletions\" IS NULL OR \"github_commits\".\"deletions\" >= 0)"
+        },
+        "github_commits_nonnegative_attempts": {
+          "name": "github_commits_nonnegative_attempts",
+          "value": "\"github_commits\".\"enrichment_attempts\" >= 0 AND \"github_commits\".\"pr_discovery_attempts\" >= 0"
+        },
+        "github_commits_owner_type": {
+          "name": "github_commits_owner_type",
+          "value": "\"github_commits\".\"repository_owner_type\" IS NULL OR \"github_commits\".\"repository_owner_type\" IN ('Organization', 'User')"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.github_issues": {
+      "name": "github_issues",
+      "schema": "",
+      "columns": {
+        "account": {
+          "name": "account",
+          "type": "varchar(39)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_login": {
+          "name": "author_login",
+          "type": "varchar(39)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_user_id": {
+          "name": "author_user_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_observed_at": {
+          "name": "first_observed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "varchar(128)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "number": {
+          "name": "number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title_snapshot": {
+          "name": "title_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url_snapshot": {
+          "name": "url_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "github_issues_repository_number_unique": {
+          "name": "github_issues_repository_number_unique",
+          "columns": [
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_issues_author_idx": {
+          "name": "github_issues_author_idx",
+          "columns": [
+            {
+              "expression": "author_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_issues_repository_id_github_repositories_id_fk": {
+          "name": "github_issues_repository_id_github_repositories_id_fk",
+          "tableFrom": "github_issues",
+          "tableTo": "github_repositories",
+          "columnsFrom": ["repository_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "github_issues_tracked_account": {
+          "name": "github_issues_tracked_account",
+          "value": "\"github_issues\".\"account\" IN ('f0rr0', 'yuppiestechdev')"
+        },
+        "github_issues_positive_number": {
+          "name": "github_issues_positive_number",
+          "value": "\"github_issues\".\"number\" > 0"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.github_public_feed_head": {
+      "name": "github_public_feed_head",
+      "schema": "",
+      "columns": {
+        "feed_revision": {
+          "name": "feed_revision",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "head_content_revision": {
+          "name": "head_content_revision",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "id": {
+          "name": "id",
+          "type": "boolean",
+          "primaryKey": true,
+          "notNull": true,
+          "default": true
+        },
+        "last_published_at": {
+          "name": "last_published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ordering_revision": {
+          "name": "ordering_revision",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "summarizing": {
+          "name": "summarizing",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "gh_public_feed_head_singleton": {
+          "name": "gh_public_feed_head_singleton",
+          "value": "\"github_public_feed_head\".\"id\""
+        },
+        "gh_public_feed_head_revisions": {
+          "name": "gh_public_feed_head_revisions",
+          "value": "\"github_public_feed_head\".\"feed_revision\" >= 0 AND \"github_public_feed_head\".\"head_content_revision\" >= 0 AND \"github_public_feed_head\".\"ordering_revision\" >= 0"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.github_pull_request_memberships": {
+      "name": "github_pull_request_memberships",
+      "schema": "",
+      "columns": {
+        "commit_repository_id": {
+          "name": "commit_repository_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "commit_sha": {
+          "name": "commit_sha",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_head": {
+          "name": "is_head",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version_id": {
+          "name": "version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "github_pull_request_memberships_position_unique": {
+          "name": "github_pull_request_memberships_position_unique",
+          "columns": [
+            {
+              "expression": "version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_pull_request_memberships_commit_lookup_idx": {
+          "name": "github_pull_request_memberships_commit_lookup_idx",
+          "columns": [
+            {
+              "expression": "commit_repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "commit_sha",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gh_pr_memberships_version_fk": {
+          "name": "gh_pr_memberships_version_fk",
+          "tableFrom": "github_pull_request_memberships",
+          "tableTo": "github_pull_request_versions",
+          "columnsFrom": ["version_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "gh_pr_memberships_pk": {
+          "name": "gh_pr_memberships_pk",
+          "columns": ["version_id", "commit_repository_id", "commit_sha"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "github_pull_request_memberships_sha_shape": {
+          "name": "github_pull_request_memberships_sha_shape",
+          "value": "\"github_pull_request_memberships\".\"commit_sha\" ~ '^[a-f0-9]{40}$'"
+        },
+        "github_pull_request_memberships_nonnegative_position": {
+          "name": "github_pull_request_memberships_nonnegative_position",
+          "value": "\"github_pull_request_memberships\".\"position\" >= 0"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.github_pull_request_signals": {
+      "name": "github_pull_request_signals",
+      "schema": "",
+      "columns": {
+        "account": {
+          "name": "account",
+          "type": "varchar(39)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "lease_token": {
+          "name": "lease_token",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lease_until": {
+          "name": "lease_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "number": {
+          "name": "number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "observed_at": {
+          "name": "observed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository_name_snapshot": {
+          "name": "repository_name_snapshot",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        }
+      },
+      "indexes": {
+        "github_pull_request_signals_event_unique": {
+          "name": "github_pull_request_signals_event_unique",
+          "columns": [
+            {
+              "expression": "account",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_pull_request_signals_pending_idx": {
+          "name": "github_pull_request_signals_pending_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lease_until",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "observed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "github_pull_request_signals_account": {
+          "name": "github_pull_request_signals_account",
+          "value": "\"github_pull_request_signals\".\"account\" IN ('f0rr0', 'yuppiestechdev')"
+        },
+        "github_pull_request_signals_event_id": {
+          "name": "github_pull_request_signals_event_id",
+          "value": "\"github_pull_request_signals\".\"event_id\" ~ '^[0-9]{1,64}$'"
+        },
+        "github_pull_request_signals_repository_id": {
+          "name": "github_pull_request_signals_repository_id",
+          "value": "\"github_pull_request_signals\".\"repository_id\" ~ '^[0-9]{1,32}$'"
+        },
+        "github_pull_request_signals_state": {
+          "name": "github_pull_request_signals_state",
+          "value": "\"github_pull_request_signals\".\"state\" IN ('pending', 'processing', 'complete', 'unavailable')"
+        },
+        "github_pull_request_signals_lease": {
+          "name": "github_pull_request_signals_lease",
+          "value": "(\"github_pull_request_signals\".\"state\" = 'processing') = (\"github_pull_request_signals\".\"lease_token\" IS NOT NULL) AND (\"github_pull_request_signals\".\"state\" <> 'processing' OR \"github_pull_request_signals\".\"lease_until\" IS NOT NULL)"
+        },
+        "github_pull_request_signals_values": {
+          "name": "github_pull_request_signals_values",
+          "value": "\"github_pull_request_signals\".\"number\" > 0 AND \"github_pull_request_signals\".\"attempt_count\" >= 0"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.github_pull_request_versions": {
+      "name": "github_pull_request_versions",
+      "schema": "",
+      "columns": {
+        "base_ref_name": {
+          "name": "base_ref_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_repository_id": {
+          "name": "base_repository_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_sha": {
+          "name": "base_sha",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "commit_count": {
+          "name": "commit_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_facts": {
+          "name": "file_facts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_facts_complete": {
+          "name": "file_facts_complete",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "head_ref_name": {
+          "name": "head_ref_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "head_repository_id": {
+          "name": "head_repository_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "head_sha": {
+          "name": "head_sha",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "is_current": {
+          "name": "is_current",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "membership_complete": {
+          "name": "membership_complete",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "merge_snapshot": {
+          "name": "merge_snapshot",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "observed_at": {
+          "name": "observed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "provider_updated_at": {
+          "name": "provider_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pull_request_node_id": {
+          "name": "pull_request_node_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "github_pull_request_versions_head_unique": {
+          "name": "github_pull_request_versions_head_unique",
+          "columns": [
+            {
+              "expression": "pull_request_node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "head_sha",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_pull_request_versions_current_unique": {
+          "name": "github_pull_request_versions_current_unique",
+          "columns": [
+            {
+              "expression": "pull_request_node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"github_pull_request_versions\".\"is_current\"",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gh_pr_versions_pull_request_fk": {
+          "name": "gh_pr_versions_pull_request_fk",
+          "tableFrom": "github_pull_request_versions",
+          "tableTo": "github_pull_requests",
+          "columnsFrom": ["pull_request_node_id"],
+          "columnsTo": ["node_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "github_pull_request_versions_sha_shapes": {
+          "name": "github_pull_request_versions_sha_shapes",
+          "value": "\"github_pull_request_versions\".\"base_sha\" ~ '^[a-f0-9]{40}$' AND \"github_pull_request_versions\".\"head_sha\" ~ '^[a-f0-9]{40}$'"
+        },
+        "github_pull_request_versions_nonnegative_count": {
+          "name": "github_pull_request_versions_nonnegative_count",
+          "value": "\"github_pull_request_versions\".\"commit_count\" IS NULL OR \"github_pull_request_versions\".\"commit_count\" >= 0"
+        },
+        "github_pull_request_versions_file_facts_array": {
+          "name": "github_pull_request_versions_file_facts_array",
+          "value": "\"github_pull_request_versions\".\"file_facts\" IS NULL OR jsonb_typeof(\"github_pull_request_versions\".\"file_facts\") = 'array'"
+        },
+        "github_pull_request_versions_file_facts_complete": {
+          "name": "github_pull_request_versions_file_facts_complete",
+          "value": "NOT \"github_pull_request_versions\".\"file_facts_complete\" OR \"github_pull_request_versions\".\"file_facts\" IS NOT NULL"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.github_pull_requests": {
+      "name": "github_pull_requests",
+      "schema": "",
+      "columns": {
+        "account": {
+          "name": "account",
+          "type": "varchar(39)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "additions": {
+          "name": "additions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_login": {
+          "name": "author_login",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_user_id": {
+          "name": "author_user_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "base_ref_name": {
+          "name": "base_ref_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_repository_id": {
+          "name": "base_repository_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_sha": {
+          "name": "base_sha",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body_snapshot": {
+          "name": "body_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "changed_files": {
+          "name": "changed_files",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commit_count": {
+          "name": "commit_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deletions": {
+          "name": "deletions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "draft": {
+          "name": "draft",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "first_observed_at": {
+          "name": "first_observed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "head_ref_name": {
+          "name": "head_ref_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "head_repository_id": {
+          "name": "head_repository_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "head_sha": {
+          "name": "head_sha",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_reconciled_at": {
+          "name": "last_reconciled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "merged_at": {
+          "name": "merged_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "merge_sha": {
+          "name": "merge_sha",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "merge_sha_verified_at": {
+          "name": "merge_sha_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_reconcile_at": {
+          "name": "next_reconcile_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "varchar(128)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "number": {
+          "name": "number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_file_cap_reached": {
+          "name": "provider_file_cap_reached",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "provider_updated_at": {
+          "name": "provider_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reconcile_attempts": {
+          "name": "reconcile_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reconcile_error": {
+          "name": "reconcile_error",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "terminal_at": {
+          "name": "terminal_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title_snapshot": {
+          "name": "title_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "github_pull_requests_repository_number_unique": {
+          "name": "github_pull_requests_repository_number_unique",
+          "columns": [
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_pull_requests_reconciliation_idx": {
+          "name": "github_pull_requests_reconciliation_idx",
+          "columns": [
+            {
+              "expression": "account",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_reconcile_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_pull_requests_author_idx": {
+          "name": "github_pull_requests_author_idx",
+          "columns": [
+            {
+              "expression": "author_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_pull_requests_repository_id_github_repositories_id_fk": {
+          "name": "github_pull_requests_repository_id_github_repositories_id_fk",
+          "tableFrom": "github_pull_requests",
+          "tableTo": "github_repositories",
+          "columnsFrom": ["repository_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "github_pull_requests_tracked_account": {
+          "name": "github_pull_requests_tracked_account",
+          "value": "\"github_pull_requests\".\"account\" IN ('f0rr0', 'yuppiestechdev')"
+        },
+        "github_pull_requests_state": {
+          "name": "github_pull_requests_state",
+          "value": "\"github_pull_requests\".\"state\" IN ('open', 'closed', 'merged')"
+        },
+        "github_pull_requests_terminal_state": {
+          "name": "github_pull_requests_terminal_state",
+          "value": "(\"github_pull_requests\".\"state\" = 'open' AND \"github_pull_requests\".\"terminal_at\" IS NULL) OR (\"github_pull_requests\".\"state\" IN ('closed', 'merged') AND \"github_pull_requests\".\"terminal_at\" IS NOT NULL)"
+        },
+        "github_pull_requests_merged_state": {
+          "name": "github_pull_requests_merged_state",
+          "value": "(\"github_pull_requests\".\"state\" = 'merged') = (\"github_pull_requests\".\"merged_at\" IS NOT NULL)"
+        },
+        "github_pull_requests_sha_shapes": {
+          "name": "github_pull_requests_sha_shapes",
+          "value": "(\"github_pull_requests\".\"base_sha\" IS NULL OR \"github_pull_requests\".\"base_sha\" ~ '^[a-f0-9]{40}$') AND (\"github_pull_requests\".\"head_sha\" IS NULL OR \"github_pull_requests\".\"head_sha\" ~ '^[a-f0-9]{40}$') AND (\"github_pull_requests\".\"merge_sha\" IS NULL OR \"github_pull_requests\".\"merge_sha\" ~ '^[a-f0-9]{40}$')"
+        },
+        "github_pull_requests_verified_merge_sha": {
+          "name": "github_pull_requests_verified_merge_sha",
+          "value": "(\"github_pull_requests\".\"merge_sha\" IS NULL AND \"github_pull_requests\".\"merge_sha_verified_at\" IS NULL) OR (\"github_pull_requests\".\"state\" = 'merged' AND \"github_pull_requests\".\"merge_sha_verified_at\" IS NOT NULL)"
+        },
+        "github_pull_requests_positive_number": {
+          "name": "github_pull_requests_positive_number",
+          "value": "\"github_pull_requests\".\"number\" > 0"
+        },
+        "github_pull_requests_nonnegative_counts": {
+          "name": "github_pull_requests_nonnegative_counts",
+          "value": "(\"github_pull_requests\".\"changed_files\" IS NULL OR \"github_pull_requests\".\"changed_files\" >= 0) AND (\"github_pull_requests\".\"additions\" IS NULL OR \"github_pull_requests\".\"additions\" >= 0) AND (\"github_pull_requests\".\"deletions\" IS NULL OR \"github_pull_requests\".\"deletions\" >= 0) AND (\"github_pull_requests\".\"commit_count\" IS NULL OR \"github_pull_requests\".\"commit_count\" >= 0)"
+        },
+        "github_pull_requests_nonnegative_attempts": {
+          "name": "github_pull_requests_nonnegative_attempts",
+          "value": "\"github_pull_requests\".\"reconcile_attempts\" >= 0"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.github_push_observation_commits": {
+      "name": "github_push_observation_commits",
+      "schema": "",
+      "columns": {
+        "observation_id": {
+          "name": "observation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sha": {
+          "name": "sha",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "github_push_observation_commits_position_unique": {
+          "name": "github_push_observation_commits_position_unique",
+          "columns": [
+            {
+              "expression": "observation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gh_push_observation_commits_observation_fk": {
+          "name": "gh_push_observation_commits_observation_fk",
+          "tableFrom": "github_push_observation_commits",
+          "tableTo": "github_push_observations",
+          "columnsFrom": ["observation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "gh_push_observation_commits_pk": {
+          "name": "gh_push_observation_commits_pk",
+          "columns": ["observation_id", "repository_id", "sha"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "github_push_observation_commits_sha_shape": {
+          "name": "github_push_observation_commits_sha_shape",
+          "value": "\"github_push_observation_commits\".\"sha\" ~ '^[a-f0-9]{40}$'"
+        },
+        "github_push_observation_commits_nonnegative_position": {
+          "name": "github_push_observation_commits_nonnegative_position",
+          "value": "\"github_push_observation_commits\".\"position\" >= 0"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.github_push_observations": {
+      "name": "github_push_observations",
+      "schema": "",
+      "columns": {
+        "account": {
+          "name": "account",
+          "type": "varchar(39)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "after_sha": {
+          "name": "after_sha",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "before_sha": {
+          "name": "before_sha",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expected_commit_count": {
+          "name": "expected_commit_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "history_since_at": {
+          "name": "history_since_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "history_until_at": {
+          "name": "history_until_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "lease_token": {
+          "name": "lease_token",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lease_until": {
+          "name": "lease_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "observed_at": {
+          "name": "observed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "provider_created_at": {
+          "name": "provider_created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ref_name": {
+          "name": "ref_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository_name_snapshot": {
+          "name": "repository_name_snapshot",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        }
+      },
+      "indexes": {
+        "github_push_observations_source_unique": {
+          "name": "github_push_observations_source_unique",
+          "columns": [
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_push_observations_push_unique": {
+          "name": "github_push_observations_push_unique",
+          "columns": [
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ref_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "before_sha",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "after_sha",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"github_push_observations\".\"source\" <> 'backfill'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_push_observations_pending_idx": {
+          "name": "github_push_observations_pending_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lease_until",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "observed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_push_observations_account_idx": {
+          "name": "github_push_observations_account_idx",
+          "columns": [
+            {
+              "expression": "account",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "observed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gh_push_observations_repository_fk": {
+          "name": "gh_push_observations_repository_fk",
+          "tableFrom": "github_push_observations",
+          "tableTo": "github_repositories",
+          "columnsFrom": ["repository_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "github_push_observations_tracked_account": {
+          "name": "github_push_observations_tracked_account",
+          "value": "\"github_push_observations\".\"account\" IN ('f0rr0', 'yuppiestechdev')"
+        },
+        "github_push_observations_source": {
+          "name": "github_push_observations_source",
+          "value": "\"github_push_observations\".\"source\" IN ('webhook', 'events', 'refs', 'backfill')"
+        },
+        "github_push_observations_sha_shape": {
+          "name": "github_push_observations_sha_shape",
+          "value": "\"github_push_observations\".\"before_sha\" ~ '^[a-f0-9]{40}$' AND \"github_push_observations\".\"after_sha\" ~ '^[a-f0-9]{40}$'"
+        },
+        "github_push_observations_nonnegative_count": {
+          "name": "github_push_observations_nonnegative_count",
+          "value": "\"github_push_observations\".\"attempt_count\" >= 0 AND (\"github_push_observations\".\"expected_commit_count\" IS NULL OR \"github_push_observations\".\"expected_commit_count\" >= 0)"
+        },
+        "github_push_observations_history_bounds": {
+          "name": "github_push_observations_history_bounds",
+          "value": "(\"github_push_observations\".\"source\" <> 'backfill' AND \"github_push_observations\".\"history_since_at\" IS NULL AND \"github_push_observations\".\"history_until_at\" IS NULL) OR (\"github_push_observations\".\"source\" = 'backfill' AND \"github_push_observations\".\"history_since_at\" IS NOT NULL AND \"github_push_observations\".\"history_until_at\" IS NOT NULL AND \"github_push_observations\".\"history_since_at\" <= \"github_push_observations\".\"history_until_at\" AND \"github_push_observations\".\"expected_commit_count\" IS NULL AND \"github_push_observations\".\"before_sha\" = repeat('0', 40))"
+        },
+        "github_push_observations_state": {
+          "name": "github_push_observations_state",
+          "value": "\"github_push_observations\".\"state\" IN ('pending', 'processing', 'complete', 'deferred', 'unavailable')"
+        },
+        "github_push_observations_lease": {
+          "name": "github_push_observations_lease",
+          "value": "(\"github_push_observations\".\"state\" = 'processing') = (\"github_push_observations\".\"lease_token\" IS NOT NULL) AND (\"github_push_observations\".\"state\" <> 'processing' OR \"github_push_observations\".\"lease_until\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.github_ref_generations": {
+      "name": "github_ref_generations",
+      "schema": "",
+      "columns": {
+        "branch_lineage_id": {
+          "name": "branch_lineage_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "coverage_since_at": {
+          "name": "coverage_since_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generation": {
+          "name": "generation",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "head_sha": {
+          "name": "head_sha",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ref_name": {
+          "name": "ref_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "gh_ref_generations_lineage_idx": {
+          "name": "gh_ref_generations_lineage_idx",
+          "columns": [
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "branch_lineage_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gh_ref_generations_repository_fk": {
+          "name": "gh_ref_generations_repository_fk",
+          "tableFrom": "github_ref_generations",
+          "tableTo": "github_repositories",
+          "columnsFrom": ["repository_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "gh_ref_generations_pk": {
+          "name": "gh_ref_generations_pk",
+          "columns": ["repository_id", "ref_name"]
+        }
+      },
+      "uniqueConstraints": {
+        "gh_ref_generations_version_unique": {
+          "name": "gh_ref_generations_version_unique",
+          "nullsNotDistinct": false,
+          "columns": ["repository_id", "ref_name", "generation"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "gh_ref_generations_head_name": {
+          "name": "gh_ref_generations_head_name",
+          "value": "\"github_ref_generations\".\"ref_name\" LIKE 'refs/heads/%'"
+        },
+        "gh_ref_generations_sha_shape": {
+          "name": "gh_ref_generations_sha_shape",
+          "value": "\"github_ref_generations\".\"head_sha\" ~ '^[a-f0-9]{40}$'"
+        },
+        "gh_ref_generations_positive": {
+          "name": "gh_ref_generations_positive",
+          "value": "\"github_ref_generations\".\"generation\" > 0"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.github_ref_memberships": {
+      "name": "github_ref_memberships",
+      "schema": "",
+      "columns": {
+        "commit_repository_id": {
+          "name": "commit_repository_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "commit_sha": {
+          "name": "commit_sha",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generation": {
+          "name": "generation",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ref_name": {
+          "name": "ref_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "gh_ref_memberships_position_unique": {
+          "name": "gh_ref_memberships_position_unique",
+          "columns": [
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ref_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "gh_ref_memberships_commit_idx": {
+          "name": "gh_ref_memberships_commit_idx",
+          "columns": [
+            {
+              "expression": "commit_repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "commit_sha",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gh_ref_memberships_generation_fk": {
+          "name": "gh_ref_memberships_generation_fk",
+          "tableFrom": "github_ref_memberships",
+          "tableTo": "github_ref_generations",
+          "columnsFrom": ["repository_id", "ref_name", "generation"],
+          "columnsTo": ["repository_id", "ref_name", "generation"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gh_ref_memberships_commit_fk": {
+          "name": "gh_ref_memberships_commit_fk",
+          "tableFrom": "github_ref_memberships",
+          "tableTo": "github_commits",
+          "columnsFrom": ["commit_repository_id", "commit_sha"],
+          "columnsTo": ["repository_id", "sha"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "gh_ref_memberships_pk": {
+          "name": "gh_ref_memberships_pk",
+          "columns": [
+            "repository_id",
+            "ref_name",
+            "commit_repository_id",
+            "commit_sha"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "gh_ref_memberships_values": {
+          "name": "gh_ref_memberships_values",
+          "value": "\"github_ref_memberships\".\"generation\" > 0 AND \"github_ref_memberships\".\"position\" >= 0 AND \"github_ref_memberships\".\"commit_sha\" ~ '^[a-f0-9]{40}$'"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.github_repositories": {
+      "name": "github_repositories",
+      "schema": "",
+      "columns": {
+        "default_branch": {
+          "name": "default_branch",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_observed_at": {
+          "name": "first_observed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "facts_verified_at": {
+          "name": "facts_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "inventory_verified_at": {
+          "name": "inventory_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "homepage_url": {
+          "name": "homepage_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "heads_last_reconciled_at": {
+          "name": "heads_last_reconciled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "html_url": {
+          "name": "html_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar(32)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "last_observed_at": {
+          "name": "last_observed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "owner_avatar_url": {
+          "name": "owner_avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_login": {
+          "name": "owner_login",
+          "type": "varchar(39)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_type": {
+          "name": "owner_type",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pushed_at": {
+          "name": "pushed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "topics": {
+          "name": "topics",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags_last_reconciled_at": {
+          "name": "tags_last_reconciled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "github_repositories_full_name_idx": {
+          "name": "github_repositories_full_name_idx",
+          "columns": [
+            {
+              "expression": "full_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "github_repositories_owner_type": {
+          "name": "github_repositories_owner_type",
+          "value": "\"github_repositories\".\"owner_type\" IS NULL OR \"github_repositories\".\"owner_type\" IN ('Organization', 'User')"
+        },
+        "github_repositories_visibility": {
+          "name": "github_repositories_visibility",
+          "value": "\"github_repositories\".\"visibility\" IS NULL OR \"github_repositories\".\"visibility\" IN ('public', 'private', 'internal')"
+        },
+        "github_repositories_topics_array": {
+          "name": "github_repositories_topics_array",
+          "value": "\"github_repositories\".\"topics\" IS NULL OR jsonb_typeof(\"github_repositories\".\"topics\") = 'array'"
+        },
+        "github_repositories_observation_order": {
+          "name": "github_repositories_observation_order",
+          "value": "\"github_repositories\".\"last_observed_at\" >= \"github_repositories\".\"first_observed_at\""
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.github_repository_inventory_heads": {
+      "name": "github_repository_inventory_heads",
+      "schema": "",
+      "columns": {
+        "account_login": {
+          "name": "account_login",
+          "type": "varchar(39)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_user_id": {
+          "name": "account_user_id",
+          "type": "varchar(32)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "generation": {
+          "name": "generation",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "gh_repo_inventory_head_account_id": {
+          "name": "gh_repo_inventory_head_account_id",
+          "value": "\"github_repository_inventory_heads\".\"account_user_id\" ~ '^[0-9]{1,32}$'"
+        },
+        "gh_repo_inventory_head_generation": {
+          "name": "gh_repo_inventory_head_generation",
+          "value": "(\"github_repository_inventory_heads\".\"generation\" = 0 AND \"github_repository_inventory_heads\".\"completed_at\" IS NULL) OR (\"github_repository_inventory_heads\".\"generation\" > 0 AND \"github_repository_inventory_heads\".\"completed_at\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.github_repository_refs": {
+      "name": "github_repository_refs",
+      "schema": "",
+      "columns": {
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "branch_lineage_id": {
+          "name": "branch_lineage_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_observed_at": {
+          "name": "first_observed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "head_sha": {
+          "name": "head_sha",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_observed_at": {
+          "name": "last_observed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "projection_relevant": {
+          "name": "projection_relevant",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "ref_name": {
+          "name": "ref_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repair_attempts": {
+          "name": "repair_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "repair_error": {
+          "name": "repair_error",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repair_lease_token": {
+          "name": "repair_lease_token",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repair_lease_until": {
+          "name": "repair_lease_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "github_repository_refs_active_idx": {
+          "name": "github_repository_refs_active_idx",
+          "columns": [
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_repository_refs_projection_idx": {
+          "name": "github_repository_refs_projection_idx",
+          "columns": [
+            {
+              "expression": "projection_relevant",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_observed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_repository_refs_repository_fk": {
+          "name": "github_repository_refs_repository_fk",
+          "tableFrom": "github_repository_refs",
+          "tableTo": "github_repositories",
+          "columnsFrom": ["repository_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "github_repository_refs_repository_id_ref_name_pk": {
+          "name": "github_repository_refs_repository_id_ref_name_pk",
+          "columns": ["repository_id", "ref_name"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "github_repository_refs_kind": {
+          "name": "github_repository_refs_kind",
+          "value": "\"github_repository_refs\".\"kind\" IN ('head', 'tag')"
+        },
+        "github_repository_refs_name": {
+          "name": "github_repository_refs_name",
+          "value": "(\"github_repository_refs\".\"kind\" = 'head' AND \"github_repository_refs\".\"ref_name\" LIKE 'refs/heads/%') OR (\"github_repository_refs\".\"kind\" = 'tag' AND \"github_repository_refs\".\"ref_name\" LIKE 'refs/tags/%')"
+        },
+        "github_repository_refs_lineage": {
+          "name": "github_repository_refs_lineage",
+          "value": "(\"github_repository_refs\".\"kind\" = 'head') = (\"github_repository_refs\".\"branch_lineage_id\" IS NOT NULL)"
+        },
+        "github_repository_refs_projection_relevance": {
+          "name": "github_repository_refs_projection_relevance",
+          "value": "NOT \"github_repository_refs\".\"projection_relevant\" OR \"github_repository_refs\".\"kind\" = 'head'"
+        },
+        "github_repository_refs_sha_shape": {
+          "name": "github_repository_refs_sha_shape",
+          "value": "\"github_repository_refs\".\"head_sha\" ~ '^[a-f0-9]{40}$'"
+        },
+        "github_repository_refs_observation_order": {
+          "name": "github_repository_refs_observation_order",
+          "value": "\"github_repository_refs\".\"last_observed_at\" >= \"github_repository_refs\".\"first_observed_at\""
+        },
+        "github_repository_refs_repair_lease": {
+          "name": "github_repository_refs_repair_lease",
+          "value": "(\"github_repository_refs\".\"repair_lease_token\" IS NULL) = (\"github_repository_refs\".\"repair_lease_until\" IS NULL) AND (\"github_repository_refs\".\"repair_lease_token\" IS NULL OR \"github_repository_refs\".\"kind\" = 'head')"
+        },
+        "github_repository_refs_repair_attempts": {
+          "name": "github_repository_refs_repair_attempts",
+          "value": "\"github_repository_refs\".\"repair_attempts\" >= 0"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.github_webhook_deliveries": {
+      "name": "github_webhook_deliveries",
+      "schema": "",
+      "columns": {
+        "accepted": {
+          "name": "accepted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account": {
+          "name": "account",
+          "type": "varchar(39)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_id": {
+          "name": "delivery_id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event": {
+          "name": "event",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "observed_at": {
+          "name": "observed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "github_webhook_deliveries_audit_idx": {
+          "name": "github_webhook_deliveries_audit_idx",
+          "columns": [
+            {
+              "expression": "event",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "observed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "github_webhook_deliveries_id_shape": {
+          "name": "github_webhook_deliveries_id_shape",
+          "value": "\"github_webhook_deliveries\".\"delivery_id\" ~ '^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$'"
+        },
+        "github_webhook_deliveries_event_shape": {
+          "name": "github_webhook_deliveries_event_shape",
+          "value": "\"github_webhook_deliveries\".\"event\" ~ '^[a-z][a-z0-9_]{0,39}$'"
+        },
+        "github_webhook_deliveries_action_shape": {
+          "name": "github_webhook_deliveries_action_shape",
+          "value": "\"github_webhook_deliveries\".\"action\" IS NULL OR \"github_webhook_deliveries\".\"action\" ~ '^[a-z][a-z0-9_]{0,39}$'"
+        },
+        "github_webhook_deliveries_repository_id_shape": {
+          "name": "github_webhook_deliveries_repository_id_shape",
+          "value": "\"github_webhook_deliveries\".\"repository_id\" IS NULL OR \"github_webhook_deliveries\".\"repository_id\" ~ '^[0-9]{1,32}$'"
+        },
+        "github_webhook_deliveries_tracked_account": {
+          "name": "github_webhook_deliveries_tracked_account",
+          "value": "\"github_webhook_deliveries\".\"account\" IS NULL OR \"github_webhook_deliveries\".\"account\" IN ('f0rr0', 'yuppiestechdev')"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.github_work_unit_memberships": {
+      "name": "github_work_unit_memberships",
+      "schema": "",
+      "columns": {
+        "logical_repository_id": {
+          "name": "logical_repository_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logical_sha": {
+          "name": "logical_sha",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "work_unit_id": {
+          "name": "work_unit_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "gh_work_unit_memberships_position_unique": {
+          "name": "gh_work_unit_memberships_position_unique",
+          "columns": [
+            {
+              "expression": "work_unit_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "gh_work_unit_memberships_commit_unique": {
+          "name": "gh_work_unit_memberships_commit_unique",
+          "columns": [
+            {
+              "expression": "logical_repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "logical_sha",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gh_work_unit_memberships_unit_fk": {
+          "name": "gh_work_unit_memberships_unit_fk",
+          "tableFrom": "github_work_unit_memberships",
+          "tableTo": "github_work_units",
+          "columnsFrom": ["work_unit_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gh_work_unit_memberships_commit_fk": {
+          "name": "gh_work_unit_memberships_commit_fk",
+          "tableFrom": "github_work_unit_memberships",
+          "tableTo": "github_commits",
+          "columnsFrom": ["logical_repository_id", "logical_sha"],
+          "columnsTo": ["repository_id", "sha"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "gh_work_unit_memberships_pk": {
+          "name": "gh_work_unit_memberships_pk",
+          "columns": ["work_unit_id", "logical_repository_id", "logical_sha"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "gh_work_unit_memberships_values": {
+          "name": "gh_work_unit_memberships_values",
+          "value": "\"github_work_unit_memberships\".\"position\" >= 0 AND \"github_work_unit_memberships\".\"logical_sha\" ~ '^[a-f0-9]{40}$'"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.github_work_unit_summary_attempts": {
+      "name": "github_work_unit_summary_attempts",
+      "schema": "",
+      "columns": {
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attribution_mode": {
+          "name": "attribution_mode",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "debounce_until": {
+          "name": "debounce_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_started_at": {
+          "name": "last_started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latency_ms": {
+          "name": "latency_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lease_token": {
+          "name": "lease_token",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lease_until": {
+          "name": "lease_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "outcome_digest": {
+          "name": "outcome_digest",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recipe": {
+          "name": "recipe",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_payload": {
+          "name": "request_payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revision": {
+          "name": "revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_requests": {
+          "name": "started_requests",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "state": {
+          "name": "state",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "summary_input_digest": {
+          "name": "summary_input_digest",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unit_revision": {
+          "name": "unit_revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "work_unit_id": {
+          "name": "work_unit_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "gh_work_unit_summary_input_unique": {
+          "name": "gh_work_unit_summary_input_unique",
+          "columns": [
+            {
+              "expression": "work_unit_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "summary_input_digest",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "recipe",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "gh_work_unit_summary_claim_idx": {
+          "name": "gh_work_unit_summary_claim_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "debounce_until",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gh_work_unit_summary_attempts_unit_fk": {
+          "name": "gh_work_unit_summary_attempts_unit_fk",
+          "tableFrom": "github_work_unit_summary_attempts",
+          "tableTo": "github_work_units",
+          "columnsFrom": ["work_unit_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "gh_work_unit_summary_attempts_pk": {
+          "name": "gh_work_unit_summary_attempts_pk",
+          "columns": ["work_unit_id", "revision"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "gh_work_unit_summary_state": {
+          "name": "gh_work_unit_summary_state",
+          "value": "\"github_work_unit_summary_attempts\".\"state\" IN ('pending', 'processing', 'retryable', 'accepted', 'terminal')"
+        },
+        "gh_work_unit_summary_digests": {
+          "name": "gh_work_unit_summary_digests",
+          "value": "\"github_work_unit_summary_attempts\".\"outcome_digest\" ~ '^[a-f0-9]{64}$' AND \"github_work_unit_summary_attempts\".\"summary_input_digest\" ~ '^[a-f0-9]{64}$'"
+        },
+        "gh_work_unit_summary_attribution": {
+          "name": "gh_work_unit_summary_attribution",
+          "value": "\"github_work_unit_summary_attempts\".\"attribution_mode\" IN ('tracked_authored_pr', 'foreign_pr_contribution', 'canonical_owned_composite', 'branch_owned_composite')"
+        },
+        "gh_work_unit_summary_revisions": {
+          "name": "gh_work_unit_summary_revisions",
+          "value": "\"github_work_unit_summary_attempts\".\"revision\" > 0 AND \"github_work_unit_summary_attempts\".\"unit_revision\" > 0 AND \"github_work_unit_summary_attempts\".\"started_requests\" BETWEEN 0 AND 2"
+        },
+        "gh_work_unit_summary_lease": {
+          "name": "gh_work_unit_summary_lease",
+          "value": "(\"github_work_unit_summary_attempts\".\"lease_token\" IS NULL) = (\"github_work_unit_summary_attempts\".\"lease_until\" IS NULL) AND (\"github_work_unit_summary_attempts\".\"state\" = 'processing') = (\"github_work_unit_summary_attempts\".\"lease_token\" IS NOT NULL) AND (\"github_work_unit_summary_attempts\".\"state\" <> 'processing' OR (\"github_work_unit_summary_attempts\".\"started_requests\" > 0 AND \"github_work_unit_summary_attempts\".\"request_payload\" IS NOT NULL))"
+        },
+        "gh_work_unit_summary_terminal_payload": {
+          "name": "gh_work_unit_summary_terminal_payload",
+          "value": "\"github_work_unit_summary_attempts\".\"state\" NOT IN ('accepted', 'terminal') OR \"github_work_unit_summary_attempts\".\"request_payload\" IS NULL"
+        },
+        "gh_work_unit_summary_accepted_output": {
+          "name": "gh_work_unit_summary_accepted_output",
+          "value": "(\"github_work_unit_summary_attempts\".\"state\" = 'accepted' AND \"github_work_unit_summary_attempts\".\"outcome\" IS NOT NULL AND \"github_work_unit_summary_attempts\".\"accepted_at\" IS NOT NULL AND \"github_work_unit_summary_attempts\".\"completed_at\" IS NOT NULL) OR (\"github_work_unit_summary_attempts\".\"state\" <> 'accepted' AND \"github_work_unit_summary_attempts\".\"outcome\" IS NULL AND \"github_work_unit_summary_attempts\".\"accepted_at\" IS NULL AND (\"github_work_unit_summary_attempts\".\"state\" <> 'terminal' OR \"github_work_unit_summary_attempts\".\"completed_at\" IS NOT NULL))"
+        },
+        "gh_work_unit_summary_started": {
+          "name": "gh_work_unit_summary_started",
+          "value": "(\"github_work_unit_summary_attempts\".\"started_requests\" = 0) = (\"github_work_unit_summary_attempts\".\"last_started_at\" IS NULL) AND (\"github_work_unit_summary_attempts\".\"state\" <> 'retryable' OR \"github_work_unit_summary_attempts\".\"request_payload\" IS NOT NULL)"
+        },
+        "gh_work_unit_summary_request_cap": {
+          "name": "gh_work_unit_summary_request_cap",
+          "value": "\"github_work_unit_summary_attempts\".\"request_payload\" IS NULL OR octet_length(\"github_work_unit_summary_attempts\".\"request_payload\") <= 393216"
+        },
+        "gh_work_unit_summary_metrics": {
+          "name": "gh_work_unit_summary_metrics",
+          "value": "(\"github_work_unit_summary_attempts\".\"input_tokens\" IS NULL OR \"github_work_unit_summary_attempts\".\"input_tokens\" >= 0) AND (\"github_work_unit_summary_attempts\".\"output_tokens\" IS NULL OR \"github_work_unit_summary_attempts\".\"output_tokens\" >= 0) AND (\"github_work_unit_summary_attempts\".\"latency_ms\" IS NULL OR \"github_work_unit_summary_attempts\".\"latency_ms\" >= 0)"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.github_work_unit_summary_daily_usage": {
+      "name": "github_work_unit_summary_daily_usage",
+      "schema": "",
+      "columns": {
+        "day": {
+          "name": "day",
+          "type": "date",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "started_requests": {
+          "name": "started_requests",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "gh_work_unit_summary_daily_usage_cap": {
+          "name": "gh_work_unit_summary_daily_usage_cap",
+          "value": "\"github_work_unit_summary_daily_usage\".\"started_requests\" BETWEEN 0 AND 12"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.github_work_units": {
+      "name": "github_work_units",
+      "schema": "",
+      "columns": {
+        "activity_anchor_at": {
+          "name": "activity_anchor_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activity_at": {
+          "name": "activity_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activity_day": {
+          "name": "activity_day",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "additions": {
+          "name": "additions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attribution_mode": {
+          "name": "attribution_mode",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "branch_lineage_id": {
+          "name": "branch_lineage_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_observed_at": {
+          "name": "content_observed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deletions": {
+          "name": "deletions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "facts_digest": {
+          "name": "facts_digest",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_count": {
+          "name": "file_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_activity_at": {
+          "name": "first_activity_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "identity_key": {
+          "name": "identity_key",
+          "type": "varchar(180)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "languages": {
+          "name": "languages",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_activity_at": {
+          "name": "last_activity_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "member_count": {
+          "name": "member_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "membership_digest": {
+          "name": "membership_digest",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "newest_commit_repository_id": {
+          "name": "newest_commit_repository_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "newest_commit_sha": {
+          "name": "newest_commit_sha",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "outcome_digest": {
+          "name": "outcome_digest",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pull_request_node_id": {
+          "name": "pull_request_node_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revision": {
+          "name": "revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "summary_input_digest": {
+          "name": "summary_input_digest",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "gh_work_units_identity_unique": {
+          "name": "gh_work_units_identity_unique",
+          "columns": [
+            {
+              "expression": "identity_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "gh_work_units_pr_unique": {
+          "name": "gh_work_units_pr_unique",
+          "columns": [
+            {
+              "expression": "pull_request_node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"github_work_units\".\"kind\" = 'pull_request'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "gh_work_units_canonical_day_unique": {
+          "name": "gh_work_units_canonical_day_unique",
+          "columns": [
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "activity_day",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"github_work_units\".\"kind\" = 'canonical_day'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "gh_work_units_branch_unique": {
+          "name": "gh_work_units_branch_unique",
+          "columns": [
+            {
+              "expression": "branch_lineage_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"github_work_units\".\"kind\" = 'branch'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "gh_work_units_feed_idx": {
+          "name": "gh_work_units_feed_idx",
+          "columns": [
+            {
+              "expression": "visibility",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "activity_day",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "activity_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gh_work_units_repository_fk": {
+          "name": "gh_work_units_repository_fk",
+          "tableFrom": "github_work_units",
+          "tableTo": "github_repositories",
+          "columnsFrom": ["repository_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gh_work_units_pull_request_fk": {
+          "name": "gh_work_units_pull_request_fk",
+          "tableFrom": "github_work_units",
+          "tableTo": "github_pull_requests",
+          "columnsFrom": ["pull_request_node_id"],
+          "columnsTo": ["node_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gh_work_units_newest_commit_fk": {
+          "name": "gh_work_units_newest_commit_fk",
+          "tableFrom": "github_work_units",
+          "tableTo": "github_commits",
+          "columnsFrom": ["newest_commit_repository_id", "newest_commit_sha"],
+          "columnsTo": ["repository_id", "sha"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "gh_work_units_kind": {
+          "name": "gh_work_units_kind",
+          "value": "\"github_work_units\".\"kind\" IN ('pull_request', 'canonical_day', 'branch')"
+        },
+        "gh_work_units_owner_shape": {
+          "name": "gh_work_units_owner_shape",
+          "value": "(\"github_work_units\".\"kind\" = 'pull_request' AND \"github_work_units\".\"pull_request_node_id\" IS NOT NULL AND \"github_work_units\".\"branch_lineage_id\" IS NULL) OR (\"github_work_units\".\"kind\" = 'canonical_day' AND \"github_work_units\".\"pull_request_node_id\" IS NULL AND \"github_work_units\".\"branch_lineage_id\" IS NULL) OR (\"github_work_units\".\"kind\" = 'branch' AND \"github_work_units\".\"pull_request_node_id\" IS NULL AND \"github_work_units\".\"branch_lineage_id\" IS NOT NULL)"
+        },
+        "gh_work_units_identity": {
+          "name": "gh_work_units_identity",
+          "value": "(\"github_work_units\".\"kind\" = 'pull_request' AND \"github_work_units\".\"identity_key\" = 'pr:' || \"github_work_units\".\"pull_request_node_id\") OR (\"github_work_units\".\"kind\" = 'canonical_day' AND \"github_work_units\".\"identity_key\" = 'canonical:' || \"github_work_units\".\"repository_id\" || ':' || \"github_work_units\".\"activity_day\"::text) OR (\"github_work_units\".\"kind\" = 'branch' AND \"github_work_units\".\"identity_key\" = 'branch:' || \"github_work_units\".\"branch_lineage_id\"::text)"
+        },
+        "gh_work_units_attribution_mode": {
+          "name": "gh_work_units_attribution_mode",
+          "value": "\"github_work_units\".\"attribution_mode\" IN ('tracked_authored_pr', 'foreign_pr_contribution', 'canonical_owned_composite', 'branch_owned_composite')"
+        },
+        "gh_work_units_kind_attribution": {
+          "name": "gh_work_units_kind_attribution",
+          "value": "(\"github_work_units\".\"kind\" = 'pull_request' AND \"github_work_units\".\"attribution_mode\" IN ('tracked_authored_pr', 'foreign_pr_contribution')) OR (\"github_work_units\".\"kind\" = 'canonical_day' AND \"github_work_units\".\"attribution_mode\" = 'canonical_owned_composite') OR (\"github_work_units\".\"kind\" = 'branch' AND \"github_work_units\".\"attribution_mode\" = 'branch_owned_composite')"
+        },
+        "gh_work_units_visibility": {
+          "name": "gh_work_units_visibility",
+          "value": "\"github_work_units\".\"visibility\" IN ('public', 'private')"
+        },
+        "gh_work_units_nonnegative_facts": {
+          "name": "gh_work_units_nonnegative_facts",
+          "value": "\"github_work_units\".\"member_count\" > 0 AND \"github_work_units\".\"file_count\" >= 0 AND \"github_work_units\".\"additions\" >= 0 AND \"github_work_units\".\"deletions\" >= 0 AND \"github_work_units\".\"revision\" > 0"
+        },
+        "gh_work_units_activity_order": {
+          "name": "gh_work_units_activity_order",
+          "value": "\"github_work_units\".\"first_activity_at\" <= \"github_work_units\".\"last_activity_at\" AND \"github_work_units\".\"activity_day\" = (\"github_work_units\".\"activity_at\" AT TIME ZONE 'UTC')::date"
+        },
+        "gh_work_units_digest_shapes": {
+          "name": "gh_work_units_digest_shapes",
+          "value": "\"github_work_units\".\"facts_digest\" ~ '^[a-f0-9]{64}$' AND \"github_work_units\".\"membership_digest\" ~ '^[a-f0-9]{64}$' AND (\"github_work_units\".\"outcome_digest\" IS NULL OR \"github_work_units\".\"outcome_digest\" ~ '^[a-f0-9]{64}$') AND (\"github_work_units\".\"summary_input_digest\" IS NULL OR \"github_work_units\".\"summary_input_digest\" ~ '^[a-f0-9]{64}$')"
+        },
+        "gh_work_units_languages_array": {
+          "name": "gh_work_units_languages_array",
+          "value": "\"github_work_units\".\"languages\" IS NULL OR jsonb_typeof(\"github_work_units\".\"languages\") = 'array'"
+        }
+      },
+      "isRLSEnabled": true
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -99,6 +99,13 @@
       "when": 1788249618634,
       "tag": "0013_github_work_units",
       "breakpoints": true
+    },
+    {
+      "idx": 14,
+      "version": "7",
+      "when": 1788259696425,
+      "tag": "0014_friendly_crusher_hogan",
+      "breakpoints": true
     }
   ]
 }

--- a/scripts/backfill-github-activity.ts
+++ b/scripts/backfill-github-activity.ts
@@ -223,9 +223,8 @@ const stoppedFactualDrain = (
 });
 
 /**
- * Drains factual worker claims for one historical scope. A provider deferral is
- * returned immediately; the caller never sleeps or retries a deferred claim in
- * process. Summary generation and ref repair remain outside this drain.
+ * Drains ready factual worker claims for one historical scope without sleeping
+ * on future-deferred work. Summary generation and ref repair stay outside it.
  */
 export const runGitHubBackfillFactualDrain = async (
   input: {
@@ -270,7 +269,6 @@ export const runGitHubBackfillFactualDrain = async (
     const stages = factualStagesFrom(pass);
     const claimed = stages.reduce((sum, stage) => sum + stage.claimed, 0);
     const completed = stages.reduce((sum, stage) => sum + stage.completed, 0);
-    const deferred = stages.reduce((sum, stage) => sum + stage.deferred, 0);
     result.claimed += claimed;
     result.completed += completed;
     result.passes += 1;
@@ -304,7 +302,7 @@ export const runGitHubBackfillFactualDrain = async (
     ) {
       return stoppedFactualDrain(result, { stopReason: "deadline" });
     }
-    if (deferred > 0 || claimed === 0) {
+    if (claimed === 0 || backlog.retryAt !== null) {
       return stoppedFactualDrain(result, {
         retryAt: backlog.retryAt,
         stopReason: "deferred",
@@ -533,7 +531,8 @@ export const runGitHubBackfillDiscovery = async (
           onProgress: (progress) => {
             input.onProgress?.({
               account,
-              completed: progress.scannedPullRequests,
+              completed:
+                progress.scannedPullRequests + progress.reusedPullRequests,
               phase: "progress",
               stage: "pull_requests",
               total: progress.selectedAuthoredPullRequests,
@@ -547,7 +546,8 @@ export const runGitHubBackfillDiscovery = async (
         input.onProgress?.({
           account,
           complete: pullRequests.complete,
-          completed: pullRequests.scannedPullRequests,
+          completed:
+            pullRequests.scannedPullRequests + pullRequests.reusedPullRequests,
           phase: "finished",
           stage: "pull_requests",
           total: pullRequests.selectedAuthoredPullRequests,

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -23,6 +23,75 @@ import type {
   GitHubWorkUnitFileFact,
 } from "@/lib/github-change-evidence";
 
+export const githubRepositories = pgTable(
+  "github_repositories",
+  {
+    defaultBranch: varchar("default_branch", { length: 255 }),
+    description: text("description"),
+    firstObservedAt: timestamp("first_observed_at", {
+      mode: "date",
+      withTimezone: true,
+    })
+      .defaultNow()
+      .notNull(),
+    factsVerifiedAt: timestamp("facts_verified_at", {
+      mode: "date",
+      withTimezone: true,
+    }),
+    inventoryVerifiedAt: timestamp("inventory_verified_at", {
+      mode: "date",
+      withTimezone: true,
+    }),
+    fullName: varchar("full_name", { length: 200 }).notNull(),
+    homepageUrl: text("homepage_url"),
+    headsLastReconciledAt: timestamp("heads_last_reconciled_at", {
+      mode: "date",
+      withTimezone: true,
+    }),
+    htmlUrl: text("html_url"),
+    id: varchar("id", { length: 32 }).primaryKey(),
+    lastObservedAt: timestamp("last_observed_at", {
+      mode: "date",
+      withTimezone: true,
+    })
+      .defaultNow()
+      .notNull(),
+    ownerAvatarUrl: text("owner_avatar_url"),
+    ownerId: varchar("owner_id", { length: 32 }),
+    ownerLogin: varchar("owner_login", { length: 39 }),
+    ownerType: varchar("owner_type", { length: 12 }),
+    pushedAt: timestamp("pushed_at", {
+      mode: "date",
+      withTimezone: true,
+    }),
+    topics: jsonb("topics").$type<readonly string[]>(),
+    tagsLastReconciledAt: timestamp("tags_last_reconciled_at", {
+      mode: "date",
+      withTimezone: true,
+    }),
+    visibility: varchar("visibility", { length: 12 }),
+  },
+  (table) => [
+    index("github_repositories_full_name_idx").on(table.fullName),
+    check(
+      "github_repositories_owner_type",
+      sql`${table.ownerType} IS NULL OR ${table.ownerType} IN ('Organization', 'User')`
+    ),
+    check(
+      "github_repositories_visibility",
+      sql`${table.visibility} IS NULL OR ${table.visibility} IN ('public', 'private', 'internal')`
+    ),
+    check(
+      "github_repositories_topics_array",
+      sql`${table.topics} IS NULL OR jsonb_typeof(${table.topics}) = 'array'`
+    ),
+    check(
+      "github_repositories_observation_order",
+      sql`${table.lastObservedAt} >= ${table.firstObservedAt}`
+    ),
+  ]
+).enableRLS();
+
 export const githubCommits = pgTable(
   "github_commits",
   {
@@ -81,7 +150,7 @@ export const githubCommits = pgTable(
     pullRequestDiscoveryState: varchar("pr_discovery_state", { length: 16 })
       .default("pending")
       .notNull(),
-    repository: varchar("repository", { length: 200 }).notNull(),
+    repository: varchar("repository", { length: 200 }),
     repositoryId: varchar("repository_id", { length: 32 }).notNull(),
     repositoryOwnerAvatarUrl: text("repository_owner_avatar_url"),
     repositoryOwnerLogin: varchar("repository_owner_login", { length: 39 }),
@@ -91,6 +160,11 @@ export const githubCommits = pgTable(
   },
   (table) => [
     primaryKey({ columns: [table.repositoryId, table.sha] }),
+    foreignKey({
+      columns: [table.repositoryId],
+      foreignColumns: [githubRepositories.id],
+      name: "github_commits_repository_fk",
+    }),
     index("github_commits_committed_at_idx").on(table.committedAt),
     index("github_commits_enrichment_pending_idx").on(
       table.enrichmentState,
@@ -178,6 +252,9 @@ export const githubAccountCheckpoints = pgTable(
     gapState: varchar("gap_state", { length: 12 }).default("clear").notNull(),
     latestEventId: varchar("latest_event_id", { length: 64 }),
     paused: boolean("paused").default(false).notNull(),
+    pullRequestBackfillDigest: varchar("pull_request_backfill_digest", {
+      length: 64,
+    }),
     headRefCursorRepositoryId: varchar("head_ref_cursor_repository_id", {
       length: 32,
     }),
@@ -264,70 +341,9 @@ export const githubAccountCheckpoints = pgTable(
       "github_account_checkpoints_ref_scans",
       sql`(${table.headRefNextPage} IS NULL AND ${table.headRefScanStartedAt} IS NULL OR ${table.headRefNextPage} >= 2 AND ${table.headRefScanStartedAt} IS NOT NULL) AND (${table.tagRefNextPage} IS NULL AND ${table.tagRefScanStartedAt} IS NULL OR ${table.tagRefNextPage} >= 2 AND ${table.tagRefScanStartedAt} IS NOT NULL)`
     ),
-  ]
-).enableRLS();
-
-export const githubRepositories = pgTable(
-  "github_repositories",
-  {
-    defaultBranch: varchar("default_branch", { length: 255 }),
-    description: text("description"),
-    firstObservedAt: timestamp("first_observed_at", {
-      mode: "date",
-      withTimezone: true,
-    })
-      .defaultNow()
-      .notNull(),
-    factsVerifiedAt: timestamp("facts_verified_at", {
-      mode: "date",
-      withTimezone: true,
-    }),
-    fullName: varchar("full_name", { length: 200 }).notNull(),
-    homepageUrl: text("homepage_url"),
-    headsLastReconciledAt: timestamp("heads_last_reconciled_at", {
-      mode: "date",
-      withTimezone: true,
-    }),
-    htmlUrl: text("html_url"),
-    id: varchar("id", { length: 32 }).primaryKey(),
-    lastObservedAt: timestamp("last_observed_at", {
-      mode: "date",
-      withTimezone: true,
-    })
-      .defaultNow()
-      .notNull(),
-    ownerAvatarUrl: text("owner_avatar_url"),
-    ownerId: varchar("owner_id", { length: 32 }),
-    ownerLogin: varchar("owner_login", { length: 39 }),
-    ownerType: varchar("owner_type", { length: 12 }),
-    pushedAt: timestamp("pushed_at", {
-      mode: "date",
-      withTimezone: true,
-    }),
-    topics: jsonb("topics").$type<readonly string[]>(),
-    tagsLastReconciledAt: timestamp("tags_last_reconciled_at", {
-      mode: "date",
-      withTimezone: true,
-    }),
-    visibility: varchar("visibility", { length: 12 }),
-  },
-  (table) => [
-    index("github_repositories_full_name_idx").on(table.fullName),
     check(
-      "github_repositories_owner_type",
-      sql`${table.ownerType} IS NULL OR ${table.ownerType} IN ('Organization', 'User')`
-    ),
-    check(
-      "github_repositories_visibility",
-      sql`${table.visibility} IS NULL OR ${table.visibility} IN ('public', 'private', 'internal')`
-    ),
-    check(
-      "github_repositories_topics_array",
-      sql`${table.topics} IS NULL OR jsonb_typeof(${table.topics}) = 'array'`
-    ),
-    check(
-      "github_repositories_observation_order",
-      sql`${table.lastObservedAt} >= ${table.firstObservedAt}`
+      "github_account_checkpoints_pr_backfill_digest",
+      sql`${table.pullRequestBackfillDigest} IS NULL OR ${table.pullRequestBackfillDigest} ~ '^[a-f0-9]{64}$'`
     ),
   ]
 ).enableRLS();

--- a/src/lib/github-activity-processor.ts
+++ b/src/lib/github-activity-processor.ts
@@ -32,24 +32,12 @@ const ZERO_SHA = "0".repeat(40);
 
 type JsonObject = Record<string, unknown>;
 
-export interface GitHubActivityRepositoryEvidence {
-  avatarUrl: string | null;
-  description: string | null;
-  fullName: string;
-  homepageUrl: string | null;
-  ownerLogin: string;
-  ownerType: "Organization" | "User";
-  private: boolean;
-  topics: readonly string[];
-}
-
 export interface GitHubActivityCommitSource {
   authorUserId: string;
   authoredAt: string;
   commit: GitHubCommitChangeEvidence;
   committerAt: string;
   committerUserId: string | null;
-  repository: GitHubActivityRepositoryEvidence;
 }
 
 export interface GitHubActivityCommitReference {
@@ -651,62 +639,6 @@ const withAuthoritativeMergeCommits = async (
   });
 };
 
-const safeAvatarUrl = (value: unknown) => {
-  if (typeof value !== "string") {
-    return null;
-  }
-  try {
-    const url = new URL(value);
-    return url.protocol === "https:" &&
-      url.hostname === "avatars.githubusercontent.com"
-      ? url.toString()
-      : null;
-  } catch {
-    return null;
-  }
-};
-
-const repositoryEvidenceFrom = (
-  value: unknown,
-  expectedRepositoryId: string
-): GitHubActivityRepositoryEvidence => {
-  if (!isObject(value) || !isObject(value.owner)) {
-    throw new ActivityProcessingError(
-      "source_invalid",
-      "GitHub returned invalid repository evidence."
-    );
-  }
-  const repository = repositoryFrom(value);
-  const ownerLogin = requiredString(value.owner.login, "repository owner");
-  const ownerType = value.owner.type;
-  if (
-    repository === null ||
-    repository.id !== expectedRepositoryId ||
-    typeof value.private !== "boolean" ||
-    (ownerType !== "Organization" && ownerType !== "User")
-  ) {
-    throw new ActivityProcessingError(
-      "source_invalid",
-      "GitHub returned inconsistent repository evidence."
-    );
-  }
-  return {
-    avatarUrl: safeAvatarUrl(value.owner.avatar_url),
-    description: optionalString(value.description),
-    fullName: repository.fullName,
-    homepageUrl: optionalString(value.homepage),
-    ownerLogin,
-    ownerType,
-    private: value.private,
-    topics: Array.isArray(value.topics)
-      ? value.topics.filter(
-          (topic): topic is string =>
-            typeof topic === "string" && topic.length > 0
-        )
-      : [],
-  };
-};
-
 const fileEvidenceFrom = (value: unknown): GitHubFileChangeEvidence => {
   if (!isObject(value)) {
     throw new ActivityProcessingError(
@@ -812,22 +744,13 @@ const fetchCommitSourceWithToken = async (
   token: string,
   options: GitHubProviderRequestOptions = {}
 ): Promise<GitHubActivityCommitSource> => {
-  const repositoryPayload = await fetchJson(
-    repositoryApiPath(row.repository),
-    token,
-    options
-  );
-  const repository = repositoryEvidenceFrom(
-    repositoryPayload,
-    row.repositoryId
-  );
   const files = new Map<string, GitHubFileChangeEvidence>();
   let root: JsonObject | null = null;
   let providerFileCapReached = false;
   for (let page = 1; page <= MAXIMUM_GITHUB_FILE_PAGES; page += 1) {
     const value = await fetchJson(
       repositoryApiPath(
-        repository.fullName,
+        row.repository,
         `/commits/${encodeURIComponent(row.sha)}?per_page=${GITHUB_FILE_PAGE_SIZE}&page=${page}`
       ),
       token,
@@ -887,7 +810,6 @@ const fetchCommitSourceWithToken = async (
       root.committer === null
         ? null
         : optionalProviderId(root.committer.id, "commit committer ID"),
-    repository,
   };
 };
 

--- a/src/lib/github-activity-worker-store.ts
+++ b/src/lib/github-activity-worker-store.ts
@@ -51,10 +51,6 @@ import {
 } from "@/lib/github-pull-request-store";
 import type { StoredPullRequestSnapshot } from "@/lib/github-pull-request-store";
 
-type DatabaseTransaction = Parameters<
-  Parameters<ReturnType<typeof getDatabase>["transaction"]>[0]
->[0];
-
 const DEFAULT_LEASE_MS = 5 * 60 * 1000;
 
 const commitIdentity = (commit: { repositoryId: string; sha: string }) =>
@@ -434,7 +430,6 @@ export const completeGitHubPushObservation = async (
                 committedAt: new Date(commit.committedAt),
                 firstObservedAt: observation.observedAt,
                 message: commit.message,
-                repository: commit.repository,
                 repositoryId: commit.repositoryId,
                 sha: commit.sha,
               }))
@@ -551,12 +546,16 @@ export const claimGitHubCommitsForEnrichment = async (
         errorCode: githubCommits.enrichmentError,
         leaseUntil: githubCommits.enrichmentLeaseUntil,
         message: githubCommits.message,
-        repository: githubCommits.repository,
+        repository: githubRepositories.fullName,
         repositoryId: githubCommits.repositoryId,
         sha: githubCommits.sha,
         state: githubCommits.enrichmentState,
       })
       .from(githubCommits)
+      .innerJoin(
+        githubRepositories,
+        eq(githubRepositories.id, githubCommits.repositoryId)
+      )
       .where(
         and(
           inArray(githubCommits.author, [...activeAccounts]),
@@ -629,109 +628,42 @@ export const claimGitHubCommitsForEnrichment = async (
   });
 };
 
-const persistRepositoryEvidence = async (
-  transaction: DatabaseTransaction,
-  source: GitHubActivityCommitSource,
-  repositoryId: string,
-  now: Date
-) => {
-  await transaction
-    .insert(githubRepositories)
-    .values({
-      description: source.repository.description,
-      factsVerifiedAt: now,
-      firstObservedAt: now,
-      fullName: source.repository.fullName,
-      homepageUrl: source.repository.homepageUrl,
-      htmlUrl: `https://github.com/${source.repository.fullName}`,
-      id: repositoryId,
-      lastObservedAt: now,
-      ownerAvatarUrl: source.repository.avatarUrl,
-      ownerLogin: source.repository.ownerLogin,
-      ownerType: source.repository.ownerType,
-      topics: source.repository.topics,
-      visibility: source.repository.private ? "private" : "public",
-    })
-    .onConflictDoUpdate({
-      set: {
-        description: source.repository.description,
-        factsVerifiedAt: now,
-        fullName: source.repository.fullName,
-        homepageUrl: source.repository.homepageUrl,
-        htmlUrl: `https://github.com/${source.repository.fullName}`,
-        lastObservedAt: now,
-        ownerAvatarUrl: source.repository.avatarUrl,
-        ownerLogin: source.repository.ownerLogin,
-        ownerType: source.repository.ownerType,
-        topics: source.repository.topics,
-        visibility: source.repository.private ? "private" : "public",
-      },
-      target: githubRepositories.id,
-    });
-};
-
 export const completeGitHubCommitEnrichment = async (
   commit: ClaimedGitHubCommit,
-  source: GitHubActivityCommitSource,
-  now = new Date()
-): Promise<boolean> =>
-  await getDatabase().transaction(async (transaction) => {
-    const [locked] = await transaction
-      .select({ repositoryId: githubCommits.repositoryId })
-      .from(githubCommits)
-      .where(
-        and(
-          commitIdentity(commit),
-          eq(githubCommits.enrichmentState, "processing"),
-          eq(githubCommits.enrichmentLeaseToken, commit.leaseToken)
-        )
+  source: GitHubActivityCommitSource
+): Promise<boolean> => {
+  const fileFacts = githubWorkUnitFileFactsFrom(source.commit.files);
+  const [updated] = await getDatabase()
+    .update(githubCommits)
+    .set({
+      additions: source.commit.stats.additions,
+      authoredAt: new Date(source.authoredAt),
+      authorUserId: source.authorUserId,
+      changedFiles: source.commit.files.length,
+      committerAt: new Date(source.committerAt),
+      committerUserId: source.committerUserId,
+      committedAt: new Date(source.committerAt),
+      deletions: source.commit.stats.deletions,
+      enrichmentError: null,
+      enrichmentLeaseToken: null,
+      enrichmentLeaseUntil: null,
+      enrichmentState: "complete",
+      fileFacts,
+      fileFactsComplete: !source.commit.providerFileCapReached,
+      message: source.commit.message,
+      parentShas: source.commit.parents,
+      providerFileCapReached: source.commit.providerFileCapReached,
+    })
+    .where(
+      and(
+        commitIdentity(commit),
+        eq(githubCommits.enrichmentState, "processing"),
+        eq(githubCommits.enrichmentLeaseToken, commit.leaseToken)
       )
-      .for("update");
-    if (locked === undefined) {
-      return false;
-    }
-    await persistRepositoryEvidence(
-      transaction,
-      source,
-      commit.repositoryId,
-      now
-    );
-    const fileFacts = githubWorkUnitFileFactsFrom(source.commit.files);
-    await transaction
-      .update(githubCommits)
-      .set({
-        additions: source.commit.stats.additions,
-        authoredAt: new Date(source.authoredAt),
-        authorUserId: source.authorUserId,
-        changedFiles: source.commit.files.length,
-        committerAt: new Date(source.committerAt),
-        committerUserId: source.committerUserId,
-        committedAt: new Date(source.committerAt),
-        deletions: source.commit.stats.deletions,
-        enrichmentError: null,
-        enrichmentLeaseToken: null,
-        enrichmentLeaseUntil: null,
-        enrichmentState: "complete",
-        fileFacts,
-        fileFactsComplete: !source.commit.providerFileCapReached,
-        message: source.commit.message,
-        parentShas: source.commit.parents,
-        providerFileCapReached: source.commit.providerFileCapReached,
-        repository: source.repository.fullName,
-        repositoryOwnerAvatarUrl: source.repository.avatarUrl,
-        repositoryOwnerLogin: source.repository.ownerLogin,
-        repositoryOwnerType: source.repository.ownerType,
-        repositoryPrivate: source.repository.private,
-      })
-      .where(
-        and(
-          commitIdentity(commit),
-          eq(githubCommits.enrichmentState, "processing"),
-          eq(githubCommits.enrichmentLeaseToken, commit.leaseToken)
-        )
-      );
-    return true;
-  });
+    )
+    .returning({ sha: githubCommits.sha });
+  return updated !== undefined;
+};
 
 export const deferGitHubCommitEnrichment = async (
   commit: ClaimedGitHubCommit,
@@ -819,12 +751,16 @@ export const claimGitHubCommitsForPullRequestDiscovery = async (
         errorCode: githubCommits.pullRequestDiscoveryError,
         leaseUntil: githubCommits.pullRequestDiscoveryLeaseUntil,
         message: githubCommits.message,
-        repository: githubCommits.repository,
+        repository: githubRepositories.fullName,
         repositoryId: githubCommits.repositoryId,
         sha: githubCommits.sha,
         state: githubCommits.pullRequestDiscoveryState,
       })
       .from(githubCommits)
+      .innerJoin(
+        githubRepositories,
+        eq(githubRepositories.id, githubCommits.repositoryId)
+      )
       .where(
         and(
           inArray(githubCommits.author, [...activeAccounts]),
@@ -1141,6 +1077,7 @@ export const persistGitHubPullRequestSnapshot = async (
   account: TrackedGitHubAccount,
   pullRequest: GitHubPullRequest,
   options: {
+    existingOnly?: boolean;
     reconciliationLeaseUntil?: Date;
     refreshMembership?: boolean;
   } = {},
@@ -1154,6 +1091,7 @@ export const persistGitHubPullRequestSnapshot = async (
         pullRequest,
         {
           authority: "authoritative",
+          existingOnly: options.existingOnly,
           reconciliationLeaseUntil: options.reconciliationLeaseUntil,
           refreshMembership: options.refreshMembership === true,
         },
@@ -1353,14 +1291,27 @@ export const persistGitHubPullRequestMembership = async (
   await getDatabase().transaction(async (transaction) => {
     const [version] = await transaction
       .select({
+        baseRepositoryId: githubPullRequestVersions.baseRepositoryId,
+        baseSha: githubPullRequestVersions.baseSha,
         commitCount: githubPullRequestVersions.commitCount,
         headSha: githubPullRequestVersions.headSha,
+        headRepositoryId: githubPullRequestVersions.headRepositoryId,
         id: githubPullRequestVersions.id,
+        isCurrent: githubPullRequestVersions.isCurrent,
+        pullRequestNodeId: githubPullRequestVersions.pullRequestNodeId,
       })
       .from(githubPullRequestVersions)
       .where(eq(githubPullRequestVersions.id, stored.versionId))
       .for("update");
-    if (version === undefined) {
+    if (
+      version === undefined ||
+      !version.isCurrent ||
+      version.pullRequestNodeId !== stored.pullRequestNodeId ||
+      version.baseRepositoryId !== stored.baseRepositoryId ||
+      version.baseSha !== stored.baseSha ||
+      (version.headRepositoryId ?? version.baseRepositoryId) !==
+        stored.commitRepositoryId
+    ) {
       return false;
     }
     const completeMembershipIsValid =

--- a/src/lib/github-backfill-store.ts
+++ b/src/lib/github-backfill-store.ts
@@ -12,6 +12,7 @@ import {
 
 import { getDatabase } from "@/db/client";
 import {
+  githubAccountCheckpoints,
   githubCommits,
   githubPullRequests,
   githubPullRequestSignals,
@@ -30,6 +31,33 @@ import {
 } from "@/lib/github-activity-worker-store";
 import type { GitHubActivityWorkerScope } from "@/lib/github-activity-worker-store";
 import type { TrackedGitHubAccount } from "@/lib/github-commits-core";
+
+export const readGitHubPullRequestBackfillDigest = async (
+  account: TrackedGitHubAccount
+) => {
+  const [checkpoint] = await getDatabase()
+    .select({ digest: githubAccountCheckpoints.pullRequestBackfillDigest })
+    .from(githubAccountCheckpoints)
+    .where(eq(githubAccountCheckpoints.account, account))
+    .limit(1);
+  return checkpoint?.digest ?? null;
+};
+
+export const persistGitHubPullRequestBackfillDigest = async (input: {
+  account: TrackedGitHubAccount;
+  digest: string;
+}) => {
+  await getDatabase()
+    .insert(githubAccountCheckpoints)
+    .values({
+      account: input.account,
+      pullRequestBackfillDigest: input.digest,
+    })
+    .onConflictDoUpdate({
+      set: { pullRequestBackfillDigest: input.digest },
+      target: githubAccountCheckpoints.account,
+    });
+};
 
 export interface GitHubFactualWorkerBacklog {
   pending: {

--- a/src/lib/github-commits-core.ts
+++ b/src/lib/github-commits-core.ts
@@ -35,6 +35,13 @@ export interface GitHubRepositoryFacts extends GitHubRepository {
   visibility: "internal" | "private" | "public" | null;
 }
 
+/** Complete summary context available only from a repository inventory. */
+export interface GitHubRepositoryInventoryFacts extends GitHubRepositoryFacts {
+  description: string | null;
+  homepageUrl: string | null;
+  topics: readonly string[];
+}
+
 interface GitHubRefSignal {
   afterSha: string | null;
   beforeSha: string | null;
@@ -500,6 +507,61 @@ export const repositoryFactsFrom = (
     ...owner,
     pushedAt: pushedAt.value,
     visibility: visibility.visibility,
+  };
+};
+
+const inventoryTextFrom = (value: unknown, maximumLength: number) => {
+  if (value === null) {
+    return { valid: true, value: null } as const;
+  }
+  if (typeof value !== "string" || value.length > maximumLength) {
+    return { valid: false, value: null } as const;
+  }
+  return { valid: true, value: normalizedText(value, maximumLength) } as const;
+};
+
+const inventoryTopicsFrom = (value: unknown) => {
+  if (!Array.isArray(value) || value.length > 20) {
+    return null;
+  }
+  const topics = new Set<string>();
+  for (const topic of value) {
+    if (typeof topic !== "string" || topic.length > 50) {
+      return null;
+    }
+    const normalized = normalizedText(topic, 50);
+    if (normalized === null || normalized !== topic) {
+      return null;
+    }
+    topics.add(normalized);
+  }
+  return [...topics].toSorted();
+};
+
+/** Parses the complete repository shape returned by GitHub inventory APIs. */
+export const repositoryInventoryFactsFrom = (
+  value: unknown
+): GitHubRepositoryInventoryFacts | null => {
+  if (!isObject(value)) {
+    return null;
+  }
+  const repository = repositoryFactsFrom(value);
+  const description = inventoryTextFrom(value.description, 1000);
+  const homepageUrl = inventoryTextFrom(value.homepage, 2000);
+  const topics = inventoryTopicsFrom(value.topics);
+  if (
+    repository === null ||
+    !description.valid ||
+    !homepageUrl.valid ||
+    topics === null
+  ) {
+    return null;
+  }
+  return {
+    ...repository,
+    description: description.value,
+    homepageUrl: homepageUrl.value,
+    topics,
   };
 };
 

--- a/src/lib/github-commits-store.ts
+++ b/src/lib/github-commits-store.ts
@@ -44,7 +44,10 @@ import type {
   TrackedGitHubAccount,
 } from "@/lib/github-commits-core";
 import { persistPullRequestSnapshotInTransaction } from "@/lib/github-pull-request-store";
-import { upsertGitHubRepository } from "@/lib/github-repository-store";
+import {
+  upsertGitHubRepositories,
+  upsertGitHubRepository,
+} from "@/lib/github-repository-store";
 
 export class CheckpointConflictError extends Error {
   constructor() {
@@ -330,9 +333,11 @@ export const persistGitHubCommitReferences = async (input: {
         id: commit.repositoryId,
       });
     }
-    for (const repository of repositories.values()) {
-      await upsertGitHubRepository(transaction, repository, observedAt);
-    }
+    await upsertGitHubRepositories(
+      transaction,
+      [...repositories.values()],
+      observedAt
+    );
 
     let inserted = 0;
     const values = [...commits.values()];
@@ -351,7 +356,6 @@ export const persistGitHubCommitReferences = async (input: {
               committedAt: new Date(commit.committedAt),
               firstObservedAt: observedAt,
               message: commit.message,
-              repository: commit.repository,
               repositoryId: commit.repositoryId,
               sha: commit.sha,
             }))

--- a/src/lib/github-pull-request-backfill.ts
+++ b/src/lib/github-pull-request-backfill.ts
@@ -1,3 +1,5 @@
+import { createHash } from "node:crypto";
+
 import {
   ActivityProcessingError,
   fetchGitHubPullRequestMembershipWithToken,
@@ -21,12 +23,16 @@ import {
   GitHubResponseError,
   githubApiUrl,
 } from "@/lib/github-api";
+import {
+  persistGitHubPullRequestBackfillDigest,
+  readGitHubPullRequestBackfillDigest,
+} from "@/lib/github-backfill-store";
 import type {
   GitHubCommit,
-  GitHubPullRequest,
   TrackedGitHubAccount,
 } from "@/lib/github-commits-core";
 import {
+  commitShaFrom,
   repositoryFullNameFrom,
   repositoryIdFrom,
 } from "@/lib/github-commits-core";
@@ -37,6 +43,7 @@ const PULL_REQUEST_PROCESSING_BATCH_SIZE = 10;
 const DEADLINE_MARGIN_MS = 30_000;
 const AUTHORED_PULL_REQUEST_PAGE_SIZE = 100;
 const PERMANENT_RESOURCE_STATUSES = new Set([403, 404, 410, 422]);
+const PULL_REQUEST_BACKFILL_RECIPE = "authored-pull-requests-v1";
 
 const AUTHORED_PULL_REQUESTS_QUERY = `query AuthoredPullRequests($login: String!, $cursor: String, $pageSize: Int!) {
   user(login: $login) {
@@ -48,8 +55,12 @@ const AUTHORED_PULL_REQUESTS_QUERY = `query AuthoredPullRequests($login: String!
     ) {
       totalCount
       nodes {
+        baseRefOid
+        commits { totalCount }
+        headRefOid
         id
         number
+        state
         updatedAt
         url
         author { login }
@@ -92,8 +103,12 @@ const providerRetryFrom = (error: unknown) => {
 };
 
 export interface GitHubPullRequestBackfillCandidate extends GitHubActivityPullRequestReference {
+  baseSha: string;
+  commitCount: number;
+  headSha: string;
   nodeId: string;
   providerUpdatedAt: string;
+  state: "closed" | "merged" | "open";
 }
 
 export interface GitHubAuthoredPullRequestBackfillCandidateCollection {
@@ -101,6 +116,33 @@ export interface GitHubAuthoredPullRequestBackfillCandidateCollection {
   pullRequests: readonly GitHubPullRequestBackfillCandidate[];
   totalCount: number;
 }
+
+const pullRequestNodeIdFrom = (value: unknown) =>
+  typeof value === "string" &&
+  value.length > 0 &&
+  value.length <= 100 &&
+  !/\s/u.test(value)
+    ? value
+    : null;
+
+const pullRequestStateFrom = (
+  value: unknown
+): GitHubPullRequestBackfillCandidate["state"] | null => {
+  switch (value) {
+    case "CLOSED": {
+      return "closed";
+    }
+    case "MERGED": {
+      return "merged";
+    }
+    case "OPEN": {
+      return "open";
+    }
+    default: {
+      return null;
+    }
+  }
+};
 
 const authoredPullRequestCandidateFrom = (
   value: unknown,
@@ -116,17 +158,17 @@ const authoredPullRequestCandidateFrom = (
   const repositoryId = repositoryIdFrom(value.repository.databaseId);
   const repository = repositoryFullNameFrom(value.repository.nameWithOwner);
   const number = positiveIntegerFrom(value.number);
-  const nodeId =
-    typeof value.id === "string" &&
-    value.id.length > 0 &&
-    value.id.length <= 100 &&
-    !/\s/u.test(value.id)
-      ? value.id
-      : null;
+  const nodeId = pullRequestNodeIdFrom(value.id);
   const providerUpdatedAt =
     typeof value.updatedAt === "string"
       ? new Date(value.updatedAt)
       : new Date(Number.NaN);
+  const baseSha = commitShaFrom(value.baseRefOid);
+  const headSha = commitShaFrom(value.headRefOid);
+  const commitCount = isObject(value.commits)
+    ? nonNegativeIntegerFrom(value.commits.totalCount)
+    : null;
+  const state = pullRequestStateFrom(value.state);
   if (
     typeof value.author.login !== "string" ||
     value.author.login.toLowerCase() !== account ||
@@ -134,6 +176,10 @@ const authoredPullRequestCandidateFrom = (
     repository === null ||
     number === null ||
     nodeId === null ||
+    baseSha === null ||
+    headSha === null ||
+    commitCount === null ||
+    state === null ||
     Number.isNaN(providerUpdatedAt.getTime()) ||
     value.url !== `https://github.com/${repository}/pull/${String(number)}`
   ) {
@@ -141,44 +187,16 @@ const authoredPullRequestCandidateFrom = (
   }
   return {
     account,
+    baseSha,
+    commitCount,
+    headSha,
     nodeId,
     number,
     providerUpdatedAt: providerUpdatedAt.toISOString(),
     repository,
     repositoryId,
+    state,
   } satisfies GitHubPullRequestBackfillCandidate;
-};
-
-const samePullRequestIdentity = (
-  left: GitHubPullRequestBackfillCandidate,
-  right: GitHubPullRequestBackfillCandidate
-) =>
-  left.account === right.account &&
-  left.nodeId === right.nodeId &&
-  left.number === right.number &&
-  left.repository === right.repository &&
-  left.repositoryId === right.repositoryId;
-
-const mergeGitHubPullRequestBackfillCandidates = (
-  candidates: Map<string, GitHubPullRequestBackfillCandidate>,
-  incoming: readonly GitHubPullRequestBackfillCandidate[]
-) => {
-  for (const candidate of incoming) {
-    const existing = candidates.get(candidate.nodeId);
-    if (
-      existing !== undefined &&
-      !samePullRequestIdentity(existing, candidate)
-    ) {
-      throw new TypeError("GitHub returned conflicting pull requests.");
-    }
-    if (
-      existing === undefined ||
-      candidate.providerUpdatedAt > existing.providerUpdatedAt
-    ) {
-      candidates.set(candidate.nodeId, candidate);
-    }
-  }
-  return candidates;
 };
 
 /**
@@ -202,6 +220,7 @@ export const collectGitHubAuthoredPullRequestBackfillCandidates =
       );
     }
     const candidates = new Map<string, GitHubPullRequestBackfillCandidate>();
+    const observedNodeIds = new Set<string>();
     const visitedCursors = new Set<string>();
     let cursor: string | null = null;
     let expectedTotal: number | null = null;
@@ -251,12 +270,17 @@ export const collectGitHubAuthoredPullRequestBackfillCandidates =
         );
       }
       expectedTotal ??= totalCount;
-      const previousSize = candidates.size;
       const pageCandidates = nodes.map((node) =>
         authoredPullRequestCandidateFrom(node, input.account)
       );
       let reachedCutoff = false;
       for (const candidate of pageCandidates) {
+        if (observedNodeIds.has(candidate.nodeId)) {
+          throw new TypeError(
+            "GitHub returned invalid authored pull request pagination."
+          );
+        }
+        observedNodeIds.add(candidate.nodeId);
         const updatedAt = new Date(candidate.providerUpdatedAt).getTime();
         if (updatedAt > previousUpdatedAt) {
           throw new TypeError(
@@ -268,7 +292,7 @@ export const collectGitHubAuthoredPullRequestBackfillCandidates =
           reachedCutoff = true;
           continue;
         }
-        mergeGitHubPullRequestBackfillCandidates(candidates, [candidate]);
+        candidates.set(candidate.nodeId, candidate);
       }
       observedNodes += nodes.length;
       pages += 1;
@@ -300,7 +324,6 @@ export const collectGitHubAuthoredPullRequestBackfillCandidates =
       const nextCursor = pageInfo.endCursor;
       if (
         nodes.length === 0 ||
-        candidates.size === previousSize ||
         typeof nextCursor !== "string" ||
         nextCursor.length === 0 ||
         nextCursor.length > 2048 ||
@@ -330,6 +353,7 @@ export interface GitHubPullRequestBackfillResult {
   memberships: number;
   pullRequests: number;
   repositories: number;
+  reusedPullRequests: number;
   retryAt: Date | null;
   scannedPullRequests: number;
   selectedAuthoredPullRequests: number;
@@ -340,6 +364,7 @@ export interface GitHubPullRequestBackfillResult {
 
 interface PreparedPullRequest {
   commits: readonly GitHubCommit[];
+  inWindow: boolean;
   membership: GitHubActivityPullRequestMembershipSource;
   snapshot: GitHubActivityPullRequestSnapshot;
 }
@@ -353,6 +378,7 @@ const emptyResult = (): GitHubPullRequestBackfillResult => ({
   memberships: 0,
   pullRequests: 0,
   repositories: 0,
+  reusedPullRequests: 0,
   retryAt: null,
   scannedPullRequests: 0,
   selectedAuthoredPullRequests: 0,
@@ -394,7 +420,6 @@ const withinInclusiveWindow = (
 export const githubPullRequestBelongsInBackfillWindow = (input: {
   account: TrackedGitHubAccount;
   commits: readonly GitHubCommit[];
-  pullRequest: Pick<GitHubPullRequest, "authorAccount" | "mergedAt">;
   sinceAt: Date;
   untilAt: Date;
 }) =>
@@ -471,15 +496,15 @@ const persistPreparedPullRequests = async (
     const stored = await persistGitHubPullRequestSnapshot(
       account,
       item.snapshot.pullRequest,
-      { refreshMembership: true }
+      { existingOnly: !item.inWindow, refreshMembership: true }
     );
     if (stored === null) {
       result.skippedPullRequests += 1;
       continue;
     }
-    const commits = await persistGitHubCommitReferences({
-      commits: item.commits,
-    });
+    const commits = item.inWindow
+      ? await persistGitHubCommitReferences({ commits: item.commits })
+      : { duplicates: 0, inserted: 0 };
     const membership = await persistGitHubPullRequestBackfillMembership({
       commitShas: item.membership.commitShas,
       headSha: item.snapshot.pullRequest.headSha,
@@ -492,12 +517,16 @@ const persistPreparedPullRequests = async (
         "GitHub pull request membership was not persisted completely."
       );
     }
-    result.commits += commits.inserted;
-    result.duplicateCommits += commits.duplicates;
     if (membership.refreshed) {
       result.memberships += 1;
     }
-    result.pullRequests += 1;
+    if (item.inWindow) {
+      result.commits += commits.inserted;
+      result.duplicateCommits += commits.duplicates;
+      result.pullRequests += 1;
+    } else {
+      result.skippedPullRequests += 1;
+    }
   }
 };
 
@@ -526,14 +555,33 @@ const preparePullRequest = async (input: {
   sinceAt: Date;
   token: string;
   untilAt: Date;
-}): Promise<PreparedPullRequest | null> => {
+}): Promise<PreparedPullRequest> => {
   const snapshot = await fetchGitHubPullRequestRestSnapshotWithToken(
     input.candidate,
     input.token,
     { deadlineAt: input.deadlineAt }
   );
+  const { pullRequest } = snapshot;
+  const state: GitHubPullRequestBackfillCandidate["state"] = pullRequest.merged
+    ? "merged"
+    : pullRequest.state;
+  if (
+    pullRequest.baseSha !== input.candidate.baseSha ||
+    pullRequest.commitCount !== input.candidate.commitCount ||
+    pullRequest.headSha !== input.candidate.headSha ||
+    pullRequest.nodeId !== input.candidate.nodeId ||
+    pullRequest.number !== input.candidate.number ||
+    pullRequest.providerUpdatedAt !== input.candidate.providerUpdatedAt ||
+    pullRequest.repository.fullName !== input.candidate.repository ||
+    pullRequest.repository.id !== input.candidate.repositoryId ||
+    state !== input.candidate.state
+  ) {
+    throw new GitHubGraphQlResponseError("partial_response", {
+      retryable: true,
+    });
+  }
   const commitRepository =
-    snapshot.pullRequest.headRepository ?? snapshot.pullRequest.baseRepository;
+    pullRequest.headRepository ?? pullRequest.baseRepository;
   const membership = await fetchGitHubPullRequestMembershipWithToken(
     input.candidate,
     snapshot.expectedCommitCount,
@@ -541,8 +589,8 @@ const preparePullRequest = async (input: {
     {
       commitRepository,
       deadlineAt: input.deadlineAt,
-      expectedBaseSha: snapshot.pullRequest.baseSha,
-      expectedHeadSha: snapshot.pullRequest.headSha,
+      expectedBaseSha: pullRequest.baseSha,
+      expectedHeadSha: pullRequest.headSha,
     }
   );
   if (!membership.membershipComplete) {
@@ -556,15 +604,17 @@ const preparePullRequest = async (input: {
       commit.author === input.account &&
       withinInclusiveWindow(commit, input.sinceAt, input.untilAt)
   );
-  return githubPullRequestBelongsInBackfillWindow({
-    account: input.account,
+  return {
     commits,
-    pullRequest: snapshot.pullRequest,
-    sinceAt: input.sinceAt,
-    untilAt: input.untilAt,
-  })
-    ? { commits, membership, snapshot }
-    : null;
+    inWindow: githubPullRequestBelongsInBackfillWindow({
+      account: input.account,
+      commits,
+      sinceAt: input.sinceAt,
+      untilAt: input.untilAt,
+    }),
+    membership,
+    snapshot,
+  };
 };
 
 const stop = (
@@ -604,12 +654,45 @@ const comparePullRequestCandidates = (
   return left.nodeId < right.nodeId ? -1 : left.nodeId > right.nodeId ? 1 : 0;
 };
 
+export const githubPullRequestBackfillDigestFrom = (input: {
+  account: TrackedGitHubAccount;
+  candidates: readonly GitHubPullRequestBackfillCandidate[];
+  repositoryId: string | null;
+  sinceAt: Date;
+  untilAt: Date;
+}) =>
+  createHash("sha256")
+    .update(
+      JSON.stringify({
+        account: input.account,
+        candidates: input.candidates
+          .toSorted(comparePullRequestCandidates)
+          .map((candidate) => [
+            candidate.nodeId,
+            candidate.repositoryId,
+            candidate.repository,
+            candidate.number,
+            candidate.providerUpdatedAt,
+            candidate.baseSha,
+            candidate.headSha,
+            candidate.commitCount,
+            candidate.state,
+          ]),
+        recipe: PULL_REQUEST_BACKFILL_RECIPE,
+        repositoryId: input.repositoryId,
+        sinceAt: input.sinceAt.toISOString(),
+        untilAt: input.untilAt.toISOString(),
+      })
+    )
+    .digest("hex");
+
 const processPullRequestCandidates = async (
   candidates: readonly GitHubPullRequestBackfillCandidate[],
   input: {
     account: TrackedGitHubAccount;
     deadlineAt: number;
     onProgress: GitHubPullRequestBackfillProgressReporter;
+    persistPrepared: typeof persistPreparedPullRequestsWithGaps;
     sinceAt: Date;
     token: string;
     untilAt: Date;
@@ -641,11 +724,7 @@ const processPullRequestCandidates = async (
           token: input.token,
           untilAt: input.untilAt,
         });
-        if (value === null) {
-          result.skippedPullRequests += 1;
-        } else {
-          prepared.push(value);
-        }
+        prepared.push(value);
       } catch (error) {
         if (isDeadlineError(error)) {
           interrupted = { reason: "deadline", retryAt: null };
@@ -670,13 +749,15 @@ const processPullRequestCandidates = async (
     const unmerged = prepared.filter(
       ({ snapshot }) => !snapshot.pullRequest.merged
     );
-    await persistPreparedPullRequestsWithGaps(unmerged, input.account, result);
+    if (unmerged.length > 0) {
+      await input.persistPrepared(unmerged, input.account, result);
+    }
     const merged = prepared.filter(
       ({ snapshot }) => snapshot.pullRequest.merged
     );
     if (merged.length > 0) {
       try {
-        await persistPreparedPullRequestsWithGaps(
+        await input.persistPrepared(
           await withResolvedMergeCommits(merged, input.token, input.deadlineAt),
           input.account,
           result
@@ -688,7 +769,7 @@ const processPullRequestCandidates = async (
         if (pullRequestEvidenceIsUnavailable(error)) {
           for (const item of merged) {
             try {
-              await persistPreparedPullRequestsWithGaps(
+              await input.persistPrepared(
                 await withResolvedMergeCommits(
                   [item],
                   input.token,
@@ -734,15 +815,30 @@ const processPullRequestCandidates = async (
 };
 
 /** Discovers only authored PRs; current-head commits find associated PRs later. */
-export const backfillGitHubPullRequests = async (input: {
-  account: TrackedGitHubAccount;
-  deadlineAt: number;
-  onProgress?: GitHubPullRequestBackfillProgressReporter;
-  repositoryId: string | null;
-  sinceAt: Date;
-  token: string;
-  untilAt: Date;
-}): Promise<GitHubPullRequestBackfillResult> => {
+interface GitHubPullRequestBackfillDependencies {
+  persistDigest: typeof persistGitHubPullRequestBackfillDigest;
+  persistPrepared: typeof persistPreparedPullRequestsWithGaps;
+  readDigest: typeof readGitHubPullRequestBackfillDigest;
+}
+
+const productionBackfillDependencies: GitHubPullRequestBackfillDependencies = {
+  persistDigest: persistGitHubPullRequestBackfillDigest,
+  persistPrepared: persistPreparedPullRequestsWithGaps,
+  readDigest: readGitHubPullRequestBackfillDigest,
+};
+
+export const backfillGitHubPullRequests = async (
+  input: {
+    account: TrackedGitHubAccount;
+    deadlineAt: number;
+    onProgress?: GitHubPullRequestBackfillProgressReporter;
+    repositoryId: string | null;
+    sinceAt: Date;
+    token: string;
+    untilAt: Date;
+  },
+  dependencies: GitHubPullRequestBackfillDependencies = productionBackfillDependencies
+): Promise<GitHubPullRequestBackfillResult> => {
   if (
     !Number.isFinite(input.deadlineAt) ||
     Number.isNaN(input.sinceAt.getTime()) ||
@@ -785,13 +881,28 @@ export const backfillGitHubPullRequests = async (input: {
     candidates.map((candidate) => candidate.repositoryId)
   ).size;
   onProgress({ ...result });
+  if (candidates.length === 0) {
+    return result;
+  }
+  const digest = githubPullRequestBackfillDigestFrom({
+    ...input,
+    candidates,
+  });
+  if ((await dependencies.readDigest(input.account)) === digest) {
+    result.reusedPullRequests = candidates.length;
+    onProgress({ ...result });
+    return result;
+  }
   const interrupted = await processPullRequestCandidates(
     candidates,
-    { ...input, onProgress },
+    { ...input, onProgress, persistPrepared: dependencies.persistPrepared },
     result
   );
   if (interrupted !== null) {
     return stop(result, interrupted.reason, interrupted.retryAt);
+  }
+  if (result.unavailablePullRequests === 0) {
+    await dependencies.persistDigest({ account: input.account, digest });
   }
   return result;
 };

--- a/src/lib/github-pull-request-store.ts
+++ b/src/lib/github-pull-request-store.ts
@@ -9,9 +9,10 @@ import {
 import { githubPullRequestSnapshotDisposition } from "@/lib/github-activity-worker-core";
 import type {
   GitHubPullRequest,
+  GitHubRepository,
   TrackedGitHubAccount,
 } from "@/lib/github-commits-core";
-import { upsertGitHubRepository } from "@/lib/github-repository-store";
+import { upsertGitHubRepositories } from "@/lib/github-repository-store";
 
 type DatabaseTransaction = Parameters<
   Parameters<ReturnType<typeof getDatabase>["transaction"]>[0]
@@ -21,6 +22,7 @@ const RECONCILIATION_LEASE_MS = 5 * 60 * 1000;
 
 export interface StoredPullRequestSnapshot {
   baseRepositoryId: string;
+  baseSha: string;
   commitRepositoryId: string;
   diffRefreshRequired: boolean;
   expectedChangedFiles: number | null;
@@ -33,6 +35,7 @@ export interface StoredPullRequestSnapshot {
 
 interface PersistPullRequestSnapshotOptions {
   authority: "authoritative" | "observed";
+  existingOnly?: boolean;
   reconciliationLeaseUntil?: Date;
   refreshMembership?: boolean;
 }
@@ -98,18 +101,21 @@ export const persistPullRequestSnapshotInTransaction = async (
   if (disposition === "stale") {
     return null;
   }
+  if (existing === undefined && options.existingOnly === true) {
+    return null;
+  }
 
-  await upsertGitHubRepository(transaction, pullRequest.repository, now);
-  if (pullRequest.baseRepository.id !== pullRequest.repository.id) {
-    await upsertGitHubRepository(transaction, pullRequest.baseRepository, now);
+  const repositories = new Map<string, GitHubRepository>();
+  for (const repository of [
+    pullRequest.repository,
+    pullRequest.baseRepository,
+    pullRequest.headRepository,
+  ]) {
+    if (repository !== null) {
+      repositories.set(repository.id, repository);
+    }
   }
-  if (
-    pullRequest.headRepository !== null &&
-    pullRequest.headRepository.id !== pullRequest.repository.id &&
-    pullRequest.headRepository.id !== pullRequest.baseRepository.id
-  ) {
-    await upsertGitHubRepository(transaction, pullRequest.headRepository, now);
-  }
+  await upsertGitHubRepositories(transaction, [...repositories.values()], now);
 
   const observedState = githubPullRequestStateFrom(pullRequest);
   const terminalAt = terminalAtFrom(pullRequest, observedState);
@@ -390,11 +396,18 @@ export const persistPullRequestSnapshotInTransaction = async (
 
   const expectedMembershipCount =
     pullRequest.commitCount ?? version?.commitCount ?? null;
+  const commitRepositoryId =
+    pullRequest.headRepository?.id ??
+    existing?.headRepositoryId ??
+    pullRequest.repository.id;
   const storedMembershipCompleteFlag = version?.membershipComplete ?? false;
   const storedMembershipComplete =
     storedMembershipCompleteFlag &&
     expectedMembershipCount !== null &&
     version.membershipCount === expectedMembershipCount &&
+    version.baseSha === pullRequest.baseSha &&
+    (version.headRepositoryId ?? pullRequest.repository.id) ===
+      commitRepositoryId &&
     (expectedMembershipCount === 0
       ? version.membershipHeadSha === null
       : version.membershipHeadSha === pullRequest.headSha);
@@ -449,11 +462,9 @@ export const persistPullRequestSnapshotInTransaction = async (
   }
 
   return {
-    baseRepositoryId: pullRequest.repository.id,
-    commitRepositoryId:
-      pullRequest.headRepository?.id ??
-      existing?.headRepositoryId ??
-      pullRequest.repository.id,
+    baseRepositoryId: pullRequest.baseRepository.id,
+    baseSha: pullRequest.baseSha,
+    commitRepositoryId,
     diffRefreshRequired,
     expectedChangedFiles,
     membershipRefreshRequired,

--- a/src/lib/github-reconciliation.ts
+++ b/src/lib/github-reconciliation.ts
@@ -4,8 +4,14 @@ import {
   githubApiUrl,
   nextGitHubPage,
 } from "@/lib/github-api";
-import { commitShaFrom, repositoryFactsFrom } from "@/lib/github-commits-core";
-import type { GitHubRepositoryFacts } from "@/lib/github-commits-core";
+import {
+  commitShaFrom,
+  repositoryInventoryFactsFrom,
+} from "@/lib/github-commits-core";
+import type {
+  GitHubRepositoryFacts,
+  GitHubRepositoryInventoryFacts,
+} from "@/lib/github-commits-core";
 import type { GitHubRepositoryRefSnapshot } from "@/lib/github-commits-store";
 
 const GITHUB_PAGE_SIZE = 100;
@@ -104,7 +110,7 @@ export const collectAccessibleGitHubRepositories = async (
       token,
       options
     );
-    const facts = repositoryFactsFrom(payload);
+    const facts = repositoryInventoryFactsFrom(payload);
     if (facts === null) {
       throw new TypeError("GitHub returned an invalid repository response.");
     }
@@ -118,9 +124,9 @@ export const collectAccessibleGitHubRepositories = async (
   url.searchParams.set("sort", "full_name");
   url.searchParams.set("visibility", "all");
   const values = await fetchRepositoryInventory(url, token, options);
-  const repositories = new Map<string, GitHubRepositoryFacts>();
+  const repositories = new Map<string, GitHubRepositoryInventoryFacts>();
   for (const value of values) {
-    const repository = repositoryFactsFrom(value);
+    const repository = repositoryInventoryFactsFrom(value);
     if (repository === null) {
       throw new TypeError("GitHub returned an invalid repository response.");
     }

--- a/src/lib/github-ref-membership-store.ts
+++ b/src/lib/github-ref-membership-store.ts
@@ -473,7 +473,6 @@ export const completeGitHubRefRepair = async (
                 committedAt: new Date(commit.committedAt),
                 firstObservedAt: repair.observedAt,
                 message: commit.message,
-                repository: commit.repository,
                 repositoryId: commit.repositoryId,
                 sha: commit.sha,
               }))

--- a/src/lib/github-repository-inventory.ts
+++ b/src/lib/github-repository-inventory.ts
@@ -19,11 +19,11 @@ import {
 } from "@/db/schema";
 import { TRACKED_GITHUB_USER_IDS } from "@/lib/github-commits-core";
 import type {
-  GitHubRepositoryFacts,
+  GitHubRepositoryInventoryFacts,
   TrackedGitHubAccount,
 } from "@/lib/github-commits-core";
 import { collectAccessibleGitHubRepositories } from "@/lib/github-reconciliation";
-import { upsertGitHubRepositories } from "@/lib/github-repository-store";
+import { upsertGitHubRepositoryInventory } from "@/lib/github-repository-store";
 
 const INVENTORY_REFRESH_INTERVAL_MS = 24 * 60 * 60 * 1000;
 const INVENTORY_RETRY_INTERVAL_MS = 15 * 60 * 1000;
@@ -124,9 +124,9 @@ const releaseGitHubRepositoryInventoryRefresh = async (
 
 const publishGitHubRepositoryInventory = async (
   claim: GitHubRepositoryInventoryClaim,
-  repositories: readonly GitHubRepositoryFacts[]
+  repositories: readonly GitHubRepositoryInventoryFacts[]
 ) => {
-  const repositoriesById = new Map<string, GitHubRepositoryFacts>();
+  const repositoriesById = new Map<string, GitHubRepositoryInventoryFacts>();
   for (const repository of repositories) {
     const existing = repositoriesById.get(repository.id);
     if (existing !== undefined && existing.fullName !== repository.fullName) {
@@ -173,7 +173,7 @@ const publishGitHubRepositoryInventory = async (
     }
 
     const currentRepositories = [...repositoriesById.values()];
-    await upsertGitHubRepositories(
+    await upsertGitHubRepositoryInventory(
       transaction,
       currentRepositories,
       claim.startedAt
@@ -233,7 +233,7 @@ const publishGitHubRepositoryInventory = async (
 
 const readCurrentGitHubRepositoryInventory = async (
   account: TrackedGitHubAccount
-): Promise<readonly GitHubRepositoryFacts[] | null> => {
+): Promise<readonly GitHubRepositoryInventoryFacts[] | null> => {
   const accountUserId = TRACKED_GITHUB_USER_IDS[account];
   return await getDatabase().transaction(
     async (transaction) => {
@@ -257,14 +257,18 @@ const readCurrentGitHubRepositoryInventory = async (
       const rows = await transaction
         .select({
           defaultBranch: githubRepositories.defaultBranch,
+          description: githubRepositories.description,
           fullName: githubRepositories.fullName,
+          homepageUrl: githubRepositories.homepageUrl,
           htmlUrl: githubRepositories.htmlUrl,
           id: githubRepositories.id,
+          inventoryVerifiedAt: githubRepositories.inventoryVerifiedAt,
           ownerAvatarUrl: githubRepositories.ownerAvatarUrl,
           ownerId: githubRepositories.ownerId,
           ownerLogin: githubRepositories.ownerLogin,
           ownerType: githubRepositories.ownerType,
           pushedAt: githubRepositories.pushedAt,
+          topics: githubRepositories.topics,
           visibility: githubRepositories.visibility,
         })
         .from(githubAccountRepositoryCatalogs)
@@ -286,7 +290,11 @@ const readCurrentGitHubRepositoryInventory = async (
           )
         );
 
-      return rows.map((row) => {
+      const repositories: GitHubRepositoryInventoryFacts[] = [];
+      for (const row of rows) {
+        if (row.inventoryVerifiedAt === null || row.topics === null) {
+          return null;
+        }
         if (
           row.ownerLogin === null ||
           (row.ownerType !== null &&
@@ -301,9 +309,11 @@ const readCurrentGitHubRepositoryInventory = async (
             "The current GitHub repository inventory is inconsistent."
           );
         }
-        return {
+        repositories.push({
           defaultBranch: row.defaultBranch,
+          description: row.description,
           fullName: row.fullName,
+          homepageUrl: row.homepageUrl,
           htmlUrl: row.htmlUrl,
           id: row.id,
           ownerAvatarUrl: row.ownerAvatarUrl,
@@ -311,9 +321,11 @@ const readCurrentGitHubRepositoryInventory = async (
           ownerLogin: row.ownerLogin,
           ownerType: row.ownerType,
           pushedAt: row.pushedAt?.toISOString() ?? null,
+          topics: row.topics,
           visibility: row.visibility,
-        };
-      });
+        });
+      }
+      return repositories;
     },
     { accessMode: "read only", isolationLevel: "repeatable read" }
   );
@@ -329,7 +341,7 @@ export const loadGitHubRepositoryInventory = async (input: {
   forceRefresh?: boolean;
   now?: Date;
   token: string;
-}): Promise<readonly GitHubRepositoryFacts[]> => {
+}): Promise<readonly GitHubRepositoryInventoryFacts[]> => {
   const now = validatedInventoryTime(input.now ?? new Date());
   const claim = await claimGitHubRepositoryInventoryRefresh({
     account: input.account,

--- a/src/lib/github-repository-store.ts
+++ b/src/lib/github-repository-store.ts
@@ -1,41 +1,287 @@
-import { lte, sql } from "drizzle-orm";
+import { and, eq, inArray, isNotNull, isNull, lte, or, sql } from "drizzle-orm";
 
 import type { getDatabase } from "@/db/client";
-import { githubRepositories } from "@/db/schema";
+import { githubRepositories, githubWorkUnits } from "@/db/schema";
 import type {
   GitHubRepository,
   GitHubRepositoryFacts,
+  GitHubRepositoryInventoryFacts,
 } from "@/lib/github-commits-core";
 
 type DatabaseTransaction = Parameters<
   Parameters<ReturnType<typeof getDatabase>["transaction"]>[0]
 >[0];
 
-const githubRepositoryValuesFrom = (
+const hasRepositoryFacts = (
+  repository: GitHubRepository
+): repository is GitHubRepositoryFacts => "ownerLogin" in repository;
+
+const hasInventoryFacts = (
+  repository: GitHubRepository
+): repository is GitHubRepositoryInventoryFacts => "topics" in repository;
+
+const githubRepositoryFactValuesFrom = (
   repository: GitHubRepository,
   observedAt: Date
 ) => {
-  const facts =
-    "ownerLogin" in repository ? (repository as GitHubRepositoryFacts) : null;
+  if (!hasRepositoryFacts(repository)) {
+    return {
+      defaultBranch: null,
+      factsVerifiedAt: null,
+      htmlUrl: null,
+      ownerAvatarUrl: null,
+      ownerId: null,
+      ownerLogin: null,
+      ownerType: null,
+      pushedAt: null,
+      visibility: null,
+    };
+  }
   return {
-    defaultBranch: facts?.defaultBranch ?? null,
-    factsVerifiedAt:
-      facts === null || facts.visibility === null ? null : observedAt,
-    firstObservedAt: observedAt,
-    fullName: repository.fullName,
-    htmlUrl: facts?.htmlUrl ?? null,
-    id: repository.id,
-    lastObservedAt: observedAt,
-    ownerAvatarUrl: facts?.ownerAvatarUrl ?? null,
-    ownerId: facts?.ownerId ?? null,
-    ownerLogin: facts?.ownerLogin ?? null,
-    ownerType: facts?.ownerType ?? null,
+    defaultBranch: repository.defaultBranch,
+    factsVerifiedAt: repository.visibility === null ? null : observedAt,
+    htmlUrl: repository.htmlUrl,
+    ownerAvatarUrl: repository.ownerAvatarUrl,
+    ownerId: repository.ownerId,
+    ownerLogin: repository.ownerLogin,
+    ownerType: repository.ownerType,
     pushedAt:
-      facts === null || facts.pushedAt === null
-        ? null
-        : new Date(facts.pushedAt),
-    visibility: facts?.visibility ?? null,
+      repository.pushedAt === null ? null : new Date(repository.pushedAt),
+    visibility: repository.visibility,
   };
+};
+
+const githubRepositoryInventoryValuesFrom = (
+  repository: GitHubRepository,
+  observedAt: Date
+) =>
+  hasInventoryFacts(repository)
+    ? {
+        description: repository.description,
+        homepageUrl: repository.homepageUrl,
+        inventoryVerifiedAt: observedAt,
+        topics: repository.topics,
+      }
+    : {
+        description: null,
+        homepageUrl: null,
+        inventoryVerifiedAt: null,
+        topics: null,
+      };
+
+const githubRepositoryValuesFrom = (
+  repository: GitHubRepository,
+  observedAt: Date
+) => ({
+  firstObservedAt: observedAt,
+  fullName: repository.fullName,
+  id: repository.id,
+  lastObservedAt: observedAt,
+  ...githubRepositoryFactValuesFrom(repository, observedAt),
+  ...githubRepositoryInventoryValuesFrom(repository, observedAt),
+});
+
+const normalizedOptionalText = (value: string | null) => {
+  const normalized = value?.trim() ?? "";
+  return normalized.length === 0 ? null : normalized;
+};
+
+const normalizedTopics = (topics: readonly string[] | null) =>
+  JSON.stringify(
+    [
+      ...new Set((topics ?? []).map((topic) => topic.trim()).filter(Boolean)),
+    ].toSorted()
+  );
+
+const summaryContextChanged = (
+  existing: {
+    description: string | null;
+    fullName: string;
+    homepageUrl: string | null;
+    inventoryVerifiedAt: Date | null;
+    lastObservedAt: Date;
+    topics: readonly string[] | null;
+  },
+  repository: GitHubRepository,
+  observedAt: Date,
+  includeMetadata: boolean
+) => {
+  const identityChanged =
+    existing.lastObservedAt <= observedAt &&
+    existing.fullName !== repository.fullName;
+  const metadataChanged =
+    includeMetadata &&
+    hasInventoryFacts(repository) &&
+    (existing.inventoryVerifiedAt === null ||
+      existing.inventoryVerifiedAt <= observedAt) &&
+    (normalizedOptionalText(existing.description) !==
+      normalizedOptionalText(repository.description) ||
+      normalizedOptionalText(existing.homepageUrl) !==
+        normalizedOptionalText(repository.homepageUrl) ||
+      normalizedTopics(existing.topics) !==
+        normalizedTopics(repository.topics));
+  return identityChanged || metadataChanged;
+};
+
+const changedSummaryContextRepositoryIds = async (
+  transaction: DatabaseTransaction,
+  repositories: readonly GitHubRepository[],
+  observedAt: Date,
+  includeMetadata: boolean
+) => {
+  const repositoryIds = [...new Set(repositories.map(({ id }) => id))];
+  const existingRows = await transaction
+    .select({
+      description: githubRepositories.description,
+      fullName: githubRepositories.fullName,
+      homepageUrl: githubRepositories.homepageUrl,
+      id: githubRepositories.id,
+      inventoryVerifiedAt: githubRepositories.inventoryVerifiedAt,
+      lastObservedAt: githubRepositories.lastObservedAt,
+      topics: githubRepositories.topics,
+    })
+    .from(githubRepositories)
+    .where(inArray(githubRepositories.id, repositoryIds))
+    .orderBy(githubRepositories.id)
+    .for("update");
+  const existingById = new Map(existingRows.map((row) => [row.id, row]));
+  return [
+    ...new Set(
+      repositories.flatMap((repository) => {
+        const existing = existingById.get(repository.id);
+        return existing !== undefined &&
+          summaryContextChanged(
+            existing,
+            repository,
+            observedAt,
+            includeMetadata
+          )
+          ? [repository.id]
+          : [];
+      })
+    ),
+  ];
+};
+
+const invalidateChangedRepositorySummaries = async (
+  transaction: DatabaseTransaction,
+  repositoryIds: readonly string[]
+) => {
+  if (repositoryIds.length === 0) {
+    return;
+  }
+  await transaction
+    .update(githubWorkUnits)
+    .set({ summaryInputDigest: null })
+    .where(
+      and(
+        inArray(githubWorkUnits.repositoryId, repositoryIds),
+        eq(githubWorkUnits.visibility, "public"),
+        isNotNull(githubWorkUnits.summaryInputDigest)
+      )
+    );
+};
+
+const upsertGitHubRepositoryIdentity = async (
+  transaction: DatabaseTransaction,
+  repositories: readonly GitHubRepository[],
+  observedAt: Date
+) => {
+  await transaction
+    .insert(githubRepositories)
+    .values(
+      repositories.map((repository) =>
+        githubRepositoryValuesFrom(repository, observedAt)
+      )
+    )
+    .onConflictDoUpdate({
+      set: {
+        fullName: sql`excluded.full_name`,
+        lastObservedAt: sql`excluded.last_observed_at`,
+      },
+      setWhere: lte(githubRepositories.lastObservedAt, observedAt),
+      target: githubRepositories.id,
+    });
+};
+
+const upsertGitHubRepositoryFacts = async (
+  transaction: DatabaseTransaction,
+  repositories: readonly GitHubRepository[],
+  observedAt: Date,
+  authoritative: boolean
+) => {
+  const verifiedFacts = repositories.filter(
+    (repository): repository is GitHubRepositoryFacts =>
+      hasRepositoryFacts(repository) && repository.visibility !== null
+  );
+  if (verifiedFacts.length === 0) {
+    return;
+  }
+  await transaction
+    .insert(githubRepositories)
+    .values(
+      verifiedFacts.map((repository) =>
+        githubRepositoryValuesFrom(repository, observedAt)
+      )
+    )
+    .onConflictDoUpdate({
+      set: {
+        defaultBranch: authoritative
+          ? sql`excluded.default_branch`
+          : sql`coalesce(excluded.default_branch, ${githubRepositories.defaultBranch})`,
+        factsVerifiedAt: sql`excluded.facts_verified_at`,
+        htmlUrl: authoritative
+          ? sql`excluded.html_url`
+          : sql`coalesce(excluded.html_url, ${githubRepositories.htmlUrl})`,
+        ownerAvatarUrl: authoritative
+          ? sql`excluded.owner_avatar_url`
+          : sql`coalesce(excluded.owner_avatar_url, ${githubRepositories.ownerAvatarUrl})`,
+        ownerId: authoritative
+          ? sql`excluded.owner_id`
+          : sql`coalesce(excluded.owner_id, ${githubRepositories.ownerId})`,
+        ownerLogin: authoritative
+          ? sql`excluded.owner_login`
+          : sql`coalesce(excluded.owner_login, ${githubRepositories.ownerLogin})`,
+        ownerType: authoritative
+          ? sql`excluded.owner_type`
+          : sql`coalesce(excluded.owner_type, ${githubRepositories.ownerType})`,
+        pushedAt: authoritative
+          ? sql`excluded.pushed_at`
+          : sql`coalesce(excluded.pushed_at, ${githubRepositories.pushedAt})`,
+        visibility: sql`excluded.visibility`,
+      },
+      setWhere: or(
+        isNull(githubRepositories.factsVerifiedAt),
+        lte(githubRepositories.factsVerifiedAt, observedAt)
+      ),
+      target: githubRepositories.id,
+    });
+};
+
+const upsertGitHubRepositoryInventoryMetadata = async (
+  transaction: DatabaseTransaction,
+  repositories: readonly GitHubRepositoryInventoryFacts[],
+  observedAt: Date
+) => {
+  const values = repositories.map((repository) =>
+    githubRepositoryValuesFrom(repository, observedAt)
+  );
+  await transaction
+    .insert(githubRepositories)
+    .values(values)
+    .onConflictDoUpdate({
+      set: {
+        description: sql`excluded.description`,
+        homepageUrl: sql`excluded.homepage_url`,
+        inventoryVerifiedAt: sql`excluded.inventory_verified_at`,
+        topics: sql`excluded.topics`,
+      },
+      setWhere: or(
+        isNull(githubRepositories.inventoryVerifiedAt),
+        lte(githubRepositories.inventoryVerifiedAt, observedAt)
+      ),
+      target: githubRepositories.id,
+    });
 };
 
 export const upsertGitHubRepositories = async (
@@ -46,30 +292,49 @@ export const upsertGitHubRepositories = async (
   if (repositories.length === 0) {
     return;
   }
-  await transaction
-    .insert(githubRepositories)
-    .values(
-      repositories.map((repository) =>
-        githubRepositoryValuesFrom(repository, observedAt)
-      )
-    )
-    .onConflictDoUpdate({
-      set: {
-        defaultBranch: sql`coalesce(excluded.default_branch, ${githubRepositories.defaultBranch})`,
-        factsVerifiedAt: sql`coalesce(excluded.facts_verified_at, ${githubRepositories.factsVerifiedAt})`,
-        fullName: sql`excluded.full_name`,
-        htmlUrl: sql`coalesce(excluded.html_url, ${githubRepositories.htmlUrl})`,
-        lastObservedAt: sql`excluded.last_observed_at`,
-        ownerAvatarUrl: sql`coalesce(excluded.owner_avatar_url, ${githubRepositories.ownerAvatarUrl})`,
-        ownerId: sql`coalesce(excluded.owner_id, ${githubRepositories.ownerId})`,
-        ownerLogin: sql`coalesce(excluded.owner_login, ${githubRepositories.ownerLogin})`,
-        ownerType: sql`coalesce(excluded.owner_type, ${githubRepositories.ownerType})`,
-        pushedAt: sql`coalesce(excluded.pushed_at, ${githubRepositories.pushedAt})`,
-        visibility: sql`coalesce(excluded.visibility, ${githubRepositories.visibility})`,
-      },
-      setWhere: lte(githubRepositories.lastObservedAt, observedAt),
-      target: githubRepositories.id,
-    });
+  const changedRepositoryIds = await changedSummaryContextRepositoryIds(
+    transaction,
+    repositories,
+    observedAt,
+    false
+  );
+  await upsertGitHubRepositoryIdentity(transaction, repositories, observedAt);
+  await upsertGitHubRepositoryFacts(
+    transaction,
+    repositories,
+    observedAt,
+    false
+  );
+  await invalidateChangedRepositorySummaries(transaction, changedRepositoryIds);
+};
+
+export const upsertGitHubRepositoryInventory = async (
+  transaction: DatabaseTransaction,
+  repositories: readonly GitHubRepositoryInventoryFacts[],
+  observedAt: Date
+) => {
+  if (repositories.length === 0) {
+    return;
+  }
+  const changedRepositoryIds = await changedSummaryContextRepositoryIds(
+    transaction,
+    repositories,
+    observedAt,
+    true
+  );
+  await upsertGitHubRepositoryIdentity(transaction, repositories, observedAt);
+  await upsertGitHubRepositoryFacts(
+    transaction,
+    repositories,
+    observedAt,
+    true
+  );
+  await upsertGitHubRepositoryInventoryMetadata(
+    transaction,
+    repositories,
+    observedAt
+  );
+  await invalidateChangedRepositorySummaries(transaction, changedRepositoryIds);
 };
 
 export const upsertGitHubRepository = async (

--- a/tests/github-activity-processor.test.mjs
+++ b/tests/github-activity-processor.test.mjs
@@ -68,22 +68,6 @@ describe("GitHub activity commit acquisition", () => {
     globalThis.fetch = async (input) => {
       const url =
         input instanceof Request ? new URL(input.url) : new URL(input);
-      if (url.pathname === "/repos/example-org/example-repo") {
-        return Response.json({
-          description: "Example repository",
-          full_name: "example-org/example-repo",
-          homepage: null,
-          id: 123,
-          owner: {
-            avatar_url: "https://avatars.githubusercontent.com/u/123?v=4",
-            login: "example-org",
-            type: "Organization",
-          },
-          private: false,
-          topics: [],
-        });
-      }
-
       expect(url.pathname).toBe(
         `/repos/example-org/example-repo/commits/${sha}`
       );
@@ -141,23 +125,9 @@ describe("GitHub activity commit acquisition", () => {
     globalThis.fetch = async (input) => {
       const url =
         input instanceof Request ? new URL(input.url) : new URL(input);
-      if (url.pathname === "/repos/example-org/example-repo") {
-        return Response.json({
-          description: null,
-          full_name: "example-org/example-repo",
-          homepage: null,
-          id: 123,
-          owner: {
-            avatar_url: "https://avatars.githubusercontent.com/u/123?v=4",
-            id: 123,
-            login: "example-org",
-            type: "Organization",
-          },
-          private: false,
-          topics: [],
-          visibility: "public",
-        });
-      }
+      expect(url.pathname).toBe(
+        `/repos/example-org/example-repo/commits/${sha}`
+      );
       const parents = ancestryResponses[commitReads];
       commitReads += 1;
       return Response.json({

--- a/tests/github-activity-schema.test.mjs
+++ b/tests/github-activity-schema.test.mjs
@@ -32,6 +32,7 @@ describe("GitHub activity persistence schema", () => {
   test("keeps compact commit identity and durable enrichment state", () => {
     expect(getTableName(githubCommits)).toBe("github_commits");
     expect(githubCommits.repositoryId.primary).toBe(false);
+    expect(githubCommits.repository.notNull).toBe(false);
     expect(githubCommits.enrichmentState.default).toBe("pending");
     expect(githubCommits.enrichmentState.notNull).toBe(true);
     expect(githubCommits.pullRequestDiscoveryState.default).toBe("pending");
@@ -50,6 +51,9 @@ describe("GitHub activity persistence schema", () => {
         "github_commits_pr_discovery_state",
       ])
     );
+    expect(
+      config(githubCommits).foreignKeys.map((item) => item.getName())
+    ).toContain("github_commits_repository_fk");
   });
 
   test("records checkpoint gaps and idempotent push discovery before hydration", () => {
@@ -66,10 +70,14 @@ describe("GitHub activity persistence schema", () => {
     expect(githubAccountCheckpoints.tagRefNextPage.name).toBe(
       "tag_ref_next_page"
     );
+    expect(githubAccountCheckpoints.pullRequestBackfillDigest.name).toBe(
+      "pull_request_backfill_digest"
+    );
     expect(checkNames(githubAccountCheckpoints)).toEqual(
       expect.arrayContaining([
         "github_account_checkpoints_ref_leases",
         "github_account_checkpoints_ref_scans",
+        "github_account_checkpoints_pr_backfill_digest",
       ])
     );
     expect(getTableName(githubRepositories)).toBe("github_repositories");

--- a/tests/github-backfill.test.mjs
+++ b/tests/github-backfill.test.mjs
@@ -560,4 +560,90 @@ describe("GitHub factual history backfill", () => {
       stopReason: "deferred",
     });
   });
+
+  test("continues with ready work after one claim defers", async () => {
+    let backlogReads = 0;
+    let workerPasses = 0;
+    const result = await runGitHubBackfillFactualDrain(
+      {
+        accounts: ["f0rr0"],
+        deadlineAt: Date.now() + 60_000,
+        request,
+      },
+      {
+        readBacklog: async () => {
+          backlogReads += 1;
+          return backlogReads === 1
+            ? {
+                pending: emptyPendingFactualWork({
+                  commitEnrichment: 1,
+                  total: 1,
+                }),
+                retryAt: null,
+                unavailable: 0,
+              }
+            : {
+                pending: emptyPendingFactualWork(),
+                retryAt: null,
+                unavailable: 0,
+              };
+        },
+        refreshProjection: async () => ({}),
+        runWorker: async () => {
+          workerPasses += 1;
+          return workerResult({
+            commits:
+              workerPasses === 1
+                ? emptyWorkerStage({ claimed: 1, deferred: 1, failed: 1 })
+                : emptyWorkerStage({ claimed: 1, completed: 1 }),
+          });
+        },
+      }
+    );
+
+    expect(result).toMatchObject({
+      claimed: 2,
+      complete: true,
+      completed: 1,
+      passes: 2,
+      projectionRuns: 1,
+      stopReason: "complete",
+    });
+    expect(workerPasses).toBe(2);
+  });
+
+  test("stops without spinning when no ready work can be claimed", async () => {
+    let workerPasses = 0;
+    const result = await runGitHubBackfillFactualDrain(
+      {
+        accounts: ["f0rr0"],
+        deadlineAt: Date.now() + 60_000,
+        request,
+      },
+      {
+        readBacklog: async () => ({
+          pending: emptyPendingFactualWork({
+            pullRequestReconciliation: 1,
+            total: 1,
+          }),
+          retryAt: null,
+          unavailable: 0,
+        }),
+        refreshProjection: async () => ({}),
+        runWorker: async () => {
+          workerPasses += 1;
+          return workerResult();
+        },
+      }
+    );
+
+    expect(result).toMatchObject({
+      claimed: 0,
+      complete: false,
+      passes: 1,
+      retryAt: null,
+      stopReason: "deferred",
+    });
+    expect(workerPasses).toBe(1);
+  });
 });

--- a/tests/github-pull-request-backfill.test.mjs
+++ b/tests/github-pull-request-backfill.test.mjs
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, test } from "bun:test";
 import {
   backfillGitHubPullRequests,
   collectGitHubAuthoredPullRequestBackfillCandidates,
+  githubPullRequestBackfillDigestFrom,
   githubPullRequestBelongsInBackfillWindow,
   persistGitHubPullRequestBackfillMembership,
 } from "../src/lib/github-pull-request-backfill.ts";
@@ -25,12 +26,16 @@ const authoredPullRequestNode = (
   } = {}
 ) => ({
   author: { login: "f0rr0" },
+  baseRefOid: "a".repeat(40),
+  commits: { totalCount: 1 },
+  headRefOid: "b".repeat(40),
   id: nodeId,
   number,
   repository: {
     databaseId: repositoryId,
     nameWithOwner: repositoryName,
   },
+  state: "OPEN",
   updatedAt,
   url: `https://github.com/${repositoryName}/pull/${String(number)}`,
 });
@@ -62,6 +67,68 @@ const backfillInput = (overrides = {}) => ({
   untilAt,
   ...overrides,
 });
+
+const backfillDependencies = (overrides = {}) => ({
+  persistDigest: async () => null,
+  persistPrepared: async () => null,
+  readDigest: async () => null,
+  ...overrides,
+});
+
+const runBackfill = async (input = {}, dependencies = {}) =>
+  await backfillGitHubPullRequests(
+    backfillInput(input),
+    backfillDependencies(dependencies)
+  );
+
+const parsedCandidate = (number, overrides = {}) => ({
+  account: "f0rr0",
+  baseSha: "a".repeat(40),
+  commitCount: 1,
+  headSha: "b".repeat(40),
+  nodeId: `PR_authored_${String(number)}`,
+  number,
+  providerUpdatedAt: "2026-08-29T12:00:00.000Z",
+  repository: `external-org/repository-${String(number)}`,
+  repositoryId: String(5000 + number),
+  state: "open",
+  ...overrides,
+});
+
+const pullRequestResponse = ({ headSha = "b".repeat(40) } = {}) => {
+  const repository = {
+    full_name: "external-org/repository-1",
+    html_url: "https://github.com/external-org/repository-1",
+    id: 5001,
+    owner: {
+      avatar_url: "https://avatars.githubusercontent.com/u/5001?v=4",
+      id: 5001,
+      login: "external-org",
+      type: "Organization",
+    },
+    private: false,
+    visibility: "public",
+  };
+  return {
+    base: { ref: "main", repo: repository, sha: "a".repeat(40) },
+    body: null,
+    closed_at: null,
+    commits: 1,
+    created_at: "2026-07-30T10:00:00Z",
+    draft: false,
+    head: { ref: "feature", repo: repository, sha: headSha },
+    html_url: "https://github.com/external-org/repository-1/pull/1",
+    id: 7001,
+    merged: false,
+    merged_at: null,
+    node_id: "PR_authored_1",
+    number: 1,
+    state: "open",
+    title: "Remove August work",
+    updated_at: "2026-08-29T12:00:00Z",
+    user: { id: 8_574_219, login: "f0rr0" },
+  };
+};
 
 const trackedCommit = (committedAt, author = "f0rr0") => ({
   author,
@@ -166,6 +233,35 @@ describe("GitHub authored pull request backfill", () => {
     ).rejects.toThrow("invalid authored pull request pagination");
   });
 
+  test("fails closed when a repeated node crosses the history cutoff", async () => {
+    let page = 0;
+    globalThis.fetch = async () => {
+      page += 1;
+      return Response.json(
+        authoredPullRequestPage({
+          endCursor: page === 1 ? "page-two" : "unused",
+          hasNextPage: true,
+          nodes: [
+            authoredPullRequestNode(1, {
+              updatedAt:
+                page === 1 ? "2026-08-29T12:00:00Z" : "2026-07-31T23:59:59Z",
+            }),
+          ],
+          totalCount: 2,
+        })
+      );
+    };
+
+    await expect(
+      collectGitHubAuthoredPullRequestBackfillCandidates({
+        account: "f0rr0",
+        deadlineAt: Date.now() + 60_000,
+        token: "test-token",
+        updatedSinceAt: sinceAt,
+      })
+    ).rejects.toThrow("invalid authored pull request pagination");
+  });
+
   test("does not scan the accessible repository catalog", async () => {
     const paths = [];
     globalThis.fetch = async (input) => {
@@ -174,7 +270,7 @@ describe("GitHub authored pull request backfill", () => {
       return Response.json(authoredPullRequestPage());
     };
 
-    const result = await backfillGitHubPullRequests(backfillInput());
+    const result = await runBackfill();
 
     expect(result).toMatchObject({
       complete: true,
@@ -198,9 +294,7 @@ describe("GitHub authored pull request backfill", () => {
       );
     };
 
-    const result = await backfillGitHubPullRequests(
-      backfillInput({ repositoryId: "9999" })
-    );
+    const result = await runBackfill({ repositoryId: "9999" });
 
     expect(result).toMatchObject({
       complete: true,
@@ -229,7 +323,15 @@ describe("GitHub authored pull request backfill", () => {
     };
 
     const startedAt = Date.now();
-    const result = await backfillGitHubPullRequests(backfillInput());
+    let checkpointWrites = 0;
+    const result = await runBackfill(
+      {},
+      {
+        persistDigest: async () => {
+          checkpointWrites += 1;
+        },
+      }
+    );
 
     expect(Date.now() - startedAt).toBeLessThan(1000);
     expect(result).toMatchObject({
@@ -241,6 +343,7 @@ describe("GitHub authored pull request backfill", () => {
     expect(result.retryAt?.getTime()).toBeGreaterThanOrEqual(
       startedAt + retrySeconds * 1000
     );
+    expect(checkpointWrites).toBe(0);
   });
 
   test("records an inaccessible authored PR as an explicit coverage gap", async () => {
@@ -257,12 +360,238 @@ describe("GitHub authored pull request backfill", () => {
       return Response.json({ message: "Not Found" }, { status: 404 });
     };
 
-    expect(await backfillGitHubPullRequests(backfillInput())).toMatchObject({
+    let checkpointWrites = 0;
+    expect(
+      await runBackfill(
+        {},
+        {
+          persistDigest: async () => {
+            checkpointWrites += 1;
+          },
+        }
+      )
+    ).toMatchObject({
       complete: true,
       scannedPullRequests: 1,
       stopReason: "complete",
       unavailablePullRequests: 1,
     });
+    expect(checkpointWrites).toBe(0);
+  });
+
+  test("hashes the exact scope and candidate state independent of input order", () => {
+    const candidates = [parsedCandidate(1), parsedCandidate(2)];
+    const digest = (overrides = {}) =>
+      githubPullRequestBackfillDigestFrom({
+        account: "f0rr0",
+        candidates,
+        repositoryId: null,
+        sinceAt,
+        untilAt,
+        ...overrides,
+      });
+    const mutations = [
+      { account: "yuppiestechdev" },
+      { candidates: [candidates[0]] },
+      {
+        candidates: [
+          parsedCandidate(1, { providerUpdatedAt: "2026-08-30T00:00:00.000Z" }),
+          candidates[1],
+        ],
+      },
+      {
+        candidates: [
+          parsedCandidate(1, { repository: "renamed-org/repository-1" }),
+          candidates[1],
+        ],
+      },
+      {
+        candidates: [
+          parsedCandidate(1, { nodeId: "PR_replaced_identity" }),
+          candidates[1],
+        ],
+      },
+      {
+        candidates: [parsedCandidate(1, { number: 99 }), candidates[1]],
+      },
+      {
+        candidates: [
+          parsedCandidate(1, { repositoryId: "9999" }),
+          candidates[1],
+        ],
+      },
+      {
+        candidates: [
+          parsedCandidate(1, { headSha: "c".repeat(40) }),
+          candidates[1],
+        ],
+      },
+      {
+        candidates: [
+          parsedCandidate(1, { baseSha: "d".repeat(40) }),
+          candidates[1],
+        ],
+      },
+      {
+        candidates: [parsedCandidate(1, { commitCount: 2 }), candidates[1]],
+      },
+      {
+        candidates: [parsedCandidate(1, { state: "merged" }), candidates[1]],
+      },
+      { repositoryId: "5001" },
+      { sinceAt: new Date("2026-08-02T00:00:00.000Z") },
+      { untilAt: new Date("2026-08-30T23:59:59.999Z") },
+    ];
+
+    expect(digest({ candidates: candidates.toReversed() })).toBe(digest());
+    expect(digest()).toMatch(/^[a-f0-9]{64}$/u);
+    expect(new Set(mutations.map(digest)).size).toBe(mutations.length);
+    expect(mutations.map(digest)).not.toContain(digest());
+  });
+
+  test("reuses only an exact completed candidate traversal", async () => {
+    const candidate = parsedCandidate(1);
+    const completedDigest = githubPullRequestBackfillDigestFrom({
+      account: "f0rr0",
+      candidates: [candidate],
+      repositoryId: null,
+      sinceAt,
+      untilAt,
+    });
+    const paths = [];
+    let checkpointWrites = 0;
+    let persistenceCalls = 0;
+    globalThis.fetch = async (input) => {
+      const url = new URL(input instanceof Request ? input.url : input);
+      paths.push(url.pathname);
+      return Response.json(
+        authoredPullRequestPage({
+          nodes: [authoredPullRequestNode(1)],
+          totalCount: 1,
+        })
+      );
+    };
+
+    const result = await runBackfill(
+      {},
+      {
+        persistDigest: async () => {
+          checkpointWrites += 1;
+        },
+        persistPrepared: async () => {
+          persistenceCalls += 1;
+        },
+        readDigest: async () => completedDigest,
+      }
+    );
+
+    expect(result).toMatchObject({
+      complete: true,
+      reusedPullRequests: 1,
+      scannedPullRequests: 0,
+      selectedAuthoredPullRequests: 1,
+    });
+    expect(paths).toEqual(["/graphql"]);
+    expect(persistenceCalls).toBe(0);
+    expect(checkpointWrites).toBe(0);
+  });
+
+  test("does not checkpoint inconsistent GraphQL and REST snapshots", async () => {
+    let checkpointWrites = 0;
+    let persistenceCalls = 0;
+    globalThis.fetch = async (input) => {
+      const url = new URL(input instanceof Request ? input.url : input);
+      if (url.pathname === "/graphql") {
+        return Response.json(
+          authoredPullRequestPage({
+            nodes: [authoredPullRequestNode(1)],
+            totalCount: 1,
+          })
+        );
+      }
+      return Response.json(pullRequestResponse({ headSha: "c".repeat(40) }));
+    };
+
+    const result = await runBackfill(
+      {},
+      {
+        persistDigest: async () => {
+          checkpointWrites += 1;
+        },
+        persistPrepared: async () => {
+          persistenceCalls += 1;
+        },
+      }
+    );
+
+    expect(result).toMatchObject({
+      complete: false,
+      scannedPullRequests: 1,
+      stopReason: "provider_retry",
+      unavailablePullRequests: 0,
+    });
+    expect(persistenceCalls).toBe(0);
+    expect(checkpointWrites).toBe(0);
+  });
+
+  test("persists current membership even when no tracked commit remains in range", async () => {
+    const headSha = "b".repeat(40);
+    const persisted = [];
+    let checkpointWrites = 0;
+    globalThis.fetch = async (input) => {
+      const url = new URL(input instanceof Request ? input.url : input);
+      if (url.pathname === "/graphql") {
+        return Response.json(
+          authoredPullRequestPage({
+            nodes: [authoredPullRequestNode(1)],
+            totalCount: 1,
+          })
+        );
+      }
+      if (url.pathname.endsWith("/pulls/1/commits")) {
+        return Response.json([
+          {
+            author: { id: 8_574_219, login: "f0rr0" },
+            commit: {
+              author: { date: "2026-07-30T12:00:00Z" },
+              committer: { date: "2026-07-30T12:00:00Z" },
+              message: "feat: removed from the August branch",
+            },
+            sha: headSha,
+          },
+        ]);
+      }
+      return Response.json(pullRequestResponse({ headSha }));
+    };
+
+    const result = await runBackfill(
+      {},
+      {
+        persistDigest: async () => {
+          checkpointWrites += 1;
+        },
+        persistPrepared: async (prepared, _account, progress) => {
+          persisted.push(...prepared);
+          progress.skippedPullRequests += prepared.length;
+        },
+        readDigest: async () => "0".repeat(64),
+      }
+    );
+
+    expect(result).toMatchObject({
+      complete: true,
+      pullRequests: 0,
+      scannedPullRequests: 1,
+      skippedPullRequests: 1,
+    });
+    expect(persisted).toHaveLength(1);
+    expect(persisted[0]).toMatchObject({
+      commits: [],
+      inWindow: false,
+      membership: { commitShas: [headSha], membershipComplete: true },
+      snapshot: { pullRequest: { headSha } },
+    });
+    expect(checkpointWrites).toBe(1);
   });
 
   test("includes a PR only when its current membership has tracked work in range", () => {
@@ -270,7 +599,6 @@ describe("GitHub authored pull request backfill", () => {
       githubPullRequestBelongsInBackfillWindow({
         account: "f0rr0",
         commits,
-        pullRequest: { authorAccount: "f0rr0", mergedAt: null },
         sinceAt,
         untilAt,
       });

--- a/tests/github-pull-request-store.test.mjs
+++ b/tests/github-pull-request-store.test.mjs
@@ -8,7 +8,7 @@ import {
 } from "bun:test";
 import { setTimeout as delay } from "node:timers/promises";
 
-import { asc, eq } from "drizzle-orm";
+import { and, asc, eq } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/postgres-js";
 import { migrate } from "drizzle-orm/postgres-js/migrator";
 import postgres from "postgres";
@@ -89,14 +89,21 @@ const checkedOutput = (result, operation) => {
 
 describe.skipIf(!dockerAvailable)("GitHub pull request persistence", () => {
   let admin;
+  let claimGitHubCommitsForEnrichment;
+  let claimGitHubCommitsForPullRequestDiscovery;
   let closeDatabase;
+  let completeGitHubCommitEnrichment;
   let claimDueGitHubPullRequests;
   let containerId;
   let database;
   let originalDatabaseUrl;
+  let persistGitHubPullRequestBackfillDigest;
+  let persistGitHubPullRequestMembership;
   let persistGitHubPullRequestSnapshot;
   let persistGitHubWebhookPullRequest;
+  let releaseGitHubPullRequestDiscovery;
   let releaseGitHubPullRequestReconciliation;
+  let readGitHubPullRequestBackfillDigest;
   let schema;
 
   beforeAll(async () => {
@@ -155,11 +162,20 @@ describe.skipIf(!dockerAvailable)("GitHub pull request persistence", () => {
     ({ closeDatabase, getDatabase: database } =
       await import("../src/db/client.ts"));
     database = database();
+    ({
+      persistGitHubPullRequestBackfillDigest,
+      readGitHubPullRequestBackfillDigest,
+    } = await import("../src/lib/github-backfill-store.ts"));
     ({ persistGitHubWebhookPullRequest } =
       await import("../src/lib/github-commits-store.ts"));
     ({
       claimDueGitHubPullRequests,
+      claimGitHubCommitsForEnrichment,
+      claimGitHubCommitsForPullRequestDiscovery,
+      completeGitHubCommitEnrichment,
+      persistGitHubPullRequestMembership,
       persistGitHubPullRequestSnapshot,
+      releaseGitHubPullRequestDiscovery,
       releaseGitHubPullRequestReconciliation,
     } = await import("../src/lib/github-activity-worker-store.ts"));
   });
@@ -243,6 +259,166 @@ describe.skipIf(!dockerAvailable)("GitHub pull request persistence", () => {
     expect(verified.mergeShaVerifiedAt).not.toBeNull();
   });
 
+  test("round-trips the completed authored-PR traversal digest", async () => {
+    expect(
+      await readGitHubPullRequestBackfillDigest("yuppiestechdev")
+    ).toBeNull();
+    await persistGitHubPullRequestBackfillDigest({
+      account: "yuppiestechdev",
+      digest: "a".repeat(64),
+    });
+    expect(await readGitHubPullRequestBackfillDigest("yuppiestechdev")).toBe(
+      "a".repeat(64)
+    );
+
+    await persistGitHubPullRequestBackfillDigest({
+      account: "yuppiestechdev",
+      digest: "b".repeat(64),
+    });
+    expect(await readGitHubPullRequestBackfillDigest("yuppiestechdev")).toBe(
+      "b".repeat(64)
+    );
+  });
+
+  test("refreshes an existing out-of-window PR without creating an unrelated one", async () => {
+    const nodeId = "PR_pr_store_existing_only_8301";
+    const unseen = pullRequest({ nodeId, number: 217 });
+    expect(
+      await persistGitHubPullRequestSnapshot("f0rr0", unseen, {
+        existingOnly: true,
+      })
+    ).toBeNull();
+    expect(
+      await database
+        .select({ nodeId: schema.githubPullRequests.nodeId })
+        .from(schema.githubPullRequests)
+        .where(eq(schema.githubPullRequests.nodeId, nodeId))
+    ).toHaveLength(0);
+
+    const initial = await persistGitHubPullRequestSnapshot("f0rr0", unseen);
+    expect(initial).not.toBeNull();
+    expect(
+      await persistGitHubPullRequestMembership(
+        initial,
+        firstHeadSha,
+        ["f".repeat(40), firstHeadSha],
+        true
+      )
+    ).toBe(true);
+    const refreshed = await persistGitHubPullRequestSnapshot(
+      "f0rr0",
+      pullRequest({
+        commitCount: 1,
+        headSha: secondHeadSha,
+        nodeId,
+        number: 217,
+        providerUpdatedAt: "2026-08-30T12:02:00.000Z",
+      }),
+      { existingOnly: true, refreshMembership: true }
+    );
+
+    expect(refreshed).toMatchObject({
+      membershipRefreshRequired: true,
+      pullRequestNodeId: nodeId,
+    });
+    expect(
+      await persistGitHubPullRequestMembership(
+        refreshed,
+        secondHeadSha,
+        [secondHeadSha],
+        true
+      )
+    ).toBe(true);
+    const versions = await database
+      .select({
+        headSha: schema.githubPullRequestVersions.headSha,
+        isCurrent: schema.githubPullRequestVersions.isCurrent,
+      })
+      .from(schema.githubPullRequestVersions)
+      .where(eq(schema.githubPullRequestVersions.pullRequestNodeId, nodeId));
+    expect(versions.filter(({ isCurrent }) => isCurrent)).toEqual([
+      { headSha: secondHeadSha, isCurrent: true },
+    ]);
+    const currentMembership = await database
+      .select({ sha: schema.githubPullRequestMemberships.commitSha })
+      .from(schema.githubPullRequestMemberships)
+      .innerJoin(
+        schema.githubPullRequestVersions,
+        eq(
+          schema.githubPullRequestVersions.id,
+          schema.githubPullRequestMemberships.versionId
+        )
+      )
+      .where(
+        and(
+          eq(schema.githubPullRequestVersions.pullRequestNodeId, nodeId),
+          eq(schema.githubPullRequestVersions.isCurrent, true)
+        )
+      )
+      .orderBy(schema.githubPullRequestMemberships.position);
+    expect(currentMembership).toEqual([{ sha: secondHeadSha }]);
+  });
+
+  test("replaces same-head membership after a base retarget", async () => {
+    const nodeId = "PR_pr_store_retarget_8301";
+    const initial = await persistGitHubPullRequestSnapshot(
+      "f0rr0",
+      pullRequest({ nodeId, number: 218 })
+    );
+    expect(initial).not.toBeNull();
+    expect(
+      await persistGitHubPullRequestMembership(
+        initial,
+        firstHeadSha,
+        ["f".repeat(40), firstHeadSha],
+        true
+      )
+    ).toBe(true);
+
+    const retargeted = await persistGitHubPullRequestSnapshot(
+      "f0rr0",
+      pullRequest({
+        baseSha: "1".repeat(40),
+        nodeId,
+        number: 218,
+        providerUpdatedAt: "2026-08-30T12:03:00.000Z",
+      }),
+      { refreshMembership: true }
+    );
+    expect(retargeted).toMatchObject({
+      membershipRefreshRequired: true,
+      pullRequestNodeId: nodeId,
+    });
+    expect(
+      await persistGitHubPullRequestMembership(
+        initial,
+        firstHeadSha,
+        ["3".repeat(40), firstHeadSha],
+        true
+      )
+    ).toBe(false);
+    expect(
+      await persistGitHubPullRequestMembership(
+        retargeted,
+        firstHeadSha,
+        ["2".repeat(40), firstHeadSha],
+        true
+      )
+    ).toBe(true);
+
+    const membership = await database
+      .select({ sha: schema.githubPullRequestMemberships.commitSha })
+      .from(schema.githubPullRequestMemberships)
+      .where(
+        eq(schema.githubPullRequestMemberships.versionId, retargeted.versionId)
+      )
+      .orderBy(schema.githubPullRequestMemberships.position);
+    expect(membership).toEqual([
+      { sha: "2".repeat(40) },
+      { sha: firstHeadSha },
+    ]);
+  });
+
   test("claims due schedules written with PostgreSQL microsecond precision", async () => {
     const nodeId = "PR_pr_store_microsecond_schedule_8301";
     await persistGitHubPullRequestSnapshot(
@@ -323,5 +499,97 @@ describe.skipIf(!dockerAvailable)("GitHub pull request persistence", () => {
     expect(versions.find(({ isCurrent }) => isCurrent)?.headSha).toBe(
       thirdHeadSha
     );
+  });
+
+  test("claims canonical repository names and completes only the active commit lease", async () => {
+    const commitSha = "9".repeat(40);
+    const commitAt = new Date("2026-09-02T10:00:00.000Z");
+    const workerRepositoryId = "8401";
+    await database.insert(schema.githubRepositories).values({
+      description: "Canonical metadata must survive commit enrichment.",
+      fullName: "f0rr0/renamed-worker-path",
+      homepageUrl: "https://example.com/worker-path",
+      id: workerRepositoryId,
+      ownerLogin: "f0rr0",
+      topics: ["workers"],
+      visibility: "public",
+    });
+    await database.insert(schema.githubCommits).values({
+      author: "f0rr0",
+      committedAt: commitAt,
+      firstObservedAt: commitAt,
+      message: "feat: simplify the worker path",
+      repositoryId: workerRepositoryId,
+      sha: commitSha,
+    });
+
+    const [claimed] = await claimGitHubCommitsForEnrichment(
+      1,
+      ["f0rr0"],
+      new Date("2026-09-02T10:01:00.000Z")
+    );
+    expect(claimed.repository).toBe("f0rr0/renamed-worker-path");
+
+    const source = {
+      authoredAt: commitAt.toISOString(),
+      authorUserId: "8574219",
+      commit: {
+        committedAt: commitAt.toISOString(),
+        files: [],
+        message: "feat: simplify the worker path",
+        parents: [],
+        providerFileCapReached: false,
+        sha: commitSha,
+        stats: { additions: 0, deletions: 0, total: 0 },
+      },
+      committerAt: commitAt.toISOString(),
+      committerUserId: null,
+    };
+    expect(
+      await completeGitHubCommitEnrichment(
+        {
+          ...claimed,
+          leaseToken: "00000000-0000-4000-8000-000000000840",
+        },
+        source
+      )
+    ).toBe(false);
+    expect(await completeGitHubCommitEnrichment(claimed, source)).toBe(true);
+
+    const [storedCommit] = await database
+      .select({
+        enrichmentState: schema.githubCommits.enrichmentState,
+      })
+      .from(schema.githubCommits)
+      .where(
+        and(
+          eq(schema.githubCommits.repositoryId, workerRepositoryId),
+          eq(schema.githubCommits.sha, commitSha)
+        )
+      );
+    expect(storedCommit).toEqual({ enrichmentState: "complete" });
+    const [storedRepository] = await database
+      .select({
+        description: schema.githubRepositories.description,
+        fullName: schema.githubRepositories.fullName,
+        homepageUrl: schema.githubRepositories.homepageUrl,
+        topics: schema.githubRepositories.topics,
+      })
+      .from(schema.githubRepositories)
+      .where(eq(schema.githubRepositories.id, workerRepositoryId));
+    expect(storedRepository).toEqual({
+      description: "Canonical metadata must survive commit enrichment.",
+      fullName: "f0rr0/renamed-worker-path",
+      homepageUrl: "https://example.com/worker-path",
+      topics: ["workers"],
+    });
+
+    const [discovery] = await claimGitHubCommitsForPullRequestDiscovery(
+      1,
+      ["f0rr0"],
+      new Date("2026-09-02T10:02:00.000Z")
+    );
+    expect(discovery.repository).toBe("f0rr0/renamed-worker-path");
+    await releaseGitHubPullRequestDiscovery(discovery);
   });
 });

--- a/tests/github-reconciliation.test.mjs
+++ b/tests/github-reconciliation.test.mjs
@@ -13,7 +13,9 @@ afterEach(() => {
 
 const repository = {
   default_branch: "main",
+  description: "A private example repository.",
   full_name: "example-org/example-repo",
+  homepage: "https://example.com/project",
   html_url: "https://github.com/example-org/example-repo",
   id: 123,
   owner: {
@@ -24,12 +26,15 @@ const repository = {
   },
   private: true,
   pushed_at: "2026-08-20T00:00:00Z",
+  topics: ["typescript", "example"],
   visibility: "private",
 };
 
 const repositoryFacts = {
   defaultBranch: "main",
+  description: "A private example repository.",
   fullName: "example-org/example-repo",
+  homepageUrl: "https://example.com/project",
   htmlUrl: "https://github.com/example-org/example-repo",
   id: "123",
   ownerAvatarUrl: "https://avatars.githubusercontent.com/u/456?v=4",
@@ -37,6 +42,7 @@ const repositoryFacts = {
   ownerLogin: "example-org",
   ownerType: "Organization",
   pushedAt: "2026-08-20T00:00:00.000Z",
+  topics: ["example", "typescript"],
   visibility: "private",
 };
 
@@ -72,6 +78,15 @@ describe("GitHub repository reconciliation", () => {
         pushedSinceAt: new Date("2026-09-01T00:00:00.000Z"),
       })
     ).toEqual([repositoryFacts]);
+  });
+
+  test("rejects sparse repository responses instead of inventing summary context", async () => {
+    globalThis.fetch = async () =>
+      Response.json([{ ...repository, topics: undefined }]);
+
+    await expect(collectAccessibleGitHubRepositories("token")).rejects.toThrow(
+      "invalid repository response"
+    );
   });
 
   test("bounds a historical inventory to repositories pushed since the window began", async () => {

--- a/tests/github-repository-inventory.test.mjs
+++ b/tests/github-repository-inventory.test.mjs
@@ -27,10 +27,20 @@ const migrationsFolder = new URL("../drizzle", import.meta.url).pathname;
 const postgresImage = "postgres:17-alpine";
 const postgresPassword = "github-repository-inventory-test";
 const originalFetch = globalThis.fetch;
+const digest = (character) => character.repeat(64);
+const sha = (character) => character.repeat(40);
 
-const repositoryResponse = ({ fullName = "f0rr0/example", id = 101 } = {}) => ({
+const repositoryResponse = ({
+  description = "An example repository.",
+  fullName = "f0rr0/example",
+  homepage = "https://example.com",
+  id = 101,
+  topics = ["typescript", "example"],
+} = {}) => ({
   default_branch: "main",
+  description,
   full_name: fullName,
+  homepage,
   html_url: `https://github.com/${fullName}`,
   id,
   owner: {
@@ -41,12 +51,21 @@ const repositoryResponse = ({ fullName = "f0rr0/example", id = 101 } = {}) => ({
   },
   private: false,
   pushed_at: "2026-09-01T00:00:00Z",
+  topics,
   visibility: "public",
 });
 
-const repositoryFacts = ({ fullName = "f0rr0/example", id = "101" } = {}) => ({
+const repositoryFacts = ({
+  description = "An example repository.",
+  fullName = "f0rr0/example",
+  homepageUrl = "https://example.com",
+  id = "101",
+  topics = ["example", "typescript"],
+} = {}) => ({
   defaultBranch: "main",
+  description,
   fullName,
+  homepageUrl,
   htmlUrl: `https://github.com/${fullName}`,
   id,
   ownerAvatarUrl: "https://avatars.githubusercontent.com/u/8574219?v=4",
@@ -54,6 +73,7 @@ const repositoryFacts = ({ fullName = "f0rr0/example", id = "101" } = {}) => ({
   ownerLogin: "f0rr0",
   ownerType: "User",
   pushedAt: "2026-09-01T00:00:00.000Z",
+  topics,
   visibility: "public",
 });
 
@@ -62,9 +82,11 @@ describe.skipIf(!dockerAvailable)("GitHub repository inventory", () => {
   let claimGitHubRefRepairs;
   let closeDatabase;
   let containerId;
+  let getDatabase;
   let loadGitHubRepositoryInventory;
   let originalDatabaseUrl;
   let reconcileGitHubRepositoryRefBatch;
+  let upsertGitHubRepository;
 
   beforeAll(async () => {
     originalDatabaseUrl = env.DATABASE_URL;
@@ -124,13 +146,15 @@ describe.skipIf(!dockerAvailable)("GitHub repository inventory", () => {
     });
     await migrate(drizzle({ client: admin }), { migrationsFolder });
     env.DATABASE_URL = databaseUrl;
-    ({ closeDatabase } = await import("../src/db/client.ts"));
+    ({ closeDatabase, getDatabase } = await import("../src/db/client.ts"));
     ({ claimGitHubRefRepairs } =
       await import("../src/lib/github-ref-membership-store.ts"));
     ({ loadGitHubRepositoryInventory } =
       await import("../src/lib/github-repository-inventory.ts"));
     ({ reconcileGitHubRepositoryRefBatch } =
       await import("../src/lib/github-ref-reconciliation-batch.ts"));
+    ({ upsertGitHubRepository } =
+      await import("../src/lib/github-repository-store.ts"));
   });
 
   beforeEach(async () => {
@@ -223,6 +247,71 @@ describe.skipIf(!dockerAvailable)("GitHub repository inventory", () => {
         repositoryId: "101",
       },
     ]);
+    expect(
+      await admin`
+        select description, homepage_url as "homepageUrl", topics
+        from github_repositories
+        where id = '101'
+      `
+    ).toEqual([
+      {
+        description: "An example repository.",
+        homepageUrl: "https://example.com",
+        topics: ["example", "typescript"],
+      },
+    ]);
+  });
+
+  test("publishes metadata when sparse facts arrive during inventory traversal", async () => {
+    const startedAt = new Date("2026-09-01T12:00:00.000Z");
+    const sparseObservedAt = new Date(startedAt.getTime() + 1);
+    const startedAtIso = startedAt.toISOString();
+    const sparseObservedAtIso = sparseObservedAt.toISOString();
+    globalThis.fetch = async () => {
+      await getDatabase().transaction(async (transaction) => {
+        await upsertGitHubRepository(
+          transaction,
+          { fullName: "f0rr0/example", id: "101" },
+          sparseObservedAt
+        );
+      });
+      return Response.json([repositoryResponse()]);
+    };
+
+    expect(
+      await loadGitHubRepositoryInventory({
+        account: "f0rr0",
+        now: startedAt,
+        token: "token",
+      })
+    ).toEqual([repositoryFacts()]);
+    expect(
+      await admin`
+        select
+          description = 'An example repository.' as "metadataPersisted",
+          inventory_verified_at = ${startedAtIso} as "metadataTimestamped",
+          last_observed_at = ${sparseObservedAtIso} as "sparseFactsPreserved"
+        from github_repositories
+        where id = '101'
+      `
+    ).toEqual([
+      {
+        metadataPersisted: true,
+        metadataTimestamped: true,
+        sparseFactsPreserved: true,
+      },
+    ]);
+
+    globalThis.fetch = async () => {
+      throw new Error("The complete inventory should have been cached.");
+    };
+    expect(
+      await loadGitHubRepositoryInventory({
+        account: "f0rr0",
+        now: new Date(startedAt.getTime() + 2),
+        token: "token",
+      })
+    ).toEqual([repositoryFacts()]);
   });
 
   test("makes an already-known canonical head claimable without known commits", async () => {
@@ -374,6 +463,188 @@ describe.skipIf(!dockerAvailable)("GitHub repository inventory", () => {
         fullName: "f0rr0/current",
         generation: 3,
         repositoryId: "202",
+      },
+    ]);
+  });
+
+  test("invalidates only affected public summaries when repository context changes", async () => {
+    const startedAt = new Date("2026-09-01T12:00:00.000Z");
+    const startedAtIso = startedAt.toISOString();
+    let providerRepositories = [repositoryResponse()];
+    globalThis.fetch = async () => Response.json(providerRepositories);
+
+    await loadGitHubRepositoryInventory({
+      account: "f0rr0",
+      now: startedAt,
+      token: "token",
+    });
+    await admin`
+      insert into github_repositories (id, full_name)
+      values ('202', 'f0rr0/unrelated')
+    `;
+    await admin`
+      insert into github_commits (
+        author_login, committed_at, message, repository, repository_id, sha
+      ) values
+        ('f0rr0', ${startedAtIso}, 'affected', 'f0rr0/example', '101', ${sha("a")}),
+        ('f0rr0', ${startedAtIso}, 'unrelated', 'f0rr0/unrelated', '202', ${sha("b")})
+    `;
+    await admin`
+      insert into github_work_units (
+        activity_anchor_at, activity_at, activity_day, additions,
+        attribution_mode, branch_lineage_id, content_observed_at, deletions,
+        facts_digest, file_count, first_activity_at, id, identity_key, kind,
+        last_activity_at, member_count, membership_digest,
+        newest_commit_repository_id, newest_commit_sha, outcome_digest,
+        repository_id, summary_input_digest, visibility
+      ) values
+        (
+          ${startedAtIso}, ${startedAtIso}, '2026-09-01', 1,
+          'branch_owned_composite', '10000000-0000-4000-8000-000000000101',
+          ${startedAtIso}, 0, ${digest("a")}, 1, ${startedAtIso},
+          '20000000-0000-4000-8000-000000000101',
+          'branch:10000000-0000-4000-8000-000000000101', 'branch',
+          ${startedAtIso}, 1, ${digest("b")}, '101', ${sha("a")}, ${digest("c")},
+          '101', ${digest("d")}, 'public'
+        ),
+        (
+          ${startedAtIso}, ${startedAtIso}, '2026-09-01', 1,
+          'branch_owned_composite', '10000000-0000-4000-8000-000000000102',
+          ${startedAtIso}, 0, ${digest("e")}, 1, ${startedAtIso},
+          '20000000-0000-4000-8000-000000000102',
+          'branch:10000000-0000-4000-8000-000000000102', 'branch',
+          ${startedAtIso}, 1, ${digest("f")}, '101', ${sha("a")}, ${digest("1")},
+          '101', ${digest("2")}, 'private'
+        ),
+        (
+          ${startedAtIso}, ${startedAtIso}, '2026-09-01', 1,
+          'branch_owned_composite', '10000000-0000-4000-8000-000000000103',
+          ${startedAtIso}, 0, ${digest("3")}, 1, ${startedAtIso},
+          '20000000-0000-4000-8000-000000000103',
+          'branch:10000000-0000-4000-8000-000000000103', 'branch',
+          ${startedAtIso}, 1, ${digest("4")}, '202', ${sha("b")}, ${digest("5")},
+          '202', ${digest("6")}, 'public'
+        )
+    `;
+
+    await loadGitHubRepositoryInventory({
+      account: "f0rr0",
+      forceRefresh: true,
+      now: new Date(startedAt.getTime() + 1),
+      token: "token",
+    });
+    expect(
+      await admin`
+        select id::text, summary_input_digest as "summaryInputDigest"
+        from github_work_units
+        order by id
+      `
+    ).toEqual([
+      {
+        id: "20000000-0000-4000-8000-000000000101",
+        summaryInputDigest: digest("d"),
+      },
+      {
+        id: "20000000-0000-4000-8000-000000000102",
+        summaryInputDigest: digest("2"),
+      },
+      {
+        id: "20000000-0000-4000-8000-000000000103",
+        summaryInputDigest: digest("6"),
+      },
+    ]);
+
+    await getDatabase().transaction(async (transaction) => {
+      await upsertGitHubRepository(
+        transaction,
+        { fullName: "f0rr0/renamed", id: "101" },
+        new Date(startedAt.getTime() + 2)
+      );
+    });
+    expect(
+      await admin`
+        select description, full_name as "fullName",
+          homepage_url as "homepageUrl", topics
+        from github_repositories
+        where id = '101'
+      `
+    ).toEqual([
+      {
+        description: "An example repository.",
+        fullName: "f0rr0/renamed",
+        homepageUrl: "https://example.com",
+        topics: ["example", "typescript"],
+      },
+    ]);
+    expect(
+      await admin`
+        select summary_input_digest as "summaryInputDigest"
+        from github_work_units
+        where id = '20000000-0000-4000-8000-000000000101'
+      `
+    ).toEqual([{ summaryInputDigest: null }]);
+    await admin`
+      update github_work_units
+      set summary_input_digest = ${digest("d")}
+      where id = '20000000-0000-4000-8000-000000000101'
+    `;
+
+    providerRepositories = [
+      repositoryResponse({
+        description: null,
+        fullName: "f0rr0/renamed",
+        homepage: null,
+        topics: [],
+      }),
+    ];
+    expect(
+      await loadGitHubRepositoryInventory({
+        account: "f0rr0",
+        forceRefresh: true,
+        now: new Date(startedAt.getTime() + 3),
+        token: "token",
+      })
+    ).toEqual([
+      repositoryFacts({
+        description: null,
+        fullName: "f0rr0/renamed",
+        homepageUrl: null,
+        topics: [],
+      }),
+    ]);
+    expect(
+      await admin`
+        select description, full_name as "fullName",
+          homepage_url as "homepageUrl", topics
+        from github_repositories
+        where id = '101'
+      `
+    ).toEqual([
+      {
+        description: null,
+        fullName: "f0rr0/renamed",
+        homepageUrl: null,
+        topics: [],
+      },
+    ]);
+    expect(
+      await admin`
+        select id::text, summary_input_digest as "summaryInputDigest"
+        from github_work_units
+        order by id
+      `
+    ).toEqual([
+      {
+        id: "20000000-0000-4000-8000-000000000101",
+        summaryInputDigest: null,
+      },
+      {
+        id: "20000000-0000-4000-8000-000000000102",
+        summaryInputDigest: digest("2"),
+      },
+      {
+        id: "20000000-0000-4000-8000-000000000103",
+        summaryInputDigest: digest("6"),
       },
     ]);
   });


### PR DESCRIPTION
## What changed

- reuse only exact, fully completed authored-PR traversals
- reconcile force-push and retargeted PR membership with stale-writer protection
- read canonical repository identity from one normalized table and remove per-commit repository requests
- preserve authoritative inventory metadata with independent freshness and targeted summary invalidation
- keep factual draining productive when one claim is deferred

## Verification

- 251 tests, 0 failures
- typecheck, lint, migration journal check, diff check
- production build
- migration applied to an isolated current-production snapshot: 657 commits, 304 repositories, 0 orphans, validated foreign key
- real GitHub inventory refresh in the shadow database: 281 f0rr0 repositories and 23 yuppiestechdev repositories, all with complete metadata