### PR TITLE
fix(github): give projection a complete worker window

### DIFF
--- a/docs/github-activity-work-units.md
+++ b/docs/github-activity-work-units.md
@@ -239,7 +239,7 @@ Supabase Cron invokes:
 | Route                     | Schedule                              | Bound                                                               |
 | ------------------------- | ------------------------------------- | ------------------------------------------------------------------- |
 | `/api/cron/github-sync`   | every 5 minutes                       | 15-second request                                                   |
-| `/api/cron/github-worker` | every 5 minutes, offset by 2 minutes  | 15-second request; default four items per factual queue and one ref |
+| `/api/cron/github-worker` | every 5 minutes, offset by 2 minutes  | 60-second request; default four items per factual queue and one ref |
 | `/api/cron/github-refs`   | every 15 minutes, offset by 4 minutes | 15-second request; eight ref pages/repositories per account         |
 
 The worker processes factual queues and current-ref repair before recomputing

--- a/scripts/configure-supabase-cron.ts
+++ b/scripts/configure-supabase-cron.ts
@@ -6,12 +6,12 @@ import {
   GITHUB_EVENTS_CRON_JOB,
   GITHUB_HEAD_REFS_CRON_JOB,
   GITHUB_REF_REPOSITORY_BATCH_SIZE,
+  GITHUB_WORKER_HTTP_TIMEOUT_MS,
   GITHUB_WORKER_CRON_JOB,
 } from "../src/lib/github-cron-config";
 import { CANONICAL_SITE_URL } from "../src/lib/site-url";
 import { shouldApplyProductionMigrations } from "./migrate-production-database";
 
-const CRON_HTTP_TIMEOUT_MS = GITHUB_CRON_EXECUTION_DURATION_MS;
 const SECRET_DESCRIPTION = "Vercel GitHub sync cron configuration";
 const SECRET_NAME = "github_sync_bearer_secret";
 const URL_NAME = "github_sync_url";
@@ -112,7 +112,10 @@ const upsertVaultSecret = async (
   `;
 };
 
-const cronHttpPostCommand = (urlSecretName: string) => `
+const cronHttpPostCommand = (
+  urlSecretName: string,
+  timeoutMilliseconds = GITHUB_CRON_EXECUTION_DURATION_MS
+) => `
   select net.http_post(
     url := (
       select decrypted_secret
@@ -128,7 +131,7 @@ const cronHttpPostCommand = (urlSecretName: string) => `
       )
     ),
     body := jsonb_build_object('source', 'supabase-cron'),
-    timeout_milliseconds := ${String(CRON_HTTP_TIMEOUT_MS)}
+    timeout_milliseconds := ${String(timeoutMilliseconds)}
   ) as request_id
 `;
 
@@ -212,7 +215,7 @@ export const configureSupabaseCron = async (
         select cron.schedule(
           ${GITHUB_WORKER_CRON_JOB.name},
           ${GITHUB_WORKER_CRON_JOB.schedule},
-          ${cronHttpPostCommand(WORKER_URL_NAME)}
+          ${cronHttpPostCommand(WORKER_URL_NAME, GITHUB_WORKER_HTTP_TIMEOUT_MS)}
         ) as "jobId"
       `;
       if (

--- a/src/app/api/cron/github-worker/route.ts
+++ b/src/app/api/cron/github-worker/route.ts
@@ -1,14 +1,14 @@
 import { env } from "@/env";
 import { runGitHubActivityWorker } from "@/lib/github-activity-worker";
 import { workerBatchSizeFrom } from "@/lib/github-activity-worker-core";
-import { GITHUB_CRON_EXECUTION_DURATION_MS } from "@/lib/github-cron-config";
-import type { GITHUB_ROUTINE_MAX_DURATION_SECONDS } from "@/lib/github-cron-config";
+import { GITHUB_WORKER_EXECUTION_DURATION_MS } from "@/lib/github-cron-config";
+import type { GITHUB_WORKER_MAX_DURATION_SECONDS } from "@/lib/github-cron-config";
 import { reportOperationalError } from "@/lib/operational-error";
 import { hasBearerSecret } from "@/lib/request-auth";
 
 export const dynamic = "force-dynamic";
 export const maxDuration =
-  15 satisfies typeof GITHUB_ROUTINE_MAX_DURATION_SECONDS;
+  60 satisfies typeof GITHUB_WORKER_MAX_DURATION_SECONDS;
 export const runtime = "nodejs";
 
 export async function POST(request: Request) {
@@ -26,10 +26,10 @@ export async function POST(request: Request) {
   try {
     const activity = await runGitHubActivityWorker(
       batchSize === undefined
-        ? { maximumDurationMs: GITHUB_CRON_EXECUTION_DURATION_MS }
+        ? { maximumDurationMs: GITHUB_WORKER_EXECUTION_DURATION_MS }
         : {
             commitLimit: batchSize,
-            maximumDurationMs: GITHUB_CRON_EXECUTION_DURATION_MS,
+            maximumDurationMs: GITHUB_WORKER_EXECUTION_DURATION_MS,
             observationLimit: batchSize,
             pullRequestDiscoveryLimit: batchSize,
             pullRequestLimit: batchSize,

--- a/src/lib/github-activity-worker-core.ts
+++ b/src/lib/github-activity-worker-core.ts
@@ -4,6 +4,7 @@ export const GITHUB_PR_RECONCILIATION_MAX_AGE_DAYS = Number.POSITIVE_INFINITY;
 
 const DEFAULT_RETRY_DELAY_MS = 15 * 60 * 1000;
 const MAXIMUM_RETRY_DELAY_MS = 24 * 60 * 60 * 1000;
+export const GITHUB_SUMMARY_MINIMUM_REMAINING_MS = 5000;
 
 export const boundedWorkerLimit = (
   value: number | undefined,
@@ -82,6 +83,13 @@ export const workerDeadlineReached = (
     throw new RangeError("The GitHub activity worker deadline is invalid.");
   }
   return now - startedAt >= maximumDurationMs;
+};
+
+export const githubSummaryCanStart = (deadlineAt: number, now = Date.now()) => {
+  if (!Number.isFinite(deadlineAt) || !Number.isFinite(now)) {
+    throw new RangeError("The GitHub summary deadline is invalid.");
+  }
+  return deadlineAt - now >= GITHUB_SUMMARY_MINIMUM_REMAINING_MS;
 };
 
 export const nextGitHubPullRequestReconciliationAt = (

--- a/src/lib/github-activity-worker.ts
+++ b/src/lib/github-activity-worker.ts
@@ -13,6 +13,7 @@ import {
 import {
   boundedWorkerLimit,
   GITHUB_PR_RECONCILIATION_MAX_AGE_DAYS,
+  githubSummaryCanStart,
   workerDeadlineReached,
 } from "@/lib/github-activity-worker-core";
 import {
@@ -87,7 +88,8 @@ import {
 } from "@/lib/github-work-unit-summary-store";
 
 const DEFAULT_WORKER_MAXIMUM_DURATION_MS = 90_000;
-const MAXIMUM_PROJECTION_RESERVE_MS = 2000;
+const MAXIMUM_PROJECTION_RESERVE_MS = 50_000;
+const MINIMUM_FACTUAL_PROCESSING_MS = 8000;
 const SUMMARY_RETRY_DELAY_MS = 15 * 60_000;
 const TERMINAL_GITHUB_STATUSES = new Set([403, 404, 410, 422]);
 const TERMINAL_ACTIVITY_PROCESSING_CODES = new Set([
@@ -601,6 +603,7 @@ const processPullRequests = async (
 const processSummary = async (context: WorkerContext, result: StageResult) => {
   if (
     context.deadlineReached() ||
+    !githubSummaryCanStart(context.deadlineAt) ||
     (env.OPENAI_API_KEY?.trim().length ?? 0) === 0
   ) {
     return;
@@ -720,10 +723,13 @@ export const runGitHubActivityWorker = async (
   }
 
   const startedAt = Date.now();
-  const projectionReserveMs = Math.min(
-    MAXIMUM_PROJECTION_RESERVE_MS,
-    Math.floor(maximumDurationMs / 5)
-  );
+  const projectionReserveMs =
+    options.includeProjection === false
+      ? 0
+      : Math.min(
+          MAXIMUM_PROJECTION_RESERVE_MS,
+          Math.max(0, maximumDurationMs - MINIMUM_FACTUAL_PROCESSING_MS)
+        );
   const processingDurationMs = maximumDurationMs - projectionReserveMs;
   const deadlineReached = () =>
     workerDeadlineReached(startedAt, processingDurationMs);
@@ -741,6 +747,8 @@ export const runGitHubActivityWorker = async (
     deadlineReached,
     scope,
   };
+  const overallDeadlineReached = () =>
+    workerDeadlineReached(startedAt, maximumDurationMs);
 
   await processObservations(context, observationLimit, observations);
   await processPullRequestSignals(
@@ -773,12 +781,19 @@ export const runGitHubActivityWorker = async (
       : null;
   await reconcileGitHubWorkUnitSummaryStatus(new Date());
   if (options.includeSummaries !== false) {
-    await processSummary(context, summaries);
+    await processSummary(
+      {
+        ...context,
+        deadlineAt: startedAt + maximumDurationMs,
+        deadlineReached: overallDeadlineReached,
+      },
+      summaries
+    );
   }
 
   return {
     commits,
-    deadlineReached: context.deadlineReached(),
+    deadlineReached: overallDeadlineReached(),
     observations,
     projection,
     pullRequests,

--- a/src/lib/github-cron-config.ts
+++ b/src/lib/github-cron-config.ts
@@ -17,6 +17,10 @@ export const GITHUB_REF_REPOSITORY_BATCH_SIZE = 8;
 export const GITHUB_ROUTINE_MAX_DURATION_SECONDS = 15 as const;
 export const GITHUB_CRON_EXECUTION_DURATION_MS =
   GITHUB_ROUTINE_MAX_DURATION_SECONDS * 1000;
+export const GITHUB_WORKER_MAX_DURATION_SECONDS = 60 as const;
+export const GITHUB_WORKER_EXECUTION_DURATION_MS = 58 * 1000;
+export const GITHUB_WORKER_HTTP_TIMEOUT_MS =
+  GITHUB_WORKER_MAX_DURATION_SECONDS * 1000;
 
 export const githubRefRepositoryLimitFrom = (value: string | null) => {
   if (value === null) {

--- a/tests/github-activity-worker.test.mjs
+++ b/tests/github-activity-worker.test.mjs
@@ -10,6 +10,7 @@ import {
   githubActivityRetryAt,
   githubPullRequestSnapshotDisposition,
   githubPrReconciliationCutoff,
+  githubSummaryCanStart,
   GITHUB_PR_RECONCILIATION_MAX_AGE_DAYS,
   MAXIMUM_GITHUB_ACTIVITY_WORKER_BATCH_SIZE,
   nextGitHubPullRequestReconciliationAt,
@@ -112,6 +113,12 @@ describe("GitHub activity worker bounds", () => {
   test("uses a deterministic wall-clock deadline", () => {
     expect(workerDeadlineReached(1000, 10_000, 10_999)).toBe(false);
     expect(workerDeadlineReached(1000, 10_000, 11_000)).toBe(true);
+  });
+
+  test("starts summary work only with a complete provider budget", () => {
+    expect(githubSummaryCanStart(6000, 1000)).toBe(true);
+    expect(githubSummaryCanStart(5999, 1000)).toBe(false);
+    expect(() => githubSummaryCanStart(Number.NaN, 1000)).toThrow(RangeError);
   });
 
   test("stops terminal PR polling", () => {

--- a/tests/github-cron-config.test.mjs
+++ b/tests/github-cron-config.test.mjs
@@ -8,6 +8,9 @@ import {
   GITHUB_HEAD_REFS_CRON_JOB,
   GITHUB_REF_REPOSITORY_BATCH_SIZE,
   GITHUB_ROUTINE_MAX_DURATION_SECONDS,
+  GITHUB_WORKER_EXECUTION_DURATION_MS,
+  GITHUB_WORKER_HTTP_TIMEOUT_MS,
+  GITHUB_WORKER_MAX_DURATION_SECONDS,
   GITHUB_WORKER_CRON_JOB,
   githubRefRepositoryLimitFrom,
 } from "../src/lib/github-cron-config.ts";
@@ -53,6 +56,13 @@ describe("GitHub cron configuration", () => {
     expect(GITHUB_ROUTINE_MAX_DURATION_SECONDS).toBe(15);
     expect(GITHUB_CRON_EXECUTION_DURATION_MS).toBe(
       GITHUB_ROUTINE_MAX_DURATION_SECONDS * 1000
+    );
+    expect(GITHUB_WORKER_MAX_DURATION_SECONDS).toBe(60);
+    expect(GITHUB_WORKER_EXECUTION_DURATION_MS).toBeLessThan(
+      GITHUB_WORKER_HTTP_TIMEOUT_MS
+    );
+    expect(GITHUB_WORKER_HTTP_TIMEOUT_MS).toBe(
+      GITHUB_WORKER_MAX_DURATION_SECONDS * 1000
     );
     expect(githubRefRepositoryLimitFrom(null)).toBe(8);
     expect(githubRefRepositoryLimitFrom("1")).toBe(1);


### PR DESCRIPTION
## Summary

- give the projection worker a 58-second internal budget inside Vercel’s 60-second function limit
- configure only the worker cron request with a matching 60-second database HTTP timeout
- preserve factual time in the worker and avoid claiming summary work without enough provider-call budget

## Verification

- `bun test` (254 passing)
- `bun run typecheck`
- `bun run lint`
- `bun run build`