### PR TITLE
fix: accept GitHub push webhook timestamps

### DIFF
--- a/src/lib/github-commits-core.ts
+++ b/src/lib/github-commits-core.ts
@@ -252,6 +252,15 @@ const optionalRepositoryDate = (value: unknown) => {
   if (value === null || value === undefined) {
     return { valid: true, value: null } as const;
   }
+  if (typeof value === "number") {
+    if (!Number.isSafeInteger(value) || value < 0) {
+      return { valid: false, value: null } as const;
+    }
+    const date = new Date(value * 1000);
+    return Number.isNaN(date.getTime())
+      ? ({ valid: false, value: null } as const)
+      : ({ valid: true, value: date.toISOString() } as const);
+  }
   const date = normalizedDate(value);
   return { valid: date !== null, value: date } as const;
 };

--- a/tests/github-commits.test.mjs
+++ b/tests/github-commits.test.mjs
@@ -365,7 +365,10 @@ describe("push webhook routing", () => {
         deleted: false,
         forced: false,
         ref: "refs/heads/feature",
-        repository,
+        repository: {
+          ...repository,
+          pushed_at: Date.parse(repository.pushed_at) / 1000,
+        },
         sender: { login: "somebody-else" },
       })
     ).toEqual({


### PR DESCRIPTION
## Root cause

GitHub sends repository.pushed_at as Unix seconds in push webhook payloads, while REST repository responses use an ISO timestamp. The shared repository parser accepted only the REST representation, so valid push deliveries returned 400 before persistence. Pull-request deliveries were unaffected.

## Fix

Accept the two documented provider representations only: an ISO timestamp or a non-negative integer Unix-second timestamp. The push-webhook regression now uses the shape observed in the real failed delivery.

## Verification

- real recent push deliveries: 400; pull-request deliveries: 202
- actual failed delivery otherwise had a valid ref transition and repository identity
- 49 focused tests pass
- typecheck and lint pass