### PR TITLE
fix: accept complete GitHub provider ledgers

### DIFF
--- a/src/lib/github-work-unit-core.ts
+++ b/src/lib/github-work-unit-core.ts
@@ -326,14 +326,6 @@ export const isEligibleGitHubWorkChange = (
       file.filename.length > 0 &&
       !file.filename.includes("\0")
   );
-  const fileAdditions = change.fileFacts.reduce(
-    (total, file) => total + file.additions,
-    0
-  );
-  const fileDeletions = change.fileFacts.reduce(
-    (total, file) => total + file.deletions,
-    0
-  );
   if (
     change.authorUserId === null ||
     !trackedAuthorUserIds.has(change.authorUserId) ||
@@ -348,8 +340,6 @@ export const isEligibleGitHubWorkChange = (
     change.additions < 0 ||
     change.deletions < 0 ||
     !fileCountersAreValid ||
-    fileAdditions !== change.additions ||
-    fileDeletions !== change.deletions ||
     !shaPattern.test(change.sha) ||
     !shaPattern.test(change.logicalSha)
   ) {

--- a/tests/github-work-unit-core.test.mjs
+++ b/tests/github-work-unit-core.test.mjs
@@ -214,6 +214,39 @@ describe("deterministic GitHub work ownership", () => {
     ).toBe("PR_tracked_open");
   });
 
+  test("projects complete provider evidence when aggregate and file counters drift", () => {
+    const ledgerFile = file("src/provider-ledger.ts", 3, 4);
+    const work = change("2", {
+      additions: 5,
+      deletions: 7,
+      fileFacts: [ledgerFile],
+    });
+    const key = logicalKeyFrom(work);
+
+    const [unit] = projection({
+      changes: [work],
+      pullRequests: [
+        pullRequest("PR_provider_ledger_drift", [key], {
+          netOutcomeOwnedCompletely: false,
+          snapshotKind: "final",
+          state: "merged",
+        }),
+      ],
+    });
+
+    expect(unit).toMatchObject({
+      attributionMode: "tracked_authored_pr",
+      facts: {
+        additions: 5,
+        deletions: 7,
+        fileCount: 1,
+        memberCount: 1,
+      },
+      identityKey: "pr:PR_provider_ledger_drift",
+      kind: "pull_request",
+    });
+  });
+
   test("fails closed until lower-priority negatives and the canonical branch are complete", () => {
     const work = change("c");
     const key = githubLogicalChangeKey(

--- a/tests/github-work-unit-crosswalk.test.mjs
+++ b/tests/github-work-unit-crosswalk.test.mjs
@@ -332,6 +332,35 @@ describe("GitHub work-unit crosswalk", () => {
     expect(report.invariants).toMatchObject({ failures: [], passed: true });
   });
 
+  test("counts complete provider-ledger drift as projected owned work", () => {
+    const evidence = snapshot();
+    const [ledgerChange] = evidence.input.changes;
+    evidence.input.changes[0] = {
+      ...ledgerChange,
+      additions: 5,
+      deletions: 7,
+    };
+    const providerChangeKey = logicalKey("1", "a");
+
+    const report = buildGitHubWorkUnitCrosswalk(evidence, {
+      since: "2026-08-01",
+      until: "2026-08-08",
+    });
+
+    expect(report.categories.eligibleTrackedChanges.ids).toContain(
+      providerChangeKey
+    );
+    expect(report.categories.projectedOwnedChanges.ids).toContain(
+      providerChangeKey
+    );
+    expect(report.categories.projectedPullRequestUnits.ids).toContain(
+      "pr:PR_1"
+    );
+    expect(report.categories.zeroDiffOrIneligibleChanges.ids).not.toContain(
+      providerChangeKey
+    );
+  });
+
   test("fails coverage for each blocking exclusion reason", () => {
     const blockingReasons = [
       "canonical_branch_unknown",


### PR DESCRIPTION
## What changed

- accept GitHub commits when complete per-file counters drift from validated provider aggregate totals
- retain every other authorship, completeness, cap, ancestry, and identity gate
- cover projection and reconciliation behavior with provider-shaped tests

## Real-data verification

- August authored PR work units reconcile from 188 to 189
- 27 provider-drift commits become eligible; 19 project into owned work and 8 remain deterministic current-ownership exclusions
- zero projection coverage gaps and zero repository-visibility gaps
- identical August backfill rerun reused all 210 selected PR candidates and completed in 57 seconds

## Validation

- 253 tests passing, 0 failures
- typecheck, lint, formatting, diff check, and production build passing