### PR TITLE
fix(github): make activity projection converge

### DIFF
--- a/docs/github-activity-work-units.md
+++ b/docs/github-activity-work-units.md
@@ -144,24 +144,34 @@ presence.
 `github_work_unit_memberships` stores its ordered, one-owner membership. A
 projection refresh loads durable evidence, computes the full current result,
 and swaps changed units and memberships under one advisory lock and repeatable
-read transaction.
+read transaction. It reads compact file counters and generated evidence digests
+for the full corpus, then hydrates raw patches only for the bounded summary
+batch.
 
-`github_public_feed_head` is a singleton containing only:
+`github_public_feed_head` is a singleton containing:
 
 - `feed_revision` for initial-page work-unit changes, newly inserted
-  known-visible issues, or a first accepted initial-page summary;
+  known-visible issues, or an accepted summary becoming visible, hidden, or
+  replaced;
 - `ordering_revision` for ordered-set and membership changes;
 - `head_content_revision` for the lightweight status endpoint;
 - `last_published_at`; and
-- `summarizing`.
+- `summarizing`;
+- an internal projection-request token; and
+- the last completely evaluated semantic summary-policy digest.
+
+Evidence writers replace the projection token in the same transaction as the
+evidence change. A refresh clears only the token it observed and only after its
+bounded summary-evaluation backlog is empty. A semantic policy change creates a
+token until the current corpus has been reevaluated.
 
 The public feed reads at most five UTC days per page in a read-only repeatable
 read transaction. Pagination cursors are HMAC-signed and bound to the ordering
 revision. An ordering change returns `409`, prompting a fresh first page.
 
-Accepted summaries are read only when their outcome, input, and attribution
-digests still match the current public unit. Stale attempts cannot leak into a
-new projection.
+Accepted summaries are read only when their recipe, outcome, input, and
+attribution digests still match the current public unit. Stale attempts cannot
+leak into a new projection.
 
 ## Outcome summaries
 
@@ -191,14 +201,17 @@ low text verbosity, provider storage disabled, no SDK retry, a 32,000-token
 input cap, and a 160-token output cap. Output must be structured as one outcome
 of at most two sentences, 60 words, and 320 Unicode code points. Validation
 rejects invalid Unicode, control/bidirectional characters, URLs, HTML,
-Markdown, SHAs, unsupported numbers, and verbatim source strings.
+Markdown, and SHAs.
 
-Summary identity includes the recipe, prompt, normalized input, outcome digest,
-and attribution mode. A five-minute debounce absorbs active rewrites. Provider
-output is accepted only while the lease, unit revision, outcome digest,
-attribution mode, and summary-input digest all still match. A force push with
-the same complete PR net outcome can reuse accepted prose; a changed outcome
-queues a new attempt.
+Summary identity includes the semantic policy, recipe, prompt, normalized
+input, outcome digest, and attribution mode. Transport retries and storage
+configuration do not invalidate prose. A five-minute debounce absorbs active
+rewrites. Up to eight recent-first inputs are deterministically evaluated per
+projection refresh, while the provider worker still starts at most one claim.
+Valid public-input output remains cacheable if its input becomes stale while
+the request runs; it is displayed only when the current public unit's exact
+recipe, outcome, attribution, and summary-input keys match. A force push with
+the same complete PR net outcome can therefore reuse accepted prose.
 
 Claims are recent-first:
 
@@ -212,7 +225,10 @@ Claims are recent-first:
 
 Started requests count even when they fail. A transient failure waits 15
 minutes before its one possible retry. Invalid input/output and exhausted
-attempts become facts-only. Expired leases are recovered by the next worker.
+attempts become facts-only. Superseded attempts that never started are removed;
+a paid retryable attempt becomes a payload-free tombstone that retains its
+request count. Its input is rebuilt and debounced only if the exact input becomes
+current again. Expired leases are recovered by the next worker.
 
 `OPENAI_API_KEY` is optional; without it the factual pipeline continues and no
 summary claim is started. This is not an OpenAI free-tier design. At the
@@ -236,11 +252,11 @@ Three inputs converge on the same durable worker queues:
 
 Supabase Cron invokes:
 
-| Route                     | Schedule                              | Bound                                                               |
-| ------------------------- | ------------------------------------- | ------------------------------------------------------------------- |
-| `/api/cron/github-sync`   | every 5 minutes                       | 15-second request                                                   |
-| `/api/cron/github-worker` | every 5 minutes, offset by 2 minutes  | 60-second request; default four items per factual queue and one ref |
-| `/api/cron/github-refs`   | every 15 minutes, offset by 4 minutes | 15-second request; eight ref pages/repositories per account         |
+| Route                     | Schedule                              | Bound                                                                |
+| ------------------------- | ------------------------------------- | -------------------------------------------------------------------- |
+| `/api/cron/github-sync`   | every 5 minutes                       | 15-second request                                                    |
+| `/api/cron/github-worker` | every 5 minutes, offset by 2 minutes  | 60-second request; default eight items per factual queue and one ref |
+| `/api/cron/github-refs`   | every 15 minutes, offset by 4 minutes | 15-second request; eight ref pages/repositories per account          |
 
 The worker processes factual queues and current-ref repair before recomputing
 the projection. It then reconciles the minimal summary status and may claim one
@@ -287,13 +303,19 @@ membership can represent the same authored work as a PR independently. An
 unchanged pre-existing side branch with no surviving signal is not exhaustively
 discovered on cold start.
 
+Head webhooks are applied in delivery order; they are not an authoritative
+ordering oracle. A delayed delivery can therefore leave a stale desired tip
+until the bounded current-ref scan reads GitHub's present state. The ref route
+runs every 15 minutes and is the authoritative reconciliation path; a heavily
+paginated inventory can require more than one invocation.
+
 ## Minimal live state
 
 The status endpoint returns the feed revision, a monotone head revision, last
-feed publication time, and one boolean: whether the last worker reconciliation
-found a current, recent public summary lease on the initial five-day page. The
-next worker reconciliation clears an expired abandoned lease. The UI renders
-only:
+feed publication time, and one boolean: whether the configured summary pipeline
+has a current, recent public evaluation, queued input, retry, or provider lease
+on the initial five-day page. The next worker reconciliation clears an expired
+abandoned lease. The UI renders only:
 
 - `Shaping the latest update` while that boolean is true;
 - `Updated … ago` (or `Activity is up to date`) otherwise; or
@@ -303,7 +325,7 @@ only:
 Polling runs while the tab is visible, the browser is online, no refresh is
 pending, and the timeline is in view when the browser supports intersection
 observation. A settled page checks every five minutes at most three times.
-While summarizing, it checks every 30 seconds, subject to a total cap of 12
+While shaping recent summary work, it checks every three minutes, subject to a total cap of 12
 requests. The private, revalidated endpoint supports ETags; polling budgets
 reset after a successful feed refresh. New content is never inserted while the
 reader is moving through the page; the reader chooses `Show latest work` to
@@ -315,8 +337,9 @@ refresh.
 builds a deterministic, read-only crosswalk for a half-open interval. It emits
 stable IDs and counts for tracked candidates, eligible changes, integration
 merges, ineligible changes, PR/canonical/branch units, owned changes, visibility
-gaps, authored PRs without a current owned member, and each coverage or
-policy-exclusion reason. `merged_pr_landing` and
+gaps, commit-enrichment backlog, authored PRs without a current owned member,
+and each coverage or policy-exclusion reason. Any enrichment backlog fails the
+crosswalk. `merged_pr_landing` and
 `no_current_owner` are policy exclusions; unknown canonical branch, incomplete
 head generation, incomplete PR coverage, and unknown visibility are coverage
 gaps that fail the crosswalk.
@@ -336,6 +359,7 @@ class names:
 | same-repository merged landing absent from effective PR membership      | canonical suppressed; active side head may own it     |
 | PR rewrite with unchanged net outcome                                   | stable identity, anchor, and reusable prose           |
 | changed PR/ref membership                                               | removed SHA loses its old ownership                   |
+| ref head A → B → A                                                      | final A is projected rather than suppressed           |
 | incomplete PR discovery, visibility, default branch, or head generation | fail closed with a reported reason                    |
 | shared side-branch commit                                               | deterministic primary branch, one owner               |
 | private or unknown repository                                           | generic private day or no output                      |
@@ -343,6 +367,8 @@ class names:
 | concurrent projection/summary work                                      | leases and compare-and-swap prevent stale publication |
 | same-day repository rows                                                | one header and a count derived from final groups      |
 | summary budget/retry/expiry                                             | hard caps and facts-only terminal state               |
+| nine pending summary evaluations                                        | eight settle, then one on the next refresh            |
+| paid input A superseded by B then current again                         | count retained and debounce re-armed                  |
 
 Run the complete local gate with:
 

--- a/docs/github-commits.md
+++ b/docs/github-commits.md
@@ -34,10 +34,11 @@ The worker leases small batches and can safely resume after a deadline. It:
    reconciles PR snapshots, current/final memberships, authoritative merge
    evidence, and complete PR net file facts;
 4. recomputes the current work-unit projection from durable evidence and swaps
-   units, memberships, summary eligibility, and public feed revisions
-   atomically; and
-5. claims at most one eligible public work-unit summary at a time and accepts
-   output only through the current digest/revision compare-and-swap.
+   units, memberships, and public feed revisions atomically; and
+5. evaluates summary inputs in recent-first batches of eight, then claims at
+   most one eligible public summary. Valid public-input output can be cached
+   after becoming stale; display still requires exact current recipe, outcome,
+   attribution, and input digests.
 
 Multi-parent merge commits and commits with neither file facts nor churn are not
 separate timeline work. A same-repository merged-PR association suppresses
@@ -57,11 +58,13 @@ Unknown work contributes nothing. Private titles, messages, paths, branch
 names, repository identity, and generated prose are neither rendered nor sent
 to the model.
 
-Summary attempts are revisioned by the current outcome, attribution mode, and
+Summary attempts are keyed by the current outcome, attribution mode, recipe, and
 summary-input digest. Facts publish independently of optional prose. A force
-push recomputes current PR membership and net outcome; an unchanged outcome
-digest can reuse accepted prose. Daily and monthly request caps count started
-requests, including retries.
+push recomputes current PR membership and net outcome; an unchanged exact input
+can reuse accepted prose. A superseded unstarted input is removed. A paid
+retryable input drops its payload but retains its request count; the exact input
+is rebuilt and debounced if it becomes current later. Daily and monthly request
+caps count started requests, including retries.
 
 Opened issues remain durable authored milestones outside the work-unit summary
 pipeline. A newly inserted issue with known visibility transactionally advances
@@ -69,8 +72,12 @@ the public feed head; replayed deliveries and unknown visibility do not.
 
 The public reader groups a repository once per UTC day and reads complete days
 against the current ordered-set revision. `github_public_feed_head` contains
-only the monotone feed/content/order revisions, last feed publication time,
-and whether an initial-page summary is currently processing.
+the monotone feed/content/order revisions, last publication time, a durable
+projection-request token, the applied semantic summary-policy digest, and
+whether configured recent initial-page summary work is being evaluated, queued,
+retried, or processed. Evidence writers set the token transactionally;
+projection clears the observed token only after its bounded summary-evaluation
+backlog reaches zero.
 
 ## Runtime configuration
 

--- a/drizzle/0016_moaning_paibok.sql
+++ b/drizzle/0016_moaning_paibok.sql
@@ -1,0 +1,23 @@
+ALTER TABLE "github_work_units" DROP CONSTRAINT "gh_work_units_digest_shapes";--> statement-breakpoint
+ALTER TABLE "github_repositories" ADD CONSTRAINT "github_repositories_full_name" CHECK (length(btrim("github_repositories"."full_name")) > 0);--> statement-breakpoint
+ALTER TABLE "github_pull_requests" DROP COLUMN "provider_file_cap_reached";--> statement-breakpoint
+ALTER TABLE "github_work_unit_summary_attempts" DROP COLUMN "unit_revision";--> statement-breakpoint
+ALTER TABLE "github_work_unit_summary_attempts" ADD CONSTRAINT "gh_work_unit_summary_revisions" CHECK ("github_work_unit_summary_attempts"."revision" > 0 AND "github_work_unit_summary_attempts"."started_requests" BETWEEN 0 AND 2);--> statement-breakpoint
+ALTER TABLE "github_work_unit_summary_attempts" DROP CONSTRAINT "gh_work_unit_summary_started";--> statement-breakpoint
+ALTER TABLE "github_work_unit_summary_attempts" ADD CONSTRAINT "gh_work_unit_summary_started" CHECK (("github_work_unit_summary_attempts"."started_requests" = 0) = ("github_work_unit_summary_attempts"."last_started_at" IS NULL) AND ("github_work_unit_summary_attempts"."state" <> 'pending' OR "github_work_unit_summary_attempts"."request_payload" IS NOT NULL));--> statement-breakpoint
+UPDATE "github_commits"
+SET "author_user_id" = CASE "author_login"
+  WHEN 'f0rr0' THEN '8574219'
+  WHEN 'yuppiestechdev' THEN '99666891'
+END
+WHERE "author_user_id" IS NULL
+  AND "author_login" IN ('f0rr0', 'yuppiestechdev');--> statement-breakpoint
+ALTER TABLE "github_commits" ADD COLUMN "file_facts_digest" varchar(64) GENERATED ALWAYS AS (CASE WHEN "file_facts" IS NULL THEN NULL ELSE encode(sha256(jsonb_send("file_facts")), 'hex') END) STORED;--> statement-breakpoint
+ALTER TABLE "github_public_feed_head" ADD COLUMN "projection_request_token" uuid;--> statement-breakpoint
+ALTER TABLE "github_public_feed_head" ADD COLUMN "summary_policy_digest" varchar(64);--> statement-breakpoint
+UPDATE "github_public_feed_head" SET "projection_request_token" = gen_random_uuid();--> statement-breakpoint
+ALTER TABLE "github_pull_request_versions" ADD COLUMN "file_facts_digest" varchar(64) GENERATED ALWAYS AS (CASE WHEN "file_facts" IS NULL THEN NULL ELSE encode(sha256(jsonb_send("file_facts")), 'hex') END) STORED;--> statement-breakpoint
+ALTER TABLE "github_work_units" ADD COLUMN "summary_evaluation_digest" varchar(64);--> statement-breakpoint
+ALTER TABLE "github_work_units" ADD COLUMN "summary_evaluated_digest" varchar(64);--> statement-breakpoint
+ALTER TABLE "github_work_units" ADD CONSTRAINT "gh_work_units_digest_shapes" CHECK ("github_work_units"."facts_digest" ~ '^[a-f0-9]{64}$' AND "github_work_units"."membership_digest" ~ '^[a-f0-9]{64}$' AND ("github_work_units"."outcome_digest" IS NULL OR "github_work_units"."outcome_digest" ~ '^[a-f0-9]{64}$') AND ("github_work_units"."summary_evaluation_digest" IS NULL OR "github_work_units"."summary_evaluation_digest" ~ '^[a-f0-9]{64}$') AND ("github_work_units"."summary_evaluated_digest" IS NULL OR "github_work_units"."summary_evaluated_digest" ~ '^[a-f0-9]{64}$') AND ("github_work_units"."summary_input_digest" IS NULL OR "github_work_units"."summary_input_digest" ~ '^[a-f0-9]{64}$'));--> statement-breakpoint
+ALTER TABLE "github_public_feed_head" ADD CONSTRAINT "gh_public_feed_head_summary_policy_digest" CHECK ("github_public_feed_head"."summary_policy_digest" IS NULL OR "github_public_feed_head"."summary_policy_digest" ~ '^[a-f0-9]{64}$');

--- a/drizzle/meta/0016_snapshot.json
+++ b/drizzle/meta/0016_snapshot.json
@@ -1,0 +1,3643 @@
+{
+  "id": "31383d79-7e1f-48fb-b00e-1713698aa9ac",
+  "prevId": "7947f6d0-536d-43bb-847e-e5d8865cfec1",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.github_account_checkpoints": {
+      "name": "github_account_checkpoints",
+      "schema": "",
+      "columns": {
+        "account": {
+          "name": "account",
+          "type": "varchar(39)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "events_etag": {
+          "name": "events_etag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "events_last_attempted_at": {
+          "name": "events_last_attempted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "events_last_succeeded_at": {
+          "name": "events_last_succeeded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "events_next_poll_at": {
+          "name": "events_next_poll_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gap_detected_at": {
+          "name": "gap_detected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gap_expected_event_id": {
+          "name": "gap_expected_event_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gap_oldest_available_event_id": {
+          "name": "gap_oldest_available_event_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gap_state": {
+          "name": "gap_state",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'clear'"
+        },
+        "latest_event_id": {
+          "name": "latest_event_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "paused": {
+          "name": "paused",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "pull_request_backfill_digest": {
+          "name": "pull_request_backfill_digest",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "head_ref_cursor_repository_id": {
+          "name": "head_ref_cursor_repository_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "head_ref_cycle_started_at": {
+          "name": "head_ref_cycle_started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "head_ref_last_attempted_at": {
+          "name": "head_ref_last_attempted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "head_ref_last_succeeded_at": {
+          "name": "head_ref_last_succeeded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "head_ref_lease_token": {
+          "name": "head_ref_lease_token",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "head_ref_lease_until": {
+          "name": "head_ref_lease_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "head_ref_next_page": {
+          "name": "head_ref_next_page",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "head_ref_scan_started_at": {
+          "name": "head_ref_scan_started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ref_backfill_since_at": {
+          "name": "ref_backfill_since_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "tag_ref_cursor_repository_id": {
+          "name": "tag_ref_cursor_repository_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tag_ref_cycle_started_at": {
+          "name": "tag_ref_cycle_started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tag_ref_last_attempted_at": {
+          "name": "tag_ref_last_attempted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tag_ref_last_succeeded_at": {
+          "name": "tag_ref_last_succeeded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tag_ref_lease_token": {
+          "name": "tag_ref_lease_token",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tag_ref_lease_until": {
+          "name": "tag_ref_lease_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tag_ref_next_page": {
+          "name": "tag_ref_next_page",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tag_ref_scan_started_at": {
+          "name": "tag_ref_scan_started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "github_account_checkpoints_tracked_account": {
+          "name": "github_account_checkpoints_tracked_account",
+          "value": "\"github_account_checkpoints\".\"account\" IN ('f0rr0', 'yuppiestechdev')"
+        },
+        "github_account_checkpoints_event_id_shape": {
+          "name": "github_account_checkpoints_event_id_shape",
+          "value": "(\"github_account_checkpoints\".\"latest_event_id\" IS NULL OR \"github_account_checkpoints\".\"latest_event_id\" ~ '^[0-9]{1,64}$') AND (\"github_account_checkpoints\".\"gap_expected_event_id\" IS NULL OR \"github_account_checkpoints\".\"gap_expected_event_id\" ~ '^[0-9]{1,64}$') AND (\"github_account_checkpoints\".\"gap_oldest_available_event_id\" IS NULL OR \"github_account_checkpoints\".\"gap_oldest_available_event_id\" ~ '^[0-9]{1,64}$')"
+        },
+        "github_account_checkpoints_gap_state": {
+          "name": "github_account_checkpoints_gap_state",
+          "value": "\"github_account_checkpoints\".\"gap_state\" IN ('clear', 'detected')"
+        },
+        "github_account_checkpoints_gap_details": {
+          "name": "github_account_checkpoints_gap_details",
+          "value": "(\"github_account_checkpoints\".\"gap_state\" = 'detected' AND \"github_account_checkpoints\".\"gap_detected_at\" IS NOT NULL) OR (\"github_account_checkpoints\".\"gap_state\" = 'clear' AND \"github_account_checkpoints\".\"gap_detected_at\" IS NULL AND \"github_account_checkpoints\".\"gap_expected_event_id\" IS NULL AND \"github_account_checkpoints\".\"gap_oldest_available_event_id\" IS NULL)"
+        },
+        "github_account_checkpoints_ref_cursor_shape": {
+          "name": "github_account_checkpoints_ref_cursor_shape",
+          "value": "(\"github_account_checkpoints\".\"head_ref_cursor_repository_id\" IS NULL OR \"github_account_checkpoints\".\"head_ref_cursor_repository_id\" ~ '^[0-9]{1,32}$') AND (\"github_account_checkpoints\".\"tag_ref_cursor_repository_id\" IS NULL OR \"github_account_checkpoints\".\"tag_ref_cursor_repository_id\" ~ '^[0-9]{1,32}$')"
+        },
+        "github_account_checkpoints_ref_leases": {
+          "name": "github_account_checkpoints_ref_leases",
+          "value": "(\"github_account_checkpoints\".\"head_ref_lease_token\" IS NULL) = (\"github_account_checkpoints\".\"head_ref_lease_until\" IS NULL) AND (\"github_account_checkpoints\".\"tag_ref_lease_token\" IS NULL) = (\"github_account_checkpoints\".\"tag_ref_lease_until\" IS NULL)"
+        },
+        "github_account_checkpoints_ref_scans": {
+          "name": "github_account_checkpoints_ref_scans",
+          "value": "(\"github_account_checkpoints\".\"head_ref_next_page\" IS NULL AND \"github_account_checkpoints\".\"head_ref_scan_started_at\" IS NULL OR \"github_account_checkpoints\".\"head_ref_next_page\" >= 2 AND \"github_account_checkpoints\".\"head_ref_scan_started_at\" IS NOT NULL) AND (\"github_account_checkpoints\".\"tag_ref_next_page\" IS NULL AND \"github_account_checkpoints\".\"tag_ref_scan_started_at\" IS NULL OR \"github_account_checkpoints\".\"tag_ref_next_page\" >= 2 AND \"github_account_checkpoints\".\"tag_ref_scan_started_at\" IS NOT NULL)"
+        },
+        "github_account_checkpoints_pr_backfill_digest": {
+          "name": "github_account_checkpoints_pr_backfill_digest",
+          "value": "\"github_account_checkpoints\".\"pull_request_backfill_digest\" IS NULL OR \"github_account_checkpoints\".\"pull_request_backfill_digest\" ~ '^[a-f0-9]{64}$'"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.github_account_repository_catalogs": {
+      "name": "github_account_repository_catalogs",
+      "schema": "",
+      "columns": {
+        "account_user_id": {
+          "name": "account_user_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active_access": {
+          "name": "active_access",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "inventory_generation": {
+          "name": "inventory_generation",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "observed_at": {
+          "name": "observed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "gh_account_repo_catalogs_current_idx": {
+          "name": "gh_account_repo_catalogs_current_idx",
+          "columns": [
+            {
+              "expression": "account_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "inventory_generation",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "active_access",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gh_account_repo_catalogs_account_fk": {
+          "name": "gh_account_repo_catalogs_account_fk",
+          "tableFrom": "github_account_repository_catalogs",
+          "tableTo": "github_repository_inventory_heads",
+          "columnsFrom": ["account_user_id"],
+          "columnsTo": ["account_user_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gh_account_repo_catalogs_repository_fk": {
+          "name": "gh_account_repo_catalogs_repository_fk",
+          "tableFrom": "github_account_repository_catalogs",
+          "tableTo": "github_repositories",
+          "columnsFrom": ["repository_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "gh_account_repo_catalogs_pk": {
+          "name": "gh_account_repo_catalogs_pk",
+          "columns": ["account_user_id", "repository_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "gh_account_repo_catalogs_generation": {
+          "name": "gh_account_repo_catalogs_generation",
+          "value": "\"github_account_repository_catalogs\".\"inventory_generation\" > 0"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.github_commit_pull_request_associations": {
+      "name": "github_commit_pull_request_associations",
+      "schema": "",
+      "columns": {
+        "commit_repository_id": {
+          "name": "commit_repository_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "commit_sha": {
+          "name": "commit_sha",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pull_request_node_id": {
+          "name": "pull_request_node_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "gh_commit_pr_associations_commit_fk": {
+          "name": "gh_commit_pr_associations_commit_fk",
+          "tableFrom": "github_commit_pull_request_associations",
+          "tableTo": "github_commits",
+          "columnsFrom": ["commit_repository_id", "commit_sha"],
+          "columnsTo": ["repository_id", "sha"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gh_commit_pr_associations_pr_fk": {
+          "name": "gh_commit_pr_associations_pr_fk",
+          "tableFrom": "github_commit_pull_request_associations",
+          "tableTo": "github_pull_requests",
+          "columnsFrom": ["pull_request_node_id"],
+          "columnsTo": ["node_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "gh_commit_pr_associations_pk": {
+          "name": "gh_commit_pr_associations_pk",
+          "columns": [
+            "commit_repository_id",
+            "commit_sha",
+            "pull_request_node_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "gh_commit_pr_associations_sha_shape": {
+          "name": "gh_commit_pr_associations_sha_shape",
+          "value": "\"github_commit_pull_request_associations\".\"commit_sha\" ~ '^[a-f0-9]{40}$'"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.github_commits": {
+      "name": "github_commits",
+      "schema": "",
+      "columns": {
+        "additions": {
+          "name": "additions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_login": {
+          "name": "author_login",
+          "type": "varchar(39)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "authored_at": {
+          "name": "authored_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_user_id": {
+          "name": "author_user_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "changed_files": {
+          "name": "changed_files",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "committed_at": {
+          "name": "committed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "committer_at": {
+          "name": "committer_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "committer_user_id": {
+          "name": "committer_user_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deletions": {
+          "name": "deletions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enrichment_error": {
+          "name": "enrichment_error",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enrichment_attempts": {
+          "name": "enrichment_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "enrichment_lease_token": {
+          "name": "enrichment_lease_token",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enrichment_lease_until": {
+          "name": "enrichment_lease_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enrichment_state": {
+          "name": "enrichment_state",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "file_facts": {
+          "name": "file_facts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_facts_digest": {
+          "name": "file_facts_digest",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "CASE WHEN \"file_facts\" IS NULL THEN NULL ELSE encode(sha256(jsonb_send(\"file_facts\")), 'hex') END",
+            "type": "stored"
+          }
+        },
+        "file_facts_complete": {
+          "name": "file_facts_complete",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "first_observed_at": {
+          "name": "first_observed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_shas": {
+          "name": "parent_shas",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_file_cap_reached": {
+          "name": "provider_file_cap_reached",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "pr_discovery_error": {
+          "name": "pr_discovery_error",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_discovery_attempts": {
+          "name": "pr_discovery_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "pr_discovery_lease_token": {
+          "name": "pr_discovery_lease_token",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_discovery_lease_until": {
+          "name": "pr_discovery_lease_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_discovery_state": {
+          "name": "pr_discovery_state",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sha": {
+          "name": "sha",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "github_commits_committed_at_idx": {
+          "name": "github_commits_committed_at_idx",
+          "columns": [
+            {
+              "expression": "committed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_commits_enrichment_pending_idx": {
+          "name": "github_commits_enrichment_pending_idx",
+          "columns": [
+            {
+              "expression": "enrichment_state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "enrichment_lease_until",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "committed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_commits_pr_discovery_pending_idx": {
+          "name": "github_commits_pr_discovery_pending_idx",
+          "columns": [
+            {
+              "expression": "pr_discovery_state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pr_discovery_lease_until",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "first_observed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_commits_repository_fk": {
+          "name": "github_commits_repository_fk",
+          "tableFrom": "github_commits",
+          "tableTo": "github_repositories",
+          "columnsFrom": ["repository_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "github_commits_repository_id_sha_pk": {
+          "name": "github_commits_repository_id_sha_pk",
+          "columns": ["repository_id", "sha"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "github_commits_sha_shape": {
+          "name": "github_commits_sha_shape",
+          "value": "\"github_commits\".\"sha\" ~ '^[a-f0-9]{40}$'"
+        },
+        "github_commits_parent_shas_array": {
+          "name": "github_commits_parent_shas_array",
+          "value": "\"github_commits\".\"parent_shas\" IS NULL OR jsonb_typeof(\"github_commits\".\"parent_shas\") = 'array'"
+        },
+        "github_commits_file_facts_array": {
+          "name": "github_commits_file_facts_array",
+          "value": "\"github_commits\".\"file_facts\" IS NULL OR jsonb_typeof(\"github_commits\".\"file_facts\") = 'array'"
+        },
+        "github_commits_file_facts_completeness": {
+          "name": "github_commits_file_facts_completeness",
+          "value": "NOT \"github_commits\".\"file_facts_complete\" OR (\"github_commits\".\"file_facts\" IS NOT NULL AND NOT \"github_commits\".\"provider_file_cap_reached\")"
+        },
+        "github_commits_enrichment_state": {
+          "name": "github_commits_enrichment_state",
+          "value": "\"github_commits\".\"enrichment_state\" IN ('pending', 'processing', 'complete', 'unavailable')"
+        },
+        "github_commits_enrichment_lease": {
+          "name": "github_commits_enrichment_lease",
+          "value": "(\"github_commits\".\"enrichment_state\" = 'processing') = (\"github_commits\".\"enrichment_lease_token\" IS NOT NULL) AND (\"github_commits\".\"enrichment_state\" <> 'processing' OR \"github_commits\".\"enrichment_lease_until\" IS NOT NULL) AND (\"github_commits\".\"enrichment_state\" NOT IN ('complete', 'unavailable') OR \"github_commits\".\"enrichment_lease_until\" IS NULL)"
+        },
+        "github_commits_pr_discovery_state": {
+          "name": "github_commits_pr_discovery_state",
+          "value": "\"github_commits\".\"pr_discovery_state\" IN ('pending', 'processing', 'complete', 'unavailable')"
+        },
+        "github_commits_pr_discovery_lease": {
+          "name": "github_commits_pr_discovery_lease",
+          "value": "(\"github_commits\".\"pr_discovery_state\" = 'processing') = (\"github_commits\".\"pr_discovery_lease_token\" IS NOT NULL) AND (\"github_commits\".\"pr_discovery_state\" <> 'processing' OR \"github_commits\".\"pr_discovery_lease_until\" IS NOT NULL) AND (\"github_commits\".\"pr_discovery_state\" NOT IN ('complete', 'unavailable') OR \"github_commits\".\"pr_discovery_lease_until\" IS NULL)"
+        },
+        "github_commits_tracked_author": {
+          "name": "github_commits_tracked_author",
+          "value": "\"github_commits\".\"author_login\" IN ('f0rr0', 'yuppiestechdev')"
+        },
+        "github_commits_nonnegative_activity_counts": {
+          "name": "github_commits_nonnegative_activity_counts",
+          "value": "(\"github_commits\".\"changed_files\" IS NULL OR \"github_commits\".\"changed_files\" >= 0) AND (\"github_commits\".\"additions\" IS NULL OR \"github_commits\".\"additions\" >= 0) AND (\"github_commits\".\"deletions\" IS NULL OR \"github_commits\".\"deletions\" >= 0)"
+        },
+        "github_commits_nonnegative_attempts": {
+          "name": "github_commits_nonnegative_attempts",
+          "value": "\"github_commits\".\"enrichment_attempts\" >= 0 AND \"github_commits\".\"pr_discovery_attempts\" >= 0"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.github_issues": {
+      "name": "github_issues",
+      "schema": "",
+      "columns": {
+        "account": {
+          "name": "account",
+          "type": "varchar(39)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_login": {
+          "name": "author_login",
+          "type": "varchar(39)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_user_id": {
+          "name": "author_user_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_observed_at": {
+          "name": "first_observed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "varchar(128)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "number": {
+          "name": "number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title_snapshot": {
+          "name": "title_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url_snapshot": {
+          "name": "url_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "github_issues_repository_number_unique": {
+          "name": "github_issues_repository_number_unique",
+          "columns": [
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_issues_author_idx": {
+          "name": "github_issues_author_idx",
+          "columns": [
+            {
+              "expression": "author_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_issues_repository_id_github_repositories_id_fk": {
+          "name": "github_issues_repository_id_github_repositories_id_fk",
+          "tableFrom": "github_issues",
+          "tableTo": "github_repositories",
+          "columnsFrom": ["repository_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "github_issues_tracked_account": {
+          "name": "github_issues_tracked_account",
+          "value": "\"github_issues\".\"account\" IN ('f0rr0', 'yuppiestechdev')"
+        },
+        "github_issues_positive_number": {
+          "name": "github_issues_positive_number",
+          "value": "\"github_issues\".\"number\" > 0"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.github_public_feed_head": {
+      "name": "github_public_feed_head",
+      "schema": "",
+      "columns": {
+        "feed_revision": {
+          "name": "feed_revision",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "head_content_revision": {
+          "name": "head_content_revision",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "id": {
+          "name": "id",
+          "type": "boolean",
+          "primaryKey": true,
+          "notNull": true,
+          "default": true
+        },
+        "last_published_at": {
+          "name": "last_published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ordering_revision": {
+          "name": "ordering_revision",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "projection_request_token": {
+          "name": "projection_request_token",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary_policy_digest": {
+          "name": "summary_policy_digest",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summarizing": {
+          "name": "summarizing",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "gh_public_feed_head_singleton": {
+          "name": "gh_public_feed_head_singleton",
+          "value": "\"github_public_feed_head\".\"id\""
+        },
+        "gh_public_feed_head_revisions": {
+          "name": "gh_public_feed_head_revisions",
+          "value": "\"github_public_feed_head\".\"feed_revision\" >= 0 AND \"github_public_feed_head\".\"head_content_revision\" >= 0 AND \"github_public_feed_head\".\"ordering_revision\" >= 0"
+        },
+        "gh_public_feed_head_summary_policy_digest": {
+          "name": "gh_public_feed_head_summary_policy_digest",
+          "value": "\"github_public_feed_head\".\"summary_policy_digest\" IS NULL OR \"github_public_feed_head\".\"summary_policy_digest\" ~ '^[a-f0-9]{64}$'"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.github_pull_request_memberships": {
+      "name": "github_pull_request_memberships",
+      "schema": "",
+      "columns": {
+        "commit_repository_id": {
+          "name": "commit_repository_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "commit_sha": {
+          "name": "commit_sha",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_head": {
+          "name": "is_head",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version_id": {
+          "name": "version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "github_pull_request_memberships_position_unique": {
+          "name": "github_pull_request_memberships_position_unique",
+          "columns": [
+            {
+              "expression": "version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_pull_request_memberships_commit_lookup_idx": {
+          "name": "github_pull_request_memberships_commit_lookup_idx",
+          "columns": [
+            {
+              "expression": "commit_repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "commit_sha",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gh_pr_memberships_version_fk": {
+          "name": "gh_pr_memberships_version_fk",
+          "tableFrom": "github_pull_request_memberships",
+          "tableTo": "github_pull_request_versions",
+          "columnsFrom": ["version_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "gh_pr_memberships_pk": {
+          "name": "gh_pr_memberships_pk",
+          "columns": ["version_id", "commit_repository_id", "commit_sha"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "github_pull_request_memberships_sha_shape": {
+          "name": "github_pull_request_memberships_sha_shape",
+          "value": "\"github_pull_request_memberships\".\"commit_sha\" ~ '^[a-f0-9]{40}$'"
+        },
+        "github_pull_request_memberships_nonnegative_position": {
+          "name": "github_pull_request_memberships_nonnegative_position",
+          "value": "\"github_pull_request_memberships\".\"position\" >= 0"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.github_pull_request_signals": {
+      "name": "github_pull_request_signals",
+      "schema": "",
+      "columns": {
+        "account": {
+          "name": "account",
+          "type": "varchar(39)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "lease_token": {
+          "name": "lease_token",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lease_until": {
+          "name": "lease_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "number": {
+          "name": "number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "observed_at": {
+          "name": "observed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository_name_snapshot": {
+          "name": "repository_name_snapshot",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        }
+      },
+      "indexes": {
+        "github_pull_request_signals_event_unique": {
+          "name": "github_pull_request_signals_event_unique",
+          "columns": [
+            {
+              "expression": "account",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_pull_request_signals_pending_idx": {
+          "name": "github_pull_request_signals_pending_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lease_until",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "observed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "github_pull_request_signals_account": {
+          "name": "github_pull_request_signals_account",
+          "value": "\"github_pull_request_signals\".\"account\" IN ('f0rr0', 'yuppiestechdev')"
+        },
+        "github_pull_request_signals_event_id": {
+          "name": "github_pull_request_signals_event_id",
+          "value": "\"github_pull_request_signals\".\"event_id\" ~ '^[0-9]{1,64}$'"
+        },
+        "github_pull_request_signals_repository_id": {
+          "name": "github_pull_request_signals_repository_id",
+          "value": "\"github_pull_request_signals\".\"repository_id\" ~ '^[0-9]{1,32}$'"
+        },
+        "github_pull_request_signals_state": {
+          "name": "github_pull_request_signals_state",
+          "value": "\"github_pull_request_signals\".\"state\" IN ('pending', 'processing', 'complete', 'unavailable')"
+        },
+        "github_pull_request_signals_lease": {
+          "name": "github_pull_request_signals_lease",
+          "value": "(\"github_pull_request_signals\".\"state\" = 'processing') = (\"github_pull_request_signals\".\"lease_token\" IS NOT NULL) AND (\"github_pull_request_signals\".\"state\" <> 'processing' OR \"github_pull_request_signals\".\"lease_until\" IS NOT NULL)"
+        },
+        "github_pull_request_signals_values": {
+          "name": "github_pull_request_signals_values",
+          "value": "\"github_pull_request_signals\".\"number\" > 0 AND \"github_pull_request_signals\".\"attempt_count\" >= 0"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.github_pull_request_versions": {
+      "name": "github_pull_request_versions",
+      "schema": "",
+      "columns": {
+        "base_ref_name": {
+          "name": "base_ref_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_repository_id": {
+          "name": "base_repository_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_sha": {
+          "name": "base_sha",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "commit_count": {
+          "name": "commit_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_facts": {
+          "name": "file_facts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_facts_digest": {
+          "name": "file_facts_digest",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "CASE WHEN \"file_facts\" IS NULL THEN NULL ELSE encode(sha256(jsonb_send(\"file_facts\")), 'hex') END",
+            "type": "stored"
+          }
+        },
+        "file_facts_complete": {
+          "name": "file_facts_complete",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "head_ref_name": {
+          "name": "head_ref_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "head_repository_id": {
+          "name": "head_repository_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "head_sha": {
+          "name": "head_sha",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "is_current": {
+          "name": "is_current",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "membership_complete": {
+          "name": "membership_complete",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "merge_snapshot": {
+          "name": "merge_snapshot",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "observed_at": {
+          "name": "observed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "provider_updated_at": {
+          "name": "provider_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pull_request_node_id": {
+          "name": "pull_request_node_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "github_pull_request_versions_head_unique": {
+          "name": "github_pull_request_versions_head_unique",
+          "columns": [
+            {
+              "expression": "pull_request_node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "head_sha",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_pull_request_versions_current_unique": {
+          "name": "github_pull_request_versions_current_unique",
+          "columns": [
+            {
+              "expression": "pull_request_node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"github_pull_request_versions\".\"is_current\"",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gh_pr_versions_pull_request_fk": {
+          "name": "gh_pr_versions_pull_request_fk",
+          "tableFrom": "github_pull_request_versions",
+          "tableTo": "github_pull_requests",
+          "columnsFrom": ["pull_request_node_id"],
+          "columnsTo": ["node_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "github_pull_request_versions_sha_shapes": {
+          "name": "github_pull_request_versions_sha_shapes",
+          "value": "\"github_pull_request_versions\".\"base_sha\" ~ '^[a-f0-9]{40}$' AND \"github_pull_request_versions\".\"head_sha\" ~ '^[a-f0-9]{40}$'"
+        },
+        "github_pull_request_versions_nonnegative_count": {
+          "name": "github_pull_request_versions_nonnegative_count",
+          "value": "\"github_pull_request_versions\".\"commit_count\" IS NULL OR \"github_pull_request_versions\".\"commit_count\" >= 0"
+        },
+        "github_pull_request_versions_file_facts_array": {
+          "name": "github_pull_request_versions_file_facts_array",
+          "value": "\"github_pull_request_versions\".\"file_facts\" IS NULL OR jsonb_typeof(\"github_pull_request_versions\".\"file_facts\") = 'array'"
+        },
+        "github_pull_request_versions_file_facts_complete": {
+          "name": "github_pull_request_versions_file_facts_complete",
+          "value": "NOT \"github_pull_request_versions\".\"file_facts_complete\" OR \"github_pull_request_versions\".\"file_facts\" IS NOT NULL"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.github_pull_requests": {
+      "name": "github_pull_requests",
+      "schema": "",
+      "columns": {
+        "account": {
+          "name": "account",
+          "type": "varchar(39)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "additions": {
+          "name": "additions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_login": {
+          "name": "author_login",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_user_id": {
+          "name": "author_user_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "base_ref_name": {
+          "name": "base_ref_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_repository_id": {
+          "name": "base_repository_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_sha": {
+          "name": "base_sha",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body_snapshot": {
+          "name": "body_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "changed_files": {
+          "name": "changed_files",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commit_count": {
+          "name": "commit_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deletions": {
+          "name": "deletions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "draft": {
+          "name": "draft",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "first_observed_at": {
+          "name": "first_observed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "head_ref_name": {
+          "name": "head_ref_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "head_repository_id": {
+          "name": "head_repository_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "head_sha": {
+          "name": "head_sha",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_reconciled_at": {
+          "name": "last_reconciled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "merged_at": {
+          "name": "merged_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "merge_sha": {
+          "name": "merge_sha",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "merge_sha_verified_at": {
+          "name": "merge_sha_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_reconcile_at": {
+          "name": "next_reconcile_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "varchar(128)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "number": {
+          "name": "number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_updated_at": {
+          "name": "provider_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reconcile_attempts": {
+          "name": "reconcile_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reconcile_error": {
+          "name": "reconcile_error",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "terminal_at": {
+          "name": "terminal_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title_snapshot": {
+          "name": "title_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "github_pull_requests_repository_number_unique": {
+          "name": "github_pull_requests_repository_number_unique",
+          "columns": [
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_pull_requests_reconciliation_idx": {
+          "name": "github_pull_requests_reconciliation_idx",
+          "columns": [
+            {
+              "expression": "account",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_reconcile_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_pull_requests_author_idx": {
+          "name": "github_pull_requests_author_idx",
+          "columns": [
+            {
+              "expression": "author_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_pull_requests_repository_id_github_repositories_id_fk": {
+          "name": "github_pull_requests_repository_id_github_repositories_id_fk",
+          "tableFrom": "github_pull_requests",
+          "tableTo": "github_repositories",
+          "columnsFrom": ["repository_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "github_pull_requests_tracked_account": {
+          "name": "github_pull_requests_tracked_account",
+          "value": "\"github_pull_requests\".\"account\" IN ('f0rr0', 'yuppiestechdev')"
+        },
+        "github_pull_requests_state": {
+          "name": "github_pull_requests_state",
+          "value": "\"github_pull_requests\".\"state\" IN ('open', 'closed', 'merged')"
+        },
+        "github_pull_requests_terminal_state": {
+          "name": "github_pull_requests_terminal_state",
+          "value": "(\"github_pull_requests\".\"state\" = 'open' AND \"github_pull_requests\".\"terminal_at\" IS NULL) OR (\"github_pull_requests\".\"state\" IN ('closed', 'merged') AND \"github_pull_requests\".\"terminal_at\" IS NOT NULL)"
+        },
+        "github_pull_requests_merged_state": {
+          "name": "github_pull_requests_merged_state",
+          "value": "(\"github_pull_requests\".\"state\" = 'merged') = (\"github_pull_requests\".\"merged_at\" IS NOT NULL)"
+        },
+        "github_pull_requests_sha_shapes": {
+          "name": "github_pull_requests_sha_shapes",
+          "value": "(\"github_pull_requests\".\"base_sha\" IS NULL OR \"github_pull_requests\".\"base_sha\" ~ '^[a-f0-9]{40}$') AND (\"github_pull_requests\".\"head_sha\" IS NULL OR \"github_pull_requests\".\"head_sha\" ~ '^[a-f0-9]{40}$') AND (\"github_pull_requests\".\"merge_sha\" IS NULL OR \"github_pull_requests\".\"merge_sha\" ~ '^[a-f0-9]{40}$')"
+        },
+        "github_pull_requests_verified_merge_sha": {
+          "name": "github_pull_requests_verified_merge_sha",
+          "value": "(\"github_pull_requests\".\"merge_sha\" IS NULL AND \"github_pull_requests\".\"merge_sha_verified_at\" IS NULL) OR (\"github_pull_requests\".\"state\" = 'merged' AND \"github_pull_requests\".\"merge_sha_verified_at\" IS NOT NULL)"
+        },
+        "github_pull_requests_positive_number": {
+          "name": "github_pull_requests_positive_number",
+          "value": "\"github_pull_requests\".\"number\" > 0"
+        },
+        "github_pull_requests_nonnegative_counts": {
+          "name": "github_pull_requests_nonnegative_counts",
+          "value": "(\"github_pull_requests\".\"changed_files\" IS NULL OR \"github_pull_requests\".\"changed_files\" >= 0) AND (\"github_pull_requests\".\"additions\" IS NULL OR \"github_pull_requests\".\"additions\" >= 0) AND (\"github_pull_requests\".\"deletions\" IS NULL OR \"github_pull_requests\".\"deletions\" >= 0) AND (\"github_pull_requests\".\"commit_count\" IS NULL OR \"github_pull_requests\".\"commit_count\" >= 0)"
+        },
+        "github_pull_requests_nonnegative_attempts": {
+          "name": "github_pull_requests_nonnegative_attempts",
+          "value": "\"github_pull_requests\".\"reconcile_attempts\" >= 0"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.github_push_observation_commits": {
+      "name": "github_push_observation_commits",
+      "schema": "",
+      "columns": {
+        "observation_id": {
+          "name": "observation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sha": {
+          "name": "sha",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "github_push_observation_commits_position_unique": {
+          "name": "github_push_observation_commits_position_unique",
+          "columns": [
+            {
+              "expression": "observation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gh_push_observation_commits_observation_fk": {
+          "name": "gh_push_observation_commits_observation_fk",
+          "tableFrom": "github_push_observation_commits",
+          "tableTo": "github_push_observations",
+          "columnsFrom": ["observation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "gh_push_observation_commits_pk": {
+          "name": "gh_push_observation_commits_pk",
+          "columns": ["observation_id", "repository_id", "sha"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "github_push_observation_commits_sha_shape": {
+          "name": "github_push_observation_commits_sha_shape",
+          "value": "\"github_push_observation_commits\".\"sha\" ~ '^[a-f0-9]{40}$'"
+        },
+        "github_push_observation_commits_nonnegative_position": {
+          "name": "github_push_observation_commits_nonnegative_position",
+          "value": "\"github_push_observation_commits\".\"position\" >= 0"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.github_push_observations": {
+      "name": "github_push_observations",
+      "schema": "",
+      "columns": {
+        "account": {
+          "name": "account",
+          "type": "varchar(39)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "after_sha": {
+          "name": "after_sha",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "before_sha": {
+          "name": "before_sha",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expected_commit_count": {
+          "name": "expected_commit_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "history_since_at": {
+          "name": "history_since_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "history_until_at": {
+          "name": "history_until_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "lease_token": {
+          "name": "lease_token",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lease_until": {
+          "name": "lease_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "observed_at": {
+          "name": "observed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "provider_created_at": {
+          "name": "provider_created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ref_name": {
+          "name": "ref_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository_name_snapshot": {
+          "name": "repository_name_snapshot",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        }
+      },
+      "indexes": {
+        "github_push_observations_source_unique": {
+          "name": "github_push_observations_source_unique",
+          "columns": [
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_push_observations_push_unique": {
+          "name": "github_push_observations_push_unique",
+          "columns": [
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ref_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "before_sha",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "after_sha",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"github_push_observations\".\"source\" <> 'backfill'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_push_observations_pending_idx": {
+          "name": "github_push_observations_pending_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lease_until",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "observed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_push_observations_account_idx": {
+          "name": "github_push_observations_account_idx",
+          "columns": [
+            {
+              "expression": "account",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "observed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gh_push_observations_repository_fk": {
+          "name": "gh_push_observations_repository_fk",
+          "tableFrom": "github_push_observations",
+          "tableTo": "github_repositories",
+          "columnsFrom": ["repository_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "github_push_observations_tracked_account": {
+          "name": "github_push_observations_tracked_account",
+          "value": "\"github_push_observations\".\"account\" IN ('f0rr0', 'yuppiestechdev')"
+        },
+        "github_push_observations_source": {
+          "name": "github_push_observations_source",
+          "value": "\"github_push_observations\".\"source\" IN ('webhook', 'events', 'refs', 'backfill')"
+        },
+        "github_push_observations_sha_shape": {
+          "name": "github_push_observations_sha_shape",
+          "value": "\"github_push_observations\".\"before_sha\" ~ '^[a-f0-9]{40}$' AND \"github_push_observations\".\"after_sha\" ~ '^[a-f0-9]{40}$'"
+        },
+        "github_push_observations_nonnegative_count": {
+          "name": "github_push_observations_nonnegative_count",
+          "value": "\"github_push_observations\".\"attempt_count\" >= 0 AND (\"github_push_observations\".\"expected_commit_count\" IS NULL OR \"github_push_observations\".\"expected_commit_count\" >= 0)"
+        },
+        "github_push_observations_history_bounds": {
+          "name": "github_push_observations_history_bounds",
+          "value": "(\"github_push_observations\".\"source\" <> 'backfill' AND \"github_push_observations\".\"history_since_at\" IS NULL AND \"github_push_observations\".\"history_until_at\" IS NULL) OR (\"github_push_observations\".\"source\" = 'backfill' AND \"github_push_observations\".\"history_since_at\" IS NOT NULL AND \"github_push_observations\".\"history_until_at\" IS NOT NULL AND \"github_push_observations\".\"history_since_at\" <= \"github_push_observations\".\"history_until_at\" AND \"github_push_observations\".\"expected_commit_count\" IS NULL AND \"github_push_observations\".\"before_sha\" = repeat('0', 40))"
+        },
+        "github_push_observations_state": {
+          "name": "github_push_observations_state",
+          "value": "\"github_push_observations\".\"state\" IN ('pending', 'processing', 'complete', 'deferred', 'unavailable')"
+        },
+        "github_push_observations_lease": {
+          "name": "github_push_observations_lease",
+          "value": "(\"github_push_observations\".\"state\" = 'processing') = (\"github_push_observations\".\"lease_token\" IS NOT NULL) AND (\"github_push_observations\".\"state\" <> 'processing' OR \"github_push_observations\".\"lease_until\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.github_ref_generations": {
+      "name": "github_ref_generations",
+      "schema": "",
+      "columns": {
+        "branch_lineage_id": {
+          "name": "branch_lineage_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "coverage_since_at": {
+          "name": "coverage_since_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generation": {
+          "name": "generation",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "head_sha": {
+          "name": "head_sha",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ref_name": {
+          "name": "ref_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "gh_ref_generations_lineage_idx": {
+          "name": "gh_ref_generations_lineage_idx",
+          "columns": [
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "branch_lineage_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gh_ref_generations_repository_fk": {
+          "name": "gh_ref_generations_repository_fk",
+          "tableFrom": "github_ref_generations",
+          "tableTo": "github_repositories",
+          "columnsFrom": ["repository_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "gh_ref_generations_pk": {
+          "name": "gh_ref_generations_pk",
+          "columns": ["repository_id", "ref_name"]
+        }
+      },
+      "uniqueConstraints": {
+        "gh_ref_generations_version_unique": {
+          "name": "gh_ref_generations_version_unique",
+          "nullsNotDistinct": false,
+          "columns": ["repository_id", "ref_name", "generation"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "gh_ref_generations_head_name": {
+          "name": "gh_ref_generations_head_name",
+          "value": "\"github_ref_generations\".\"ref_name\" LIKE 'refs/heads/%'"
+        },
+        "gh_ref_generations_sha_shape": {
+          "name": "gh_ref_generations_sha_shape",
+          "value": "\"github_ref_generations\".\"head_sha\" ~ '^[a-f0-9]{40}$'"
+        },
+        "gh_ref_generations_positive": {
+          "name": "gh_ref_generations_positive",
+          "value": "\"github_ref_generations\".\"generation\" > 0"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.github_ref_memberships": {
+      "name": "github_ref_memberships",
+      "schema": "",
+      "columns": {
+        "commit_repository_id": {
+          "name": "commit_repository_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "commit_sha": {
+          "name": "commit_sha",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generation": {
+          "name": "generation",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ref_name": {
+          "name": "ref_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "gh_ref_memberships_position_unique": {
+          "name": "gh_ref_memberships_position_unique",
+          "columns": [
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ref_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "gh_ref_memberships_commit_idx": {
+          "name": "gh_ref_memberships_commit_idx",
+          "columns": [
+            {
+              "expression": "commit_repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "commit_sha",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gh_ref_memberships_generation_fk": {
+          "name": "gh_ref_memberships_generation_fk",
+          "tableFrom": "github_ref_memberships",
+          "tableTo": "github_ref_generations",
+          "columnsFrom": ["repository_id", "ref_name", "generation"],
+          "columnsTo": ["repository_id", "ref_name", "generation"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gh_ref_memberships_commit_fk": {
+          "name": "gh_ref_memberships_commit_fk",
+          "tableFrom": "github_ref_memberships",
+          "tableTo": "github_commits",
+          "columnsFrom": ["commit_repository_id", "commit_sha"],
+          "columnsTo": ["repository_id", "sha"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "gh_ref_memberships_pk": {
+          "name": "gh_ref_memberships_pk",
+          "columns": [
+            "repository_id",
+            "ref_name",
+            "commit_repository_id",
+            "commit_sha"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "gh_ref_memberships_values": {
+          "name": "gh_ref_memberships_values",
+          "value": "\"github_ref_memberships\".\"generation\" > 0 AND \"github_ref_memberships\".\"position\" >= 0 AND \"github_ref_memberships\".\"commit_sha\" ~ '^[a-f0-9]{40}$'"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.github_repositories": {
+      "name": "github_repositories",
+      "schema": "",
+      "columns": {
+        "default_branch": {
+          "name": "default_branch",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_observed_at": {
+          "name": "first_observed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "facts_verified_at": {
+          "name": "facts_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "inventory_verified_at": {
+          "name": "inventory_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "homepage_url": {
+          "name": "homepage_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "heads_last_reconciled_at": {
+          "name": "heads_last_reconciled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "html_url": {
+          "name": "html_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar(32)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "last_observed_at": {
+          "name": "last_observed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "owner_avatar_url": {
+          "name": "owner_avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_login": {
+          "name": "owner_login",
+          "type": "varchar(39)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_type": {
+          "name": "owner_type",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pushed_at": {
+          "name": "pushed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "topics": {
+          "name": "topics",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags_last_reconciled_at": {
+          "name": "tags_last_reconciled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "github_repositories_full_name_idx": {
+          "name": "github_repositories_full_name_idx",
+          "columns": [
+            {
+              "expression": "full_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "github_repositories_full_name": {
+          "name": "github_repositories_full_name",
+          "value": "length(btrim(\"github_repositories\".\"full_name\")) > 0"
+        },
+        "github_repositories_owner_type": {
+          "name": "github_repositories_owner_type",
+          "value": "\"github_repositories\".\"owner_type\" IS NULL OR \"github_repositories\".\"owner_type\" IN ('Organization', 'User')"
+        },
+        "github_repositories_visibility": {
+          "name": "github_repositories_visibility",
+          "value": "\"github_repositories\".\"visibility\" IS NULL OR \"github_repositories\".\"visibility\" IN ('public', 'private', 'internal')"
+        },
+        "github_repositories_topics_array": {
+          "name": "github_repositories_topics_array",
+          "value": "\"github_repositories\".\"topics\" IS NULL OR jsonb_typeof(\"github_repositories\".\"topics\") = 'array'"
+        },
+        "github_repositories_observation_order": {
+          "name": "github_repositories_observation_order",
+          "value": "\"github_repositories\".\"last_observed_at\" >= \"github_repositories\".\"first_observed_at\""
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.github_repository_inventory_heads": {
+      "name": "github_repository_inventory_heads",
+      "schema": "",
+      "columns": {
+        "account_login": {
+          "name": "account_login",
+          "type": "varchar(39)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_user_id": {
+          "name": "account_user_id",
+          "type": "varchar(32)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "generation": {
+          "name": "generation",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "gh_repo_inventory_head_account_id": {
+          "name": "gh_repo_inventory_head_account_id",
+          "value": "\"github_repository_inventory_heads\".\"account_user_id\" ~ '^[0-9]{1,32}$'"
+        },
+        "gh_repo_inventory_head_generation": {
+          "name": "gh_repo_inventory_head_generation",
+          "value": "(\"github_repository_inventory_heads\".\"generation\" = 0 AND \"github_repository_inventory_heads\".\"completed_at\" IS NULL) OR (\"github_repository_inventory_heads\".\"generation\" > 0 AND \"github_repository_inventory_heads\".\"completed_at\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.github_repository_refs": {
+      "name": "github_repository_refs",
+      "schema": "",
+      "columns": {
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "branch_lineage_id": {
+          "name": "branch_lineage_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_observed_at": {
+          "name": "first_observed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "head_sha": {
+          "name": "head_sha",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_observed_at": {
+          "name": "last_observed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "projection_relevant": {
+          "name": "projection_relevant",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "ref_name": {
+          "name": "ref_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repair_attempts": {
+          "name": "repair_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "repair_error": {
+          "name": "repair_error",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repair_lease_token": {
+          "name": "repair_lease_token",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repair_lease_until": {
+          "name": "repair_lease_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "github_repository_refs_active_idx": {
+          "name": "github_repository_refs_active_idx",
+          "columns": [
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_repository_refs_projection_idx": {
+          "name": "github_repository_refs_projection_idx",
+          "columns": [
+            {
+              "expression": "projection_relevant",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_observed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_repository_refs_repository_fk": {
+          "name": "github_repository_refs_repository_fk",
+          "tableFrom": "github_repository_refs",
+          "tableTo": "github_repositories",
+          "columnsFrom": ["repository_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "github_repository_refs_repository_id_ref_name_pk": {
+          "name": "github_repository_refs_repository_id_ref_name_pk",
+          "columns": ["repository_id", "ref_name"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "github_repository_refs_kind": {
+          "name": "github_repository_refs_kind",
+          "value": "\"github_repository_refs\".\"kind\" IN ('head', 'tag')"
+        },
+        "github_repository_refs_name": {
+          "name": "github_repository_refs_name",
+          "value": "(\"github_repository_refs\".\"kind\" = 'head' AND \"github_repository_refs\".\"ref_name\" LIKE 'refs/heads/%') OR (\"github_repository_refs\".\"kind\" = 'tag' AND \"github_repository_refs\".\"ref_name\" LIKE 'refs/tags/%')"
+        },
+        "github_repository_refs_lineage": {
+          "name": "github_repository_refs_lineage",
+          "value": "(\"github_repository_refs\".\"kind\" = 'head') = (\"github_repository_refs\".\"branch_lineage_id\" IS NOT NULL)"
+        },
+        "github_repository_refs_projection_relevance": {
+          "name": "github_repository_refs_projection_relevance",
+          "value": "NOT \"github_repository_refs\".\"projection_relevant\" OR \"github_repository_refs\".\"kind\" = 'head'"
+        },
+        "github_repository_refs_sha_shape": {
+          "name": "github_repository_refs_sha_shape",
+          "value": "\"github_repository_refs\".\"head_sha\" ~ '^[a-f0-9]{40}$'"
+        },
+        "github_repository_refs_observation_order": {
+          "name": "github_repository_refs_observation_order",
+          "value": "\"github_repository_refs\".\"last_observed_at\" >= \"github_repository_refs\".\"first_observed_at\""
+        },
+        "github_repository_refs_repair_lease": {
+          "name": "github_repository_refs_repair_lease",
+          "value": "(\"github_repository_refs\".\"repair_lease_token\" IS NULL) = (\"github_repository_refs\".\"repair_lease_until\" IS NULL) AND (\"github_repository_refs\".\"repair_lease_token\" IS NULL OR \"github_repository_refs\".\"kind\" = 'head')"
+        },
+        "github_repository_refs_repair_attempts": {
+          "name": "github_repository_refs_repair_attempts",
+          "value": "\"github_repository_refs\".\"repair_attempts\" >= 0"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.github_webhook_deliveries": {
+      "name": "github_webhook_deliveries",
+      "schema": "",
+      "columns": {
+        "accepted": {
+          "name": "accepted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account": {
+          "name": "account",
+          "type": "varchar(39)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_id": {
+          "name": "delivery_id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event": {
+          "name": "event",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "observed_at": {
+          "name": "observed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "github_webhook_deliveries_audit_idx": {
+          "name": "github_webhook_deliveries_audit_idx",
+          "columns": [
+            {
+              "expression": "event",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "observed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "github_webhook_deliveries_id_shape": {
+          "name": "github_webhook_deliveries_id_shape",
+          "value": "\"github_webhook_deliveries\".\"delivery_id\" ~ '^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$'"
+        },
+        "github_webhook_deliveries_event_shape": {
+          "name": "github_webhook_deliveries_event_shape",
+          "value": "\"github_webhook_deliveries\".\"event\" ~ '^[a-z][a-z0-9_]{0,39}$'"
+        },
+        "github_webhook_deliveries_action_shape": {
+          "name": "github_webhook_deliveries_action_shape",
+          "value": "\"github_webhook_deliveries\".\"action\" IS NULL OR \"github_webhook_deliveries\".\"action\" ~ '^[a-z][a-z0-9_]{0,39}$'"
+        },
+        "github_webhook_deliveries_repository_id_shape": {
+          "name": "github_webhook_deliveries_repository_id_shape",
+          "value": "\"github_webhook_deliveries\".\"repository_id\" IS NULL OR \"github_webhook_deliveries\".\"repository_id\" ~ '^[0-9]{1,32}$'"
+        },
+        "github_webhook_deliveries_tracked_account": {
+          "name": "github_webhook_deliveries_tracked_account",
+          "value": "\"github_webhook_deliveries\".\"account\" IS NULL OR \"github_webhook_deliveries\".\"account\" IN ('f0rr0', 'yuppiestechdev')"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.github_work_unit_memberships": {
+      "name": "github_work_unit_memberships",
+      "schema": "",
+      "columns": {
+        "logical_repository_id": {
+          "name": "logical_repository_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logical_sha": {
+          "name": "logical_sha",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "work_unit_id": {
+          "name": "work_unit_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "gh_work_unit_memberships_position_unique": {
+          "name": "gh_work_unit_memberships_position_unique",
+          "columns": [
+            {
+              "expression": "work_unit_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "gh_work_unit_memberships_commit_unique": {
+          "name": "gh_work_unit_memberships_commit_unique",
+          "columns": [
+            {
+              "expression": "logical_repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "logical_sha",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gh_work_unit_memberships_unit_fk": {
+          "name": "gh_work_unit_memberships_unit_fk",
+          "tableFrom": "github_work_unit_memberships",
+          "tableTo": "github_work_units",
+          "columnsFrom": ["work_unit_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gh_work_unit_memberships_commit_fk": {
+          "name": "gh_work_unit_memberships_commit_fk",
+          "tableFrom": "github_work_unit_memberships",
+          "tableTo": "github_commits",
+          "columnsFrom": ["logical_repository_id", "logical_sha"],
+          "columnsTo": ["repository_id", "sha"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "gh_work_unit_memberships_pk": {
+          "name": "gh_work_unit_memberships_pk",
+          "columns": ["work_unit_id", "logical_repository_id", "logical_sha"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "gh_work_unit_memberships_values": {
+          "name": "gh_work_unit_memberships_values",
+          "value": "\"github_work_unit_memberships\".\"position\" >= 0 AND \"github_work_unit_memberships\".\"logical_sha\" ~ '^[a-f0-9]{40}$'"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.github_work_unit_summary_attempts": {
+      "name": "github_work_unit_summary_attempts",
+      "schema": "",
+      "columns": {
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attribution_mode": {
+          "name": "attribution_mode",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "debounce_until": {
+          "name": "debounce_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_started_at": {
+          "name": "last_started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latency_ms": {
+          "name": "latency_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lease_token": {
+          "name": "lease_token",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lease_until": {
+          "name": "lease_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "outcome_digest": {
+          "name": "outcome_digest",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recipe": {
+          "name": "recipe",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_payload": {
+          "name": "request_payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revision": {
+          "name": "revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_requests": {
+          "name": "started_requests",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "state": {
+          "name": "state",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "summary_input_digest": {
+          "name": "summary_input_digest",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "work_unit_id": {
+          "name": "work_unit_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "gh_work_unit_summary_input_unique": {
+          "name": "gh_work_unit_summary_input_unique",
+          "columns": [
+            {
+              "expression": "work_unit_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "summary_input_digest",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "recipe",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "gh_work_unit_summary_claim_idx": {
+          "name": "gh_work_unit_summary_claim_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "debounce_until",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gh_work_unit_summary_attempts_unit_fk": {
+          "name": "gh_work_unit_summary_attempts_unit_fk",
+          "tableFrom": "github_work_unit_summary_attempts",
+          "tableTo": "github_work_units",
+          "columnsFrom": ["work_unit_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "gh_work_unit_summary_attempts_pk": {
+          "name": "gh_work_unit_summary_attempts_pk",
+          "columns": ["work_unit_id", "revision"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "gh_work_unit_summary_state": {
+          "name": "gh_work_unit_summary_state",
+          "value": "\"github_work_unit_summary_attempts\".\"state\" IN ('pending', 'processing', 'retryable', 'accepted', 'terminal')"
+        },
+        "gh_work_unit_summary_digests": {
+          "name": "gh_work_unit_summary_digests",
+          "value": "\"github_work_unit_summary_attempts\".\"outcome_digest\" ~ '^[a-f0-9]{64}$' AND \"github_work_unit_summary_attempts\".\"summary_input_digest\" ~ '^[a-f0-9]{64}$'"
+        },
+        "gh_work_unit_summary_attribution": {
+          "name": "gh_work_unit_summary_attribution",
+          "value": "\"github_work_unit_summary_attempts\".\"attribution_mode\" IN ('tracked_authored_pr', 'foreign_pr_contribution', 'canonical_owned_composite', 'branch_owned_composite')"
+        },
+        "gh_work_unit_summary_revisions": {
+          "name": "gh_work_unit_summary_revisions",
+          "value": "\"github_work_unit_summary_attempts\".\"revision\" > 0 AND \"github_work_unit_summary_attempts\".\"started_requests\" BETWEEN 0 AND 2"
+        },
+        "gh_work_unit_summary_lease": {
+          "name": "gh_work_unit_summary_lease",
+          "value": "(\"github_work_unit_summary_attempts\".\"lease_token\" IS NULL) = (\"github_work_unit_summary_attempts\".\"lease_until\" IS NULL) AND (\"github_work_unit_summary_attempts\".\"state\" = 'processing') = (\"github_work_unit_summary_attempts\".\"lease_token\" IS NOT NULL) AND (\"github_work_unit_summary_attempts\".\"state\" <> 'processing' OR (\"github_work_unit_summary_attempts\".\"started_requests\" > 0 AND \"github_work_unit_summary_attempts\".\"request_payload\" IS NOT NULL))"
+        },
+        "gh_work_unit_summary_terminal_payload": {
+          "name": "gh_work_unit_summary_terminal_payload",
+          "value": "\"github_work_unit_summary_attempts\".\"state\" NOT IN ('accepted', 'terminal') OR \"github_work_unit_summary_attempts\".\"request_payload\" IS NULL"
+        },
+        "gh_work_unit_summary_accepted_output": {
+          "name": "gh_work_unit_summary_accepted_output",
+          "value": "(\"github_work_unit_summary_attempts\".\"state\" = 'accepted' AND \"github_work_unit_summary_attempts\".\"outcome\" IS NOT NULL AND \"github_work_unit_summary_attempts\".\"accepted_at\" IS NOT NULL AND \"github_work_unit_summary_attempts\".\"completed_at\" IS NOT NULL) OR (\"github_work_unit_summary_attempts\".\"state\" <> 'accepted' AND \"github_work_unit_summary_attempts\".\"outcome\" IS NULL AND \"github_work_unit_summary_attempts\".\"accepted_at\" IS NULL AND (\"github_work_unit_summary_attempts\".\"state\" <> 'terminal' OR \"github_work_unit_summary_attempts\".\"completed_at\" IS NOT NULL))"
+        },
+        "gh_work_unit_summary_started": {
+          "name": "gh_work_unit_summary_started",
+          "value": "(\"github_work_unit_summary_attempts\".\"started_requests\" = 0) = (\"github_work_unit_summary_attempts\".\"last_started_at\" IS NULL) AND (\"github_work_unit_summary_attempts\".\"state\" <> 'pending' OR \"github_work_unit_summary_attempts\".\"request_payload\" IS NOT NULL)"
+        },
+        "gh_work_unit_summary_request_cap": {
+          "name": "gh_work_unit_summary_request_cap",
+          "value": "\"github_work_unit_summary_attempts\".\"request_payload\" IS NULL OR octet_length(\"github_work_unit_summary_attempts\".\"request_payload\") <= 393216"
+        },
+        "gh_work_unit_summary_metrics": {
+          "name": "gh_work_unit_summary_metrics",
+          "value": "(\"github_work_unit_summary_attempts\".\"input_tokens\" IS NULL OR \"github_work_unit_summary_attempts\".\"input_tokens\" >= 0) AND (\"github_work_unit_summary_attempts\".\"output_tokens\" IS NULL OR \"github_work_unit_summary_attempts\".\"output_tokens\" >= 0) AND (\"github_work_unit_summary_attempts\".\"latency_ms\" IS NULL OR \"github_work_unit_summary_attempts\".\"latency_ms\" >= 0)"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.github_work_unit_summary_daily_usage": {
+      "name": "github_work_unit_summary_daily_usage",
+      "schema": "",
+      "columns": {
+        "day": {
+          "name": "day",
+          "type": "date",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "started_requests": {
+          "name": "started_requests",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "gh_work_unit_summary_daily_usage_cap": {
+          "name": "gh_work_unit_summary_daily_usage_cap",
+          "value": "\"github_work_unit_summary_daily_usage\".\"started_requests\" BETWEEN 0 AND 12"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.github_work_units": {
+      "name": "github_work_units",
+      "schema": "",
+      "columns": {
+        "activity_anchor_at": {
+          "name": "activity_anchor_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activity_at": {
+          "name": "activity_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activity_day": {
+          "name": "activity_day",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "additions": {
+          "name": "additions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attribution_mode": {
+          "name": "attribution_mode",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "branch_lineage_id": {
+          "name": "branch_lineage_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_observed_at": {
+          "name": "content_observed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deletions": {
+          "name": "deletions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "facts_digest": {
+          "name": "facts_digest",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_count": {
+          "name": "file_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_activity_at": {
+          "name": "first_activity_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "identity_key": {
+          "name": "identity_key",
+          "type": "varchar(180)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "languages": {
+          "name": "languages",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_activity_at": {
+          "name": "last_activity_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "member_count": {
+          "name": "member_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "membership_digest": {
+          "name": "membership_digest",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "newest_commit_repository_id": {
+          "name": "newest_commit_repository_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "newest_commit_sha": {
+          "name": "newest_commit_sha",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "outcome_digest": {
+          "name": "outcome_digest",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pull_request_node_id": {
+          "name": "pull_request_node_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revision": {
+          "name": "revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "summary_evaluation_digest": {
+          "name": "summary_evaluation_digest",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary_evaluated_digest": {
+          "name": "summary_evaluated_digest",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary_input_digest": {
+          "name": "summary_input_digest",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "gh_work_units_identity_unique": {
+          "name": "gh_work_units_identity_unique",
+          "columns": [
+            {
+              "expression": "identity_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "gh_work_units_pr_unique": {
+          "name": "gh_work_units_pr_unique",
+          "columns": [
+            {
+              "expression": "pull_request_node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"github_work_units\".\"kind\" = 'pull_request'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "gh_work_units_canonical_day_unique": {
+          "name": "gh_work_units_canonical_day_unique",
+          "columns": [
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "activity_day",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"github_work_units\".\"kind\" = 'canonical_day'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "gh_work_units_branch_unique": {
+          "name": "gh_work_units_branch_unique",
+          "columns": [
+            {
+              "expression": "branch_lineage_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"github_work_units\".\"kind\" = 'branch'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "gh_work_units_feed_idx": {
+          "name": "gh_work_units_feed_idx",
+          "columns": [
+            {
+              "expression": "visibility",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "activity_day",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "activity_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gh_work_units_repository_fk": {
+          "name": "gh_work_units_repository_fk",
+          "tableFrom": "github_work_units",
+          "tableTo": "github_repositories",
+          "columnsFrom": ["repository_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gh_work_units_pull_request_fk": {
+          "name": "gh_work_units_pull_request_fk",
+          "tableFrom": "github_work_units",
+          "tableTo": "github_pull_requests",
+          "columnsFrom": ["pull_request_node_id"],
+          "columnsTo": ["node_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gh_work_units_newest_commit_fk": {
+          "name": "gh_work_units_newest_commit_fk",
+          "tableFrom": "github_work_units",
+          "tableTo": "github_commits",
+          "columnsFrom": ["newest_commit_repository_id", "newest_commit_sha"],
+          "columnsTo": ["repository_id", "sha"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "gh_work_units_kind": {
+          "name": "gh_work_units_kind",
+          "value": "\"github_work_units\".\"kind\" IN ('pull_request', 'canonical_day', 'branch')"
+        },
+        "gh_work_units_owner_shape": {
+          "name": "gh_work_units_owner_shape",
+          "value": "(\"github_work_units\".\"kind\" = 'pull_request' AND \"github_work_units\".\"pull_request_node_id\" IS NOT NULL AND \"github_work_units\".\"branch_lineage_id\" IS NULL) OR (\"github_work_units\".\"kind\" = 'canonical_day' AND \"github_work_units\".\"pull_request_node_id\" IS NULL AND \"github_work_units\".\"branch_lineage_id\" IS NULL) OR (\"github_work_units\".\"kind\" = 'branch' AND \"github_work_units\".\"pull_request_node_id\" IS NULL AND \"github_work_units\".\"branch_lineage_id\" IS NOT NULL)"
+        },
+        "gh_work_units_identity": {
+          "name": "gh_work_units_identity",
+          "value": "(\"github_work_units\".\"kind\" = 'pull_request' AND \"github_work_units\".\"identity_key\" = 'pr:' || \"github_work_units\".\"pull_request_node_id\") OR (\"github_work_units\".\"kind\" = 'canonical_day' AND \"github_work_units\".\"identity_key\" = 'canonical:' || \"github_work_units\".\"repository_id\" || ':' || \"github_work_units\".\"activity_day\"::text) OR (\"github_work_units\".\"kind\" = 'branch' AND \"github_work_units\".\"identity_key\" = 'branch:' || \"github_work_units\".\"branch_lineage_id\"::text)"
+        },
+        "gh_work_units_attribution_mode": {
+          "name": "gh_work_units_attribution_mode",
+          "value": "\"github_work_units\".\"attribution_mode\" IN ('tracked_authored_pr', 'foreign_pr_contribution', 'canonical_owned_composite', 'branch_owned_composite')"
+        },
+        "gh_work_units_kind_attribution": {
+          "name": "gh_work_units_kind_attribution",
+          "value": "(\"github_work_units\".\"kind\" = 'pull_request' AND \"github_work_units\".\"attribution_mode\" IN ('tracked_authored_pr', 'foreign_pr_contribution')) OR (\"github_work_units\".\"kind\" = 'canonical_day' AND \"github_work_units\".\"attribution_mode\" = 'canonical_owned_composite') OR (\"github_work_units\".\"kind\" = 'branch' AND \"github_work_units\".\"attribution_mode\" = 'branch_owned_composite')"
+        },
+        "gh_work_units_visibility": {
+          "name": "gh_work_units_visibility",
+          "value": "\"github_work_units\".\"visibility\" IN ('public', 'private')"
+        },
+        "gh_work_units_nonnegative_facts": {
+          "name": "gh_work_units_nonnegative_facts",
+          "value": "\"github_work_units\".\"member_count\" > 0 AND \"github_work_units\".\"file_count\" >= 0 AND \"github_work_units\".\"additions\" >= 0 AND \"github_work_units\".\"deletions\" >= 0 AND \"github_work_units\".\"revision\" > 0"
+        },
+        "gh_work_units_activity_order": {
+          "name": "gh_work_units_activity_order",
+          "value": "\"github_work_units\".\"first_activity_at\" <= \"github_work_units\".\"last_activity_at\" AND \"github_work_units\".\"activity_day\" = (\"github_work_units\".\"activity_at\" AT TIME ZONE 'UTC')::date"
+        },
+        "gh_work_units_digest_shapes": {
+          "name": "gh_work_units_digest_shapes",
+          "value": "\"github_work_units\".\"facts_digest\" ~ '^[a-f0-9]{64}$' AND \"github_work_units\".\"membership_digest\" ~ '^[a-f0-9]{64}$' AND (\"github_work_units\".\"outcome_digest\" IS NULL OR \"github_work_units\".\"outcome_digest\" ~ '^[a-f0-9]{64}$') AND (\"github_work_units\".\"summary_evaluation_digest\" IS NULL OR \"github_work_units\".\"summary_evaluation_digest\" ~ '^[a-f0-9]{64}$') AND (\"github_work_units\".\"summary_evaluated_digest\" IS NULL OR \"github_work_units\".\"summary_evaluated_digest\" ~ '^[a-f0-9]{64}$') AND (\"github_work_units\".\"summary_input_digest\" IS NULL OR \"github_work_units\".\"summary_input_digest\" ~ '^[a-f0-9]{64}$')"
+        },
+        "gh_work_units_languages_array": {
+          "name": "gh_work_units_languages_array",
+          "value": "\"github_work_units\".\"languages\" IS NULL OR jsonb_typeof(\"github_work_units\".\"languages\") = 'array'"
+        }
+      },
+      "isRLSEnabled": true
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -113,6 +113,13 @@
       "when": 1788260951003,
       "tag": "0015_demonic_romulus",
       "breakpoints": true
+    },
+    {
+      "idx": 16,
+      "version": "7",
+      "when": 1788266468975,
+      "tag": "0016_moaning_paibok",
+      "breakpoints": true
     }
   ]
 }

--- a/scripts/backfill-github-activity.ts
+++ b/scripts/backfill-github-activity.ts
@@ -258,7 +258,6 @@ export const runGitHubBackfillFactualDrain = async (
       commitLimit: FACTUAL_WORKER_BATCH_LIMIT,
       includeProjection: false,
       includeRefs: false,
-      includeSummaries: false,
       maximumDurationMs,
       observationLimit: FACTUAL_WORKER_BATCH_LIMIT,
       pullRequestDiscoveryLimit: FACTUAL_WORKER_BATCH_LIMIT,

--- a/scripts/verify-github-work-units.ts
+++ b/scripts/verify-github-work-units.ts
@@ -33,6 +33,9 @@ if (import.meta.main) {
       argumentsFrom(process.argv.slice(2))
     );
     process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+    if (!report.invariants.passed) {
+      process.exitCode = 1;
+    }
   } catch (error) {
     const name = error instanceof Error ? error.name : "UnknownError";
     const message = error instanceof Error ? error.message : "Unknown error";

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -74,6 +74,10 @@ export const githubRepositories = pgTable(
   (table) => [
     index("github_repositories_full_name_idx").on(table.fullName),
     check(
+      "github_repositories_full_name",
+      sql`length(btrim(${table.fullName})) > 0`
+    ),
+    check(
       "github_repositories_owner_type",
       sql`${table.ownerType} IS NULL OR ${table.ownerType} IN ('Organization', 'User')`
     ),
@@ -126,6 +130,11 @@ export const githubCommits = pgTable(
       .default("pending")
       .notNull(),
     fileFacts: jsonb("file_facts").$type<readonly GitHubWorkUnitFileFact[]>(),
+    fileFactsDigest: varchar("file_facts_digest", {
+      length: 64,
+    }).generatedAlwaysAs(
+      sql`CASE WHEN "file_facts" IS NULL THEN NULL ELSE encode(sha256(jsonb_send("file_facts")), 'hex') END`
+    ),
     fileFactsComplete: boolean("file_facts_complete").default(false).notNull(),
     firstObservedAt: timestamp("first_observed_at", {
       mode: "date",
@@ -647,9 +656,6 @@ export const githubPullRequests = pgTable(
     }),
     nodeId: varchar("node_id", { length: 128 }).primaryKey(),
     number: integer("number").notNull(),
-    providerFileCapReached: boolean("provider_file_cap_reached")
-      .default(false)
-      .notNull(),
     providerUpdatedAt: timestamp("provider_updated_at", {
       mode: "date",
       withTimezone: true,
@@ -799,6 +805,11 @@ export const githubPullRequestVersions = pgTable(
     baseSha: varchar("base_sha", { length: 40 }).notNull(),
     commitCount: integer("commit_count"),
     fileFacts: jsonb("file_facts").$type<readonly GitHubWorkUnitFileFact[]>(),
+    fileFactsDigest: varchar("file_facts_digest", {
+      length: 64,
+    }).generatedAlwaysAs(
+      sql`CASE WHEN "file_facts" IS NULL THEN NULL ELSE encode(sha256(jsonb_send("file_facts")), 'hex') END`
+    ),
     fileFactsComplete: boolean("file_facts_complete").default(false).notNull(),
     headRefName: text("head_ref_name"),
     headRepositoryId: varchar("head_repository_id", { length: 32 }),
@@ -1189,6 +1200,12 @@ export const githubWorkUnits = pgTable(
     pullRequestNodeId: varchar("pull_request_node_id", { length: 128 }),
     repositoryId: varchar("repository_id", { length: 32 }).notNull(),
     revision: integer("revision").default(1).notNull(),
+    summaryEvaluationDigest: varchar("summary_evaluation_digest", {
+      length: 64,
+    }),
+    summaryEvaluatedDigest: varchar("summary_evaluated_digest", {
+      length: 64,
+    }),
     summaryInputDigest: varchar("summary_input_digest", { length: 64 }),
     visibility: varchar("visibility", { length: 8 }).notNull(),
   },
@@ -1258,7 +1275,7 @@ export const githubWorkUnits = pgTable(
     ),
     check(
       "gh_work_units_digest_shapes",
-      sql`${table.factsDigest} ~ '^[a-f0-9]{64}$' AND ${table.membershipDigest} ~ '^[a-f0-9]{64}$' AND (${table.outcomeDigest} IS NULL OR ${table.outcomeDigest} ~ '^[a-f0-9]{64}$') AND (${table.summaryInputDigest} IS NULL OR ${table.summaryInputDigest} ~ '^[a-f0-9]{64}$')`
+      sql`${table.factsDigest} ~ '^[a-f0-9]{64}$' AND ${table.membershipDigest} ~ '^[a-f0-9]{64}$' AND (${table.outcomeDigest} IS NULL OR ${table.outcomeDigest} ~ '^[a-f0-9]{64}$') AND (${table.summaryEvaluationDigest} IS NULL OR ${table.summaryEvaluationDigest} ~ '^[a-f0-9]{64}$') AND (${table.summaryEvaluatedDigest} IS NULL OR ${table.summaryEvaluatedDigest} ~ '^[a-f0-9]{64}$') AND (${table.summaryInputDigest} IS NULL OR ${table.summaryInputDigest} ~ '^[a-f0-9]{64}$')`
     ),
     check(
       "gh_work_units_languages_array",
@@ -1352,7 +1369,6 @@ export const githubWorkUnitSummaryAttempts = pgTable(
     summaryInputDigest: varchar("summary_input_digest", {
       length: 64,
     }).notNull(),
-    unitRevision: integer("unit_revision").notNull(),
     workUnitId: uuid("work_unit_id").notNull(),
   },
   (table) => [
@@ -1389,7 +1405,7 @@ export const githubWorkUnitSummaryAttempts = pgTable(
     ),
     check(
       "gh_work_unit_summary_revisions",
-      sql`${table.revision} > 0 AND ${table.unitRevision} > 0 AND ${table.startedRequests} BETWEEN 0 AND 2`
+      sql`${table.revision} > 0 AND ${table.startedRequests} BETWEEN 0 AND 2`
     ),
     check(
       "gh_work_unit_summary_lease",
@@ -1405,7 +1421,7 @@ export const githubWorkUnitSummaryAttempts = pgTable(
     ),
     check(
       "gh_work_unit_summary_started",
-      sql`(${table.startedRequests} = 0) = (${table.lastStartedAt} IS NULL) AND (${table.state} <> 'retryable' OR ${table.requestPayload} IS NOT NULL)`
+      sql`(${table.startedRequests} = 0) = (${table.lastStartedAt} IS NULL) AND (${table.state} <> 'pending' OR ${table.requestPayload} IS NOT NULL)`
     ),
     check(
       "gh_work_unit_summary_request_cap",
@@ -1449,6 +1465,8 @@ export const githubPublicFeedHead = pgTable(
     orderingRevision: bigint("ordering_revision", { mode: "number" })
       .default(0)
       .notNull(),
+    projectionRequestToken: uuid("projection_request_token"),
+    summaryPolicyDigest: varchar("summary_policy_digest", { length: 64 }),
     summarizing: boolean("summarizing").default(false).notNull(),
   },
   (table) => [
@@ -1456,6 +1474,10 @@ export const githubPublicFeedHead = pgTable(
     check(
       "gh_public_feed_head_revisions",
       sql`${table.feedRevision} >= 0 AND ${table.headContentRevision} >= 0 AND ${table.orderingRevision} >= 0`
+    ),
+    check(
+      "gh_public_feed_head_summary_policy_digest",
+      sql`${table.summaryPolicyDigest} IS NULL OR ${table.summaryPolicyDigest} ~ '^[a-f0-9]{64}$'`
     ),
   ]
 ).enableRLS();

--- a/src/lib/github-activity-status.ts
+++ b/src/lib/github-activity-status.ts
@@ -3,7 +3,7 @@ import type { PublicActivityHead } from "@/lib/github-activity-types";
 export const PUBLIC_ACTIVITY_MAX_STATUS_REQUESTS = 12;
 export const PUBLIC_ACTIVITY_MAX_SETTLED_REQUESTS = 3;
 export const PUBLIC_ACTIVITY_SETTLED_POLL_MS = 5 * 60 * 1000;
-export const PUBLIC_ACTIVITY_SUMMARY_POLL_MS = 30 * 1000;
+export const PUBLIC_ACTIVITY_SUMMARY_POLL_MS = 3 * 60 * 1000;
 
 const REVISION = /^(?:0|[1-9]\d*)$/u;
 

--- a/src/lib/github-activity-store.ts
+++ b/src/lib/github-activity-store.ts
@@ -23,6 +23,7 @@ import type {
   PublicGitHubWorkUnitKind,
 } from "@/lib/github-activity-types";
 import { hasCurrentTrackedGitHubRepositoryAccess } from "@/lib/github-repository-access";
+import { GITHUB_WORK_UNIT_SUMMARY_RECIPE } from "@/lib/github-work-unit-summary";
 
 export const PUBLIC_GITHUB_ACTIVITY_DAY_PAGE_SIZE = 5;
 const MAXIMUM_PUBLIC_DAY_PAGE_SIZE = 14;
@@ -239,7 +240,10 @@ const readAvailableDays = async (
           and(
             beforeWorkUnit,
             eq(githubWorkUnits.visibility, "private"),
-            inArray(githubRepositories.visibility, ["private", "internal"])
+            inArray(githubRepositories.visibility, ["private", "internal"]),
+            hasCurrentTrackedGitHubRepositoryAccess(
+              githubWorkUnits.repositoryId
+            )
           )
         )
         .orderBy(desc(githubWorkUnits.activityDay))
@@ -422,6 +426,10 @@ const readPublicRows = async (
           .where(
             and(
               inArray(githubWorkUnitSummaryAttempts.workUnitId, unitIds),
+              eq(
+                githubWorkUnitSummaryAttempts.recipe,
+                GITHUB_WORK_UNIT_SUMMARY_RECIPE
+              ),
               eq(githubWorkUnitSummaryAttempts.state, "accepted"),
               isNotNull(githubWorkUnitSummaryAttempts.acceptedAt),
               isNotNull(githubWorkUnitSummaryAttempts.outcome)

--- a/src/lib/github-activity-worker-core.ts
+++ b/src/lib/github-activity-worker-core.ts
@@ -1,10 +1,10 @@
-export const DEFAULT_GITHUB_ACTIVITY_WORKER_BATCH_SIZE = 4;
-export const MAXIMUM_GITHUB_ACTIVITY_WORKER_BATCH_SIZE = 8;
+const DEFAULT_GITHUB_ACTIVITY_WORKER_BATCH_SIZE = 8;
+const MAXIMUM_GITHUB_ACTIVITY_WORKER_BATCH_SIZE = 8;
 export const GITHUB_PR_RECONCILIATION_MAX_AGE_DAYS = Number.POSITIVE_INFINITY;
 
 const DEFAULT_RETRY_DELAY_MS = 15 * 60 * 1000;
 const MAXIMUM_RETRY_DELAY_MS = 24 * 60 * 60 * 1000;
-export const GITHUB_SUMMARY_MINIMUM_REMAINING_MS = 5000;
+const GITHUB_SUMMARY_MINIMUM_REMAINING_MS = 25_000;
 
 export const boundedWorkerLimit = (
   value: number | undefined,
@@ -44,7 +44,13 @@ export const workerBatchSizeFrom = (
   if (value === null) {
     return undefined;
   }
-  return /^[1-8]$/.test(value) ? Number(value) : null;
+  const selected = Number(value);
+  return Number.isSafeInteger(selected) &&
+    selected >= 1 &&
+    selected <= MAXIMUM_GITHUB_ACTIVITY_WORKER_BATCH_SIZE &&
+    String(selected) === value
+    ? selected
+    : null;
 };
 
 export const githubPrReconciliationCutoff = (

--- a/src/lib/github-activity-worker-store.ts
+++ b/src/lib/github-activity-worker-store.ts
@@ -40,7 +40,10 @@ import {
 } from "@/lib/github-activity-worker-core";
 import { githubWorkUnitFileFactsFrom } from "@/lib/github-change-evidence";
 import type { GitHubFileChangeEvidence } from "@/lib/github-change-evidence";
-import { trackedGitHubAccountFrom } from "@/lib/github-commits-core";
+import {
+  githubCommitReferenceValuesFrom,
+  trackedGitHubAccountFrom,
+} from "@/lib/github-commits-core";
 import type {
   GitHubPullRequest,
   TrackedGitHubAccount,
@@ -50,6 +53,7 @@ import {
   persistPullRequestSnapshotInTransaction,
 } from "@/lib/github-pull-request-store";
 import type { StoredPullRequestSnapshot } from "@/lib/github-pull-request-store";
+import { requestGitHubWorkUnitProjection } from "@/lib/github-work-unit-projection-state";
 
 const DEFAULT_LEASE_MS = 5 * 60 * 1000;
 
@@ -425,14 +429,9 @@ export const completeGitHubPushObservation = async (
         : await transaction
             .insert(githubCommits)
             .values(
-              source.commits.map((commit) => ({
-                author: commit.author,
-                committedAt: new Date(commit.committedAt),
-                firstObservedAt: observation.observedAt,
-                message: commit.message,
-                repositoryId: commit.repositoryId,
-                sha: commit.sha,
-              }))
+              source.commits.map((commit) =>
+                githubCommitReferenceValuesFrom(commit, observation.observedAt)
+              )
             )
             .onConflictDoNothing({
               target: [githubCommits.repositoryId, githubCommits.sha],
@@ -633,36 +632,42 @@ export const completeGitHubCommitEnrichment = async (
   source: GitHubActivityCommitSource
 ): Promise<boolean> => {
   const fileFacts = githubWorkUnitFileFactsFrom(source.commit.files);
-  const [updated] = await getDatabase()
-    .update(githubCommits)
-    .set({
-      additions: source.commit.stats.additions,
-      authoredAt: new Date(source.authoredAt),
-      authorUserId: source.authorUserId,
-      changedFiles: source.commit.files.length,
-      committerAt: new Date(source.committerAt),
-      committerUserId: source.committerUserId,
-      committedAt: new Date(source.committerAt),
-      deletions: source.commit.stats.deletions,
-      enrichmentError: null,
-      enrichmentLeaseToken: null,
-      enrichmentLeaseUntil: null,
-      enrichmentState: "complete",
-      fileFacts,
-      fileFactsComplete: !source.commit.providerFileCapReached,
-      message: source.commit.message,
-      parentShas: source.commit.parents,
-      providerFileCapReached: source.commit.providerFileCapReached,
-    })
-    .where(
-      and(
-        commitIdentity(commit),
-        eq(githubCommits.enrichmentState, "processing"),
-        eq(githubCommits.enrichmentLeaseToken, commit.leaseToken)
+  return await getDatabase().transaction(async (transaction) => {
+    const [updated] = await transaction
+      .update(githubCommits)
+      .set({
+        additions: source.commit.stats.additions,
+        authoredAt: new Date(source.authoredAt),
+        authorUserId: source.authorUserId,
+        changedFiles: source.commit.files.length,
+        committerAt: new Date(source.committerAt),
+        committerUserId: source.committerUserId,
+        committedAt: new Date(source.committerAt),
+        deletions: source.commit.stats.deletions,
+        enrichmentError: null,
+        enrichmentLeaseToken: null,
+        enrichmentLeaseUntil: null,
+        enrichmentState: "complete",
+        fileFacts,
+        fileFactsComplete: !source.commit.providerFileCapReached,
+        message: source.commit.message,
+        parentShas: source.commit.parents,
+        providerFileCapReached: source.commit.providerFileCapReached,
+      })
+      .where(
+        and(
+          commitIdentity(commit),
+          eq(githubCommits.enrichmentState, "processing"),
+          eq(githubCommits.enrichmentLeaseToken, commit.leaseToken)
+        )
       )
-    )
-    .returning({ sha: githubCommits.sha });
-  return updated !== undefined;
+      .returning({ sha: githubCommits.sha });
+    if (updated === undefined) {
+      return false;
+    }
+    await requestGitHubWorkUnitProjection(transaction);
+    return true;
+  });
 };
 
 export const deferGitHubCommitEnrichment = async (
@@ -1167,7 +1172,11 @@ export const completeGitHubPullRequestDiscovery = async (
         )
       )
       .returning({ sha: githubCommits.sha });
-    return completed !== undefined;
+    if (completed === undefined) {
+      return false;
+    }
+    await requestGitHubWorkUnitProjection(transaction);
+    return true;
   });
 
 export const claimDueGitHubPullRequests = async (
@@ -1322,10 +1331,19 @@ export const persistGitHubPullRequestMembership = async (
       headSha === version.headSha &&
       (version.commitCount === 0 || commitShas.at(-1) === version.headSha);
     if (!completeMembershipIsValid) {
-      await transaction
+      const [invalidated] = await transaction
         .update(githubPullRequestVersions)
         .set({ membershipComplete: false })
-        .where(eq(githubPullRequestVersions.id, stored.versionId));
+        .where(
+          and(
+            eq(githubPullRequestVersions.id, stored.versionId),
+            eq(githubPullRequestVersions.membershipComplete, true)
+          )
+        )
+        .returning({ id: githubPullRequestVersions.id });
+      if (invalidated !== undefined) {
+        await requestGitHubWorkUnitProjection(transaction);
+      }
       return false;
     }
     await transaction
@@ -1346,6 +1364,7 @@ export const persistGitHubPullRequestMembership = async (
       .update(githubPullRequestVersions)
       .set({ membershipComplete: true })
       .where(eq(githubPullRequestVersions.id, stored.versionId));
+    await requestGitHubWorkUnitProjection(transaction);
     return true;
   });
 
@@ -1394,7 +1413,11 @@ export const persistGitHubPullRequestDiff = async (
         )
       )
       .returning({ id: githubPullRequestVersions.id });
-    return updated !== undefined;
+    if (updated === undefined) {
+      return false;
+    }
+    await requestGitHubWorkUnitProjection(transaction);
+    return true;
   });
 };
 

--- a/src/lib/github-activity-worker.ts
+++ b/src/lib/github-activity-worker.ts
@@ -72,6 +72,7 @@ import {
   githubCurrentRefMembershipReferenceFrom,
   releaseGitHubRefRepair,
 } from "@/lib/github-ref-membership-store";
+import { ensureGitHubWorkUnitProjectionRequest } from "@/lib/github-work-unit-projection-state";
 import { refreshGitHubWorkUnitProjection } from "@/lib/github-work-unit-store";
 import type { GitHubWorkUnitProjectionRefreshResult } from "@/lib/github-work-unit-store";
 import {
@@ -88,8 +89,9 @@ import {
 } from "@/lib/github-work-unit-summary-store";
 
 const DEFAULT_WORKER_MAXIMUM_DURATION_MS = 90_000;
-const MAXIMUM_PROJECTION_RESERVE_MS = 50_000;
+const MAXIMUM_PUBLICATION_RESERVE_MS = 30_000;
 const MINIMUM_FACTUAL_PROCESSING_MS = 8000;
+const SUMMARY_SETTLEMENT_RESERVE_MS = 3000;
 const SUMMARY_RETRY_DELAY_MS = 15 * 60_000;
 const TERMINAL_GITHUB_STATUSES = new Set([403, 404, 410, 422]);
 const TERMINAL_ACTIVITY_PROCESSING_CODES = new Set([
@@ -136,7 +138,6 @@ export interface GitHubActivityWorkerOptions {
   commitLimit?: number;
   includeProjection?: boolean;
   includeRefs?: boolean;
-  includeSummaries?: boolean;
   maximumDurationMs?: number;
   observationLimit?: number;
   pullRequestDiscoveryLimit?: number;
@@ -694,9 +695,6 @@ const checkedWorkerScope = (
   };
 };
 
-const hasDurableEvidenceChanges = (stages: readonly StageResult[]) =>
-  stages.some((stage) => stage.completed > 0 || stage.unavailable > 0);
-
 export const runGitHubActivityWorker = async (
   options: GitHubActivityWorkerOptions = {}
 ): Promise<GitHubActivityWorkerResult> => {
@@ -723,14 +721,14 @@ export const runGitHubActivityWorker = async (
   }
 
   const startedAt = Date.now();
-  const projectionReserveMs =
+  const publicationReserveMs =
     options.includeProjection === false
       ? 0
       : Math.min(
-          MAXIMUM_PROJECTION_RESERVE_MS,
+          MAXIMUM_PUBLICATION_RESERVE_MS,
           Math.max(0, maximumDurationMs - MINIMUM_FACTUAL_PROCESSING_MS)
         );
-  const processingDurationMs = maximumDurationMs - projectionReserveMs;
+  const processingDurationMs = maximumDurationMs - publicationReserveMs;
   const deadlineReached = () =>
     workerDeadlineReached(startedAt, processingDurationMs);
   const observations = emptyStageResult();
@@ -749,6 +747,8 @@ export const runGitHubActivityWorker = async (
   };
   const overallDeadlineReached = () =>
     workerDeadlineReached(startedAt, maximumDurationMs);
+  const summaryDeadlineAt =
+    startedAt + Math.max(0, maximumDurationMs - SUMMARY_SETTLEMENT_RESERVE_MS);
 
   await processObservations(context, observationLimit, observations);
   await processPullRequestSignals(
@@ -766,26 +766,18 @@ export const runGitHubActivityWorker = async (
     pullRequestDiscovery
   );
   await processPullRequests(context, pullRequestLimit, pullRequests);
-  const evidenceStages = [
-    observations,
-    pullRequestSignals,
-    refs,
-    commits,
-    pullRequestDiscovery,
-    pullRequests,
-  ];
   const projection =
     options.includeProjection !== false &&
-    hasDurableEvidenceChanges(evidenceStages)
+    (await ensureGitHubWorkUnitProjectionRequest()) !== null
       ? await refreshGitHubWorkUnitProjection(new Date())
       : null;
   await reconcileGitHubWorkUnitSummaryStatus(new Date());
-  if (options.includeSummaries !== false) {
+  if (options.includeProjection !== false) {
     await processSummary(
       {
         ...context,
-        deadlineAt: startedAt + maximumDurationMs,
-        deadlineReached: overallDeadlineReached,
+        deadlineAt: summaryDeadlineAt,
+        deadlineReached: () => Date.now() >= summaryDeadlineAt,
       },
       summaries
     );

--- a/src/lib/github-change-evidence.ts
+++ b/src/lib/github-change-evidence.ts
@@ -49,10 +49,13 @@ const languageByExtension = {
   zig: ["zig", "Zig"],
 } as const;
 
-export interface GitHubFileChangeEvidence {
+export interface GitHubFileChangeStat {
   additions: number;
   deletions: number;
   filename: string;
+}
+
+export interface GitHubFileChangeEvidence extends GitHubFileChangeStat {
   patch: string | null;
   previousFilename: string | null;
   status: string;
@@ -85,12 +88,12 @@ export interface GitHubLanguageFact {
   label: string;
 }
 
-const isSubstantiveGitHubFile = (file: GitHubFileChangeEvidence) =>
+const isSubstantiveGitHubFile = (file: GitHubFileChangeStat) =>
   !generatedOrVendored.test(file.filename) &&
   !lockfile.test(file.filename) &&
   !binaryAsset.test(file.filename);
 
-const languageForFile = (file: GitHubFileChangeEvidence) => {
+const languageForFile = (file: GitHubFileChangeStat) => {
   const extension = /\.([A-Za-z0-9]+)$/u
     .exec(file.filename)?.[1]
     ?.toLowerCase();
@@ -113,7 +116,7 @@ export const githubWorkUnitFileFactsFrom = (
   }));
 
 export const aggregateGitHubLanguages = (
-  files: readonly GitHubFileChangeEvidence[]
+  files: readonly GitHubFileChangeStat[]
 ): readonly GitHubLanguageFact[] => {
   const facts = new Map<string, GitHubLanguageFact>();
   for (const file of files) {

--- a/src/lib/github-commits-core.ts
+++ b/src/lib/github-commits-core.ts
@@ -152,6 +152,19 @@ export interface GitHubCommit {
   url: string;
 }
 
+export const githubCommitReferenceValuesFrom = (
+  commit: GitHubCommit,
+  firstObservedAt: Date
+) => ({
+  author: commit.author,
+  authorUserId: TRACKED_GITHUB_USER_IDS[commit.author],
+  committedAt: new Date(commit.committedAt),
+  firstObservedAt,
+  message: commit.message,
+  repositoryId: commit.repositoryId,
+  sha: commit.sha,
+});
+
 export interface GitHubPush {
   before: string;
   commitShas: readonly string[];

--- a/src/lib/github-commits-store.ts
+++ b/src/lib/github-commits-store.ts
@@ -28,6 +28,7 @@ import {
   githubWebhookDeliveries,
 } from "@/db/schema";
 import {
+  githubCommitReferenceValuesFrom,
   planGitHubBranchLineages,
   trackedGitHubAccountFrom,
 } from "@/lib/github-commits-core";
@@ -48,6 +49,7 @@ import {
   upsertGitHubRepositories,
   upsertGitHubRepository,
 } from "@/lib/github-repository-store";
+import { requestGitHubWorkUnitProjection } from "@/lib/github-work-unit-projection-state";
 
 export class CheckpointConflictError extends Error {
   constructor() {
@@ -351,14 +353,9 @@ export const persistGitHubCommitReferences = async (input: {
         .values(
           values
             .slice(offset, offset + PUSH_COMMIT_INSERT_BATCH)
-            .map((commit) => ({
-              author: commit.author,
-              committedAt: new Date(commit.committedAt),
-              firstObservedAt: observedAt,
-              message: commit.message,
-              repositoryId: commit.repositoryId,
-              sha: commit.sha,
-            }))
+            .map((commit) =>
+              githubCommitReferenceValuesFrom(commit, observedAt)
+            )
         )
         .onConflictDoNothing({
           target: [githubCommits.repositoryId, githubCommits.sha],
@@ -392,24 +389,11 @@ const insertPushObservations = async (
     }
   }
   const observedAt = inputs[0]?.observedAt ?? new Date();
-  await transaction
-    .insert(githubRepositories)
-    .values(
-      [...repositories.values()].map((repository) => ({
-        firstObservedAt: observedAt,
-        fullName: repository.fullName,
-        id: repository.id,
-        lastObservedAt: observedAt,
-      }))
-    )
-    .onConflictDoUpdate({
-      set: {
-        fullName: sql`excluded.full_name`,
-        lastObservedAt: sql`excluded.last_observed_at`,
-      },
-      setWhere: lte(githubRepositories.lastObservedAt, observedAt),
-      target: githubRepositories.id,
-    });
+  await upsertGitHubRepositories(
+    transaction,
+    [...repositories.values()],
+    observedAt
+  );
 
   const inserted = await transaction
     .insert(githubPushObservations)
@@ -838,6 +822,7 @@ export const persistGitHubRepositoryRefPage = async (input: {
     throw new TypeError("The GitHub reference page contains duplicates.");
   }
 
+  // oxlint-disable-next-line eslint/complexity -- One transaction owns stale-scan rejection, lineage assignment, ref publication, and its checkpoint.
   return await getDatabase().transaction(async (transaction) => {
     await upsertGitHubRepository(
       transaction,
@@ -887,8 +872,10 @@ export const persistGitHubRepositoryRefPage = async (input: {
         : await transaction
             .select({
               active: githubRepositoryRefs.active,
+              branchLineageId: githubRepositoryRefs.branchLineageId,
               headSha: githubRepositoryRefs.headSha,
               lastObservedAt: githubRepositoryRefs.lastObservedAt,
+              projectionRelevant: githubRepositoryRefs.projectionRelevant,
               refName: githubRepositoryRefs.refName,
             })
             .from(githubRepositoryRefs)
@@ -919,6 +906,40 @@ export const persistGitHubRepositoryRefPage = async (input: {
     );
     const isCanonicalIncomingRef =
       incomingCanonicalRefCondition(canonicalRefName);
+    const incomingProjectionInputChanged =
+      input.kind === "head" &&
+      input.refs.some((ref) => {
+        const previous = existingByName.get(ref.refName);
+        if (
+          previous !== undefined &&
+          previous.lastObservedAt > input.scanStartedAt
+        ) {
+          return false;
+        }
+        const branchLineageId = plannedLineages.get(ref.refName);
+        if (branchLineageId === undefined) {
+          throw new Error("A GitHub head lineage was not planned.");
+        }
+        if (previous === undefined) {
+          return initialRefProjectionRelevance(
+            ref,
+            canonicalRefName,
+            establishingBaseline
+          );
+        }
+        const nextProjectionRelevant =
+          previous.projectionRelevant ||
+          !previous.active ||
+          previous.headSha !== ref.headSha ||
+          ref.refName === canonicalRefName;
+        return (
+          nextProjectionRelevant &&
+          (!previous.projectionRelevant ||
+            !previous.active ||
+            previous.headSha !== ref.headSha ||
+            previous.branchLineageId !== branchLineageId)
+        );
+      });
     const observedRanges = new Set<string>();
     const observations: PushObservationInput[] = [];
     for (const ref of input.refs) {
@@ -1037,24 +1058,27 @@ export const persistGitHubRepositoryRefPage = async (input: {
           ],
         });
     }
-    if (input.complete) {
-      await transaction
-        .update(githubRepositoryRefs)
-        .set({
-          active: false,
-          lastObservedAt: input.scanStartedAt,
-          repairLeaseToken: null,
-          repairLeaseUntil: null,
-        })
-        .where(
-          and(
-            eq(githubRepositoryRefs.repositoryId, input.repository.id),
-            eq(githubRepositoryRefs.kind, input.kind),
-            eq(githubRepositoryRefs.active, true),
-            lt(githubRepositoryRefs.lastObservedAt, input.scanStartedAt)
+    const deactivated = input.complete
+      ? await transaction
+          .update(githubRepositoryRefs)
+          .set({
+            active: false,
+            lastObservedAt: input.scanStartedAt,
+            repairLeaseToken: null,
+            repairLeaseUntil: null,
+          })
+          .where(
+            and(
+              eq(githubRepositoryRefs.repositoryId, input.repository.id),
+              eq(githubRepositoryRefs.kind, input.kind),
+              eq(githubRepositoryRefs.active, true),
+              lt(githubRepositoryRefs.lastObservedAt, input.scanStartedAt)
+            )
           )
-        );
-    }
+          .returning({
+            projectionRelevant: githubRepositoryRefs.projectionRelevant,
+          })
+      : [];
     if (input.complete) {
       await transaction
         .update(githubRepositories)
@@ -1069,6 +1093,14 @@ export const persistGitHubRepositoryRefPage = async (input: {
       nextPage: input.nextPage,
       scanStartedAt: input.complete ? null : input.scanStartedAt,
     });
+    const headProjectionInputChanged =
+      input.kind === "head" &&
+      ((input.complete && establishingBaseline) ||
+        incomingProjectionInputChanged ||
+        deactivated.some((ref) => ref.projectionRelevant));
+    if (headProjectionInputChanged) {
+      await requestGitHubWorkUnitProjection(transaction);
+    }
     return {
       knownCommits: persisted.knownCommits,
       pushes: persisted.pushes,
@@ -1292,6 +1324,9 @@ const signalKnownPullRequestReconciliation = async (
         eq(githubPullRequests.nodeId, known.nodeId)
       )
     );
+  if (promoteToProvisionalClosed) {
+    await requestGitHubWorkUnitProjection(transaction);
+  }
   return true;
 };
 
@@ -1482,6 +1517,7 @@ export const persistGitHubWebhookHeadSignal = async (
         });
     }
     await markWebhookDeliveryAccepted(transaction, delivery, true);
+    await requestGitHubWorkUnitProjection(transaction);
     return {
       duplicate: false,
       ignored: false,

--- a/src/lib/github-pull-request-store.ts
+++ b/src/lib/github-pull-request-store.ts
@@ -13,6 +13,7 @@ import type {
   TrackedGitHubAccount,
 } from "@/lib/github-commits-core";
 import { upsertGitHubRepositories } from "@/lib/github-repository-store";
+import { requestGitHubWorkUnitProjection } from "@/lib/github-work-unit-projection-state";
 
 type DatabaseTransaction = Parameters<
   Parameters<ReturnType<typeof getDatabase>["transaction"]>[0]
@@ -148,28 +149,23 @@ export const persistPullRequestSnapshotInTransaction = async (
         ? now
         : (existing?.mergeShaVerifiedAt ?? null)
       : null;
-  const canonicalEvidenceChanged =
+  const projectionEvidenceChanged =
     existing !== undefined &&
     (existing.headSha !== pullRequest.headSha ||
       existing.baseSha !== pullRequest.baseSha ||
       (pullRequest.headRepository !== null &&
         existing.headRepositoryId !== pullRequest.headRepository.id) ||
       existing.repositoryId !== pullRequest.repository.id ||
-      existing.mergeSha !== mergeSha ||
-      (existing.mergeShaVerifiedAt === null) !==
-        (mergeShaVerifiedAt === null) ||
       existing.state !== state);
-  const supplementalEvidenceChanged =
-    existing !== undefined &&
-    ((existing.additions === null && pullRequest.additions !== null) ||
-      (existing.changedFiles === null && pullRequest.changedFiles !== null) ||
-      (existing.commitCount === null && pullRequest.commitCount !== null) ||
-      (existing.deletions === null && pullRequest.deletions !== null) ||
-      (existing.headRepositoryId === null &&
-        pullRequest.headRepository !== null));
+  const persistedEvidenceChanged =
+    projectionEvidenceChanged ||
+    (existing !== undefined &&
+      (existing.mergeSha !== mergeSha ||
+        (existing.mergeShaVerifiedAt === null) !==
+          (mergeShaVerifiedAt === null)));
   const retryLifecycleReset =
     existing !== undefined &&
-    (disposition === "newer" || canonicalEvidenceChanged);
+    (disposition === "newer" || persistedEvidenceChanged);
   const retryLifecycleUpdate = retryLifecycleReset
     ? {
         nextReconcileAt: options.reconciliationLeaseUntil ?? now,
@@ -196,7 +192,6 @@ export const persistPullRequestSnapshotInTransaction = async (
       pullRequest.mergedAt === null ? null : new Date(pullRequest.mergedAt),
     mergeSha,
     mergeShaVerifiedAt,
-    providerFileCapReached: false,
     providerUpdatedAt,
     state,
     terminalAt,
@@ -281,6 +276,9 @@ export const persistPullRequestSnapshotInTransaction = async (
         )
       );
     if (existing.headSha !== pullRequest.headSha) {
+      if (terminalPromotion) {
+        await requestGitHubWorkUnitProjection(transaction);
+      }
       return null;
     }
   }
@@ -380,7 +378,7 @@ export const persistPullRequestSnapshotInTransaction = async (
             isCurrent: true,
             mergeSnapshot: state === "merged",
             ...(providerUpdatedAt > version.providerUpdatedAt ||
-            canonicalEvidenceChanged
+            projectionEvidenceChanged
               ? { observedAt: now }
               : {}),
             providerUpdatedAt,
@@ -461,6 +459,16 @@ export const persistPullRequestSnapshotInTransaction = async (
       );
   }
 
+  const projectionInputChanged =
+    projectionEvidenceChanged ||
+    version === undefined ||
+    !version.isCurrent ||
+    storedMembershipInvalid ||
+    (version.fileFactsComplete && !storedDiffComplete);
+  if (projectionInputChanged) {
+    await requestGitHubWorkUnitProjection(transaction);
+  }
+
   return {
     baseRepositoryId: pullRequest.baseRepository.id,
     baseSha: pullRequest.baseSha,
@@ -470,12 +478,7 @@ export const persistPullRequestSnapshotInTransaction = async (
     membershipRefreshRequired,
     pullRequestNodeId: pullRequest.nodeId,
     retryLifecycleReset,
-    snapshotChanged:
-      existing === undefined ||
-      disposition === "newer" ||
-      (disposition === "equal_authoritative" && canonicalEvidenceChanged) ||
-      terminalPromotion ||
-      supplementalEvidenceChanged,
+    snapshotChanged: projectionInputChanged,
     versionId,
   };
 };

--- a/src/lib/github-ref-membership-store.ts
+++ b/src/lib/github-ref-membership-store.ts
@@ -33,6 +33,7 @@ import {
   trackedGitHubAccountFrom,
 } from "@/lib/github-commits-core";
 import type { TrackedGitHubAccount } from "@/lib/github-commits-core";
+import { requestGitHubWorkUnitProjection } from "@/lib/github-work-unit-projection-state";
 
 const DEFAULT_LEASE_MS = 5 * 60 * 1000;
 const SHA = /^[a-f0-9]{40}$/u;
@@ -561,6 +562,7 @@ export const completeGitHubRefRepair = async (
         repairLeaseUntil: null,
       })
       .where(repairIdentity(repair));
+    await requestGitHubWorkUnitProjection(transaction);
     return {
       generation,
       insertedCommits: inserted.length,
@@ -604,6 +606,7 @@ export const completeGitHubRefDeletion = async (
         repairLeaseUntil: null,
       })
       .where(repairIdentity(repair));
+    await requestGitHubWorkUnitProjection(transaction);
     return { stale: false };
   });
 

--- a/src/lib/github-repository-inventory.ts
+++ b/src/lib/github-repository-inventory.ts
@@ -24,6 +24,7 @@ import type {
 } from "@/lib/github-commits-core";
 import { collectAccessibleGitHubRepositories } from "@/lib/github-reconciliation";
 import { upsertGitHubRepositoryInventory } from "@/lib/github-repository-store";
+import { requestGitHubWorkUnitProjection } from "@/lib/github-work-unit-projection-state";
 
 const INVENTORY_REFRESH_INTERVAL_MS = 24 * 60 * 60 * 1000;
 const INVENTORY_RETRY_INTERVAL_MS = 15 * 60 * 1000;
@@ -228,6 +229,7 @@ const publishGitHubRepositoryInventory = async (
           )
         );
     }
+    await requestGitHubWorkUnitProjection(transaction);
   });
 };
 

--- a/src/lib/github-repository-store.ts
+++ b/src/lib/github-repository-store.ts
@@ -1,12 +1,13 @@
-import { and, eq, inArray, isNotNull, isNull, lte, or, sql } from "drizzle-orm";
+import { inArray, isNull, lte, or, sql } from "drizzle-orm";
 
 import type { getDatabase } from "@/db/client";
-import { githubRepositories, githubWorkUnits } from "@/db/schema";
+import { githubRepositories } from "@/db/schema";
 import type {
   GitHubRepository,
   GitHubRepositoryFacts,
   GitHubRepositoryInventoryFacts,
 } from "@/lib/github-commits-core";
+import { requestGitHubWorkUnitProjection } from "@/lib/github-work-unit-projection-state";
 
 type DatabaseTransaction = Parameters<
   Parameters<ReturnType<typeof getDatabase>["transaction"]>[0]
@@ -81,105 +82,59 @@ const githubRepositoryValuesFrom = (
   ...githubRepositoryInventoryValuesFrom(repository, observedAt),
 });
 
-const normalizedOptionalText = (value: string | null) => {
-  const normalized = value?.trim() ?? "";
-  return normalized.length === 0 ? null : normalized;
-};
-
-const normalizedTopics = (topics: readonly string[] | null) =>
-  JSON.stringify(
-    [
-      ...new Set((topics ?? []).map((topic) => topic.trim()).filter(Boolean)),
-    ].toSorted()
-  );
-
-const summaryContextChanged = (
+const repositoryProjectionInputChanged = (
   existing: {
-    description: string | null;
+    defaultBranch: string | null;
+    factsVerifiedAt: Date | null;
     fullName: string;
-    homepageUrl: string | null;
-    inventoryVerifiedAt: Date | null;
     lastObservedAt: Date;
-    topics: readonly string[] | null;
+    visibility: string | null;
   },
   repository: GitHubRepository,
-  observedAt: Date,
-  includeMetadata: boolean
+  observedAt: Date
 ) => {
   const identityChanged =
     existing.lastObservedAt <= observedAt &&
     existing.fullName !== repository.fullName;
-  const metadataChanged =
-    includeMetadata &&
-    hasInventoryFacts(repository) &&
-    (existing.inventoryVerifiedAt === null ||
-      existing.inventoryVerifiedAt <= observedAt) &&
-    (normalizedOptionalText(existing.description) !==
-      normalizedOptionalText(repository.description) ||
-      normalizedOptionalText(existing.homepageUrl) !==
-        normalizedOptionalText(repository.homepageUrl) ||
-      normalizedTopics(existing.topics) !==
-        normalizedTopics(repository.topics));
-  return identityChanged || metadataChanged;
+  const factsChanged =
+    hasRepositoryFacts(repository) &&
+    repository.visibility !== null &&
+    (existing.factsVerifiedAt === null ||
+      existing.factsVerifiedAt <= observedAt) &&
+    (existing.factsVerifiedAt === null ||
+      existing.visibility !== repository.visibility ||
+      existing.defaultBranch !==
+        (repository.defaultBranch ?? existing.defaultBranch));
+  return identityChanged || factsChanged;
 };
 
-const changedSummaryContextRepositoryIds = async (
+const anyRepositoryProjectionInputChanged = async (
   transaction: DatabaseTransaction,
   repositories: readonly GitHubRepository[],
-  observedAt: Date,
-  includeMetadata: boolean
+  observedAt: Date
 ) => {
   const repositoryIds = [...new Set(repositories.map(({ id }) => id))];
   const existingRows = await transaction
     .select({
-      description: githubRepositories.description,
+      defaultBranch: githubRepositories.defaultBranch,
+      factsVerifiedAt: githubRepositories.factsVerifiedAt,
       fullName: githubRepositories.fullName,
-      homepageUrl: githubRepositories.homepageUrl,
       id: githubRepositories.id,
-      inventoryVerifiedAt: githubRepositories.inventoryVerifiedAt,
       lastObservedAt: githubRepositories.lastObservedAt,
-      topics: githubRepositories.topics,
+      visibility: githubRepositories.visibility,
     })
     .from(githubRepositories)
     .where(inArray(githubRepositories.id, repositoryIds))
     .orderBy(githubRepositories.id)
     .for("update");
   const existingById = new Map(existingRows.map((row) => [row.id, row]));
-  return [
-    ...new Set(
-      repositories.flatMap((repository) => {
-        const existing = existingById.get(repository.id);
-        return existing !== undefined &&
-          summaryContextChanged(
-            existing,
-            repository,
-            observedAt,
-            includeMetadata
-          )
-          ? [repository.id]
-          : [];
-      })
-    ),
-  ];
-};
-
-const invalidateChangedRepositorySummaries = async (
-  transaction: DatabaseTransaction,
-  repositoryIds: readonly string[]
-) => {
-  if (repositoryIds.length === 0) {
-    return;
-  }
-  await transaction
-    .update(githubWorkUnits)
-    .set({ summaryInputDigest: null })
-    .where(
-      and(
-        inArray(githubWorkUnits.repositoryId, repositoryIds),
-        eq(githubWorkUnits.visibility, "public"),
-        isNotNull(githubWorkUnits.summaryInputDigest)
-      )
+  return repositories.some((repository) => {
+    const existing = existingById.get(repository.id);
+    return (
+      existing !== undefined &&
+      repositoryProjectionInputChanged(existing, repository, observedAt)
     );
+  });
 };
 
 const upsertGitHubRepositoryIdentity = async (
@@ -292,11 +247,10 @@ export const upsertGitHubRepositories = async (
   if (repositories.length === 0) {
     return;
   }
-  const changedRepositoryIds = await changedSummaryContextRepositoryIds(
+  const projectionInputChanged = await anyRepositoryProjectionInputChanged(
     transaction,
     repositories,
-    observedAt,
-    false
+    observedAt
   );
   await upsertGitHubRepositoryIdentity(transaction, repositories, observedAt);
   await upsertGitHubRepositoryFacts(
@@ -305,7 +259,9 @@ export const upsertGitHubRepositories = async (
     observedAt,
     false
   );
-  await invalidateChangedRepositorySummaries(transaction, changedRepositoryIds);
+  if (projectionInputChanged) {
+    await requestGitHubWorkUnitProjection(transaction);
+  }
 };
 
 export const upsertGitHubRepositoryInventory = async (
@@ -316,12 +272,6 @@ export const upsertGitHubRepositoryInventory = async (
   if (repositories.length === 0) {
     return;
   }
-  const changedRepositoryIds = await changedSummaryContextRepositoryIds(
-    transaction,
-    repositories,
-    observedAt,
-    true
-  );
   await upsertGitHubRepositoryIdentity(transaction, repositories, observedAt);
   await upsertGitHubRepositoryFacts(
     transaction,
@@ -334,7 +284,6 @@ export const upsertGitHubRepositoryInventory = async (
     repositories,
     observedAt
   );
-  await invalidateChangedRepositorySummaries(transaction, changedRepositoryIds);
 };
 
 export const upsertGitHubRepository = async (

--- a/src/lib/github-work-unit-core.ts
+++ b/src/lib/github-work-unit-core.ts
@@ -2,6 +2,7 @@ import { createHash } from "node:crypto";
 
 import { aggregateGitHubLanguages } from "@/lib/github-change-evidence";
 import type {
+  GitHubFileChangeStat,
   GitHubLanguageFact,
   GitHubWorkUnitFileFact,
 } from "@/lib/github-change-evidence";
@@ -28,7 +29,7 @@ export interface GitHubLogicalChange {
   contentObservedAt: string;
   deletions: number;
   enrichmentComplete: boolean;
-  fileFacts: readonly GitHubWorkUnitFileFact[];
+  fileFacts: readonly GitHubFileChangeStat[];
   fileFactsComplete: boolean;
   mergedPullRequestLanding: boolean;
   logicalActivityAt: string;
@@ -40,6 +41,7 @@ export interface GitHubLogicalChange {
   pullRequestCoverageComplete: boolean;
   repositoryId: string;
   sha: string;
+  summaryFileFacts: readonly GitHubWorkUnitFileFact[] | null;
 }
 
 export interface GitHubRepositoryProjectionEvidence {
@@ -94,6 +96,10 @@ export interface GitHubWorkUnitProjectionInput {
   refs: readonly GitHubRefProjectionEvidence[];
   repositories: readonly GitHubRepositoryProjectionEvidence[];
   trackedAuthorUserIds: ReadonlySet<string>;
+}
+
+interface GitHubWorkUnitProjectionOptions {
+  outcomeDigests?: ReadonlyMap<string, string | null>;
 }
 
 export interface GitHubWorkUnitOwnershipIndex {
@@ -285,13 +291,15 @@ const digestCompositeOutcome = (
   orderedChanges: readonly GitHubLogicalChange[]
 ): string | null => {
   const changes = orderedChanges.map((change) =>
-    githubWorkUnitSummaryDiffEvidenceFrom(
-      change.fileFacts,
-      change.additions,
-      change.deletions,
-      change.fileFactsComplete,
-      change.providerFileCapReached
-    )
+    change.summaryFileFacts === null
+      ? null
+      : githubWorkUnitSummaryDiffEvidenceFrom(
+          change.summaryFileFacts,
+          change.additions,
+          change.deletions,
+          change.fileFactsComplete,
+          change.providerFileCapReached
+        )
   );
   if (changes.some((change) => change === null)) {
     return null;
@@ -399,7 +407,7 @@ export const chooseEffectivePullRequest = (
   return eligible[0] ?? null;
 };
 
-export const choosePrimarySideRef = (
+const choosePrimarySideRef = (
   refs: readonly GitHubRefProjectionEvidence[]
 ): GitHubRefProjectionEvidence | null => {
   const completeHeads = refs
@@ -481,11 +489,11 @@ export const stableTopologicalOrder = <
   return ordered;
 };
 
-export const aggregateGitHubWorkUnitFacts = (
+const aggregateGitHubWorkUnitFacts = (
   changes: readonly GitHubLogicalChange[]
 ): GitHubWorkUnitFacts => {
   const filenames = new Set<string>();
-  const files: GitHubWorkUnitFileFact[] = [];
+  const files: GitHubFileChangeStat[] = [];
   let additions = 0;
   let deletions = 0;
 
@@ -673,7 +681,8 @@ const projectedUnitFrom = (
   repository: GitHubRepositoryProjectionEvidence,
   changes: readonly GitHubLogicalChange[],
   trackedAuthorUserIds: ReadonlySet<string>,
-  priorAnchors: ReadonlyMap<string, string>
+  priorAnchors: ReadonlyMap<string, string>,
+  outcomeDigests: ReadonlyMap<string, string | null> | undefined
 ): GitHubProjectedWorkUnit | null => {
   const visibility = visibilityFrom(repository.visibility);
   if (visibility === null) {
@@ -690,11 +699,10 @@ const projectedUnitFrom = (
   const orderedChanges = stableTopologicalOrder(keyedChanges);
   const facts = aggregateGitHubWorkUnitFacts(orderedChanges);
   const identityKey = identityKeyFrom(owner);
-  const outcomeDigest = outcomeDigestFor(
-    owner,
-    orderedChanges,
-    trackedAuthorUserIds
-  );
+  const outcomeDigest =
+    outcomeDigests !== undefined && outcomeDigests.has(identityKey)
+      ? (outcomeDigests.get(identityKey) ?? null)
+      : outcomeDigestFor(owner, orderedChanges, trackedAuthorUserIds);
   const currentAnchor = maxInstant(
     orderedChanges.map((change) => change.logicalActivityAt)
   );
@@ -793,7 +801,8 @@ const projectedUnitFrom = (
 
 export const projectGitHubWorkUnits = (
   input: GitHubWorkUnitProjectionInput,
-  ownership = indexGitHubWorkUnitOwnershipEvidence(input)
+  ownership = indexGitHubWorkUnitOwnershipEvidence(input),
+  options: GitHubWorkUnitProjectionOptions = {}
 ): readonly GitHubProjectedWorkUnit[] => {
   const priorAnchors = new Map(
     (input.priorActivityAnchors ?? []).map((anchor) => [
@@ -855,7 +864,8 @@ export const projectGitHubWorkUnits = (
       group.repository,
       group.changes,
       input.trackedAuthorUserIds,
-      priorAnchors
+      priorAnchors,
+      options.outcomeDigests
     );
     if (unit !== null) {
       projected.push(unit);

--- a/src/lib/github-work-unit-crosswalk.ts
+++ b/src/lib/github-work-unit-crosswalk.ts
@@ -67,6 +67,7 @@ export interface GitHubWorkUnitCrosswalk {
   categories: {
     associatedOrRemovedUnreachableChanges: GitHubWorkUnitCrosswalkBucket;
     authoredPullRequestsWithoutOwnedCurrentMember: GitHubWorkUnitCrosswalkBucket;
+    commitEnrichmentBacklog: GitHubWorkUnitCrosswalkBucket;
     eligibleTrackedChanges: GitHubWorkUnitCrosswalkBucket;
     integrationMerges: GitHubWorkUnitCrosswalkBucket;
     projectedBranchUnits: GitHubWorkUnitCrosswalkBucket;
@@ -88,13 +89,14 @@ export interface GitHubWorkUnitCrosswalk {
   coverageGaps: GitHubWorkUnitCrosswalkReasonBuckets<GitHubWorkUnitCoverageGapReason>;
   invariants: {
     failures: readonly (
+      | "commit_enrichment_backlog"
       | "projection_coverage_gap"
       | "repository_visibility_gap"
     )[];
     passed: boolean;
   };
   policyExclusions: GitHubWorkUnitCrosswalkReasonBuckets<GitHubWorkUnitPolicyExclusionReason>;
-  version: 2;
+  version: 3;
 }
 
 const bytewiseCompare = (left: string, right: string) =>
@@ -250,6 +252,11 @@ export const buildGitHubWorkUnitCrosswalk = (
     isEligibleGitHubWorkChange(change, snapshot.input.trackedAuthorUserIds)
   );
   const eligibleKeys = new Set(eligibleChanges.map(logicalKeyFrom));
+  const enrichmentBacklogKeys = new Set(
+    trackedChanges
+      .filter((change) => !change.enrichmentComplete)
+      .map(logicalKeyFrom)
+  );
   const integrationMergeKeys = new Set(
     trackedChanges
       .filter((change) => change.parentCount > 1)
@@ -259,7 +266,9 @@ export const buildGitHubWorkUnitCrosswalk = (
     trackedChanges
       .filter(
         (change) =>
-          !eligibleKeys.has(logicalKeyFrom(change)) && change.parentCount <= 1
+          !eligibleKeys.has(logicalKeyFrom(change)) &&
+          !enrichmentBacklogKeys.has(logicalKeyFrom(change)) &&
+          change.parentCount <= 1
       )
       .map(logicalKeyFrom)
   );
@@ -342,6 +351,9 @@ export const buildGitHubWorkUnitCrosswalk = (
   const failures = new Set<
     GitHubWorkUnitCrosswalk["invariants"]["failures"][number]
   >();
+  if (enrichmentBacklogKeys.size > 0) {
+    failures.add("commit_enrichment_backlog");
+  }
   if (coverageGaps.count > 0) {
     failures.add("projection_coverage_gap");
   }
@@ -356,6 +368,7 @@ export const buildGitHubWorkUnitCrosswalk = (
       authoredPullRequestsWithoutOwnedCurrentMember: bucketFrom(
         authoredPullRequestsWithoutOwnedCurrentMember
       ),
+      commitEnrichmentBacklog: bucketFrom(enrichmentBacklogKeys),
       eligibleTrackedChanges: bucketFrom(eligibleKeys),
       integrationMerges: bucketFrom(integrationMergeKeys),
       projectedBranchUnits: bucketFrom(
@@ -392,7 +405,7 @@ export const buildGitHubWorkUnitCrosswalk = (
       passed: orderedFailures.length === 0,
     },
     policyExclusions,
-    version: 2,
+    version: 3,
   };
 };
 

--- a/src/lib/github-work-unit-projection-state.ts
+++ b/src/lib/github-work-unit-projection-state.ts
@@ -1,0 +1,78 @@
+import { randomUUID } from "node:crypto";
+
+import { and, eq, sql } from "drizzle-orm";
+
+import { getDatabase } from "@/db/client";
+import { githubPublicFeedHead } from "@/db/schema";
+import { GITHUB_WORK_UNIT_SUMMARY_POLICY_DIGEST } from "@/lib/github-work-unit-summary";
+
+type Database = ReturnType<typeof getDatabase>;
+type DatabaseTransaction = Parameters<
+  Parameters<Database["transaction"]>[0]
+>[0];
+
+const PROJECTION_LOCK = "github-work-unit-projection-v1";
+
+export const acquireGitHubWorkUnitProjectionLock = async (
+  transaction: DatabaseTransaction
+) => {
+  await transaction.execute(
+    sql`select pg_advisory_xact_lock(hashtext(${PROJECTION_LOCK}))`
+  );
+};
+
+export const requestGitHubWorkUnitProjection = async (
+  executor: Database | DatabaseTransaction
+) => {
+  const token = randomUUID();
+  const [requested] = await executor
+    .update(githubPublicFeedHead)
+    .set({ projectionRequestToken: token })
+    .where(eq(githubPublicFeedHead.id, true))
+    .returning({ token: githubPublicFeedHead.projectionRequestToken });
+  if (requested?.token !== token) {
+    throw new Error("The GitHub work-unit projection could not be requested.");
+  }
+  return token;
+};
+
+export const ensureGitHubWorkUnitProjectionRequest = async () =>
+  await getDatabase().transaction(async (transaction) => {
+    const [head] = await transaction
+      .select({
+        summaryPolicyDigest: githubPublicFeedHead.summaryPolicyDigest,
+        token: githubPublicFeedHead.projectionRequestToken,
+      })
+      .from(githubPublicFeedHead)
+      .where(eq(githubPublicFeedHead.id, true))
+      .for("update");
+    if (head === undefined) {
+      throw new Error("The GitHub public feed head is unavailable.");
+    }
+    if (
+      head.token !== null ||
+      head.summaryPolicyDigest === GITHUB_WORK_UNIT_SUMMARY_POLICY_DIGEST
+    ) {
+      return head.token;
+    }
+    return await requestGitHubWorkUnitProjection(transaction);
+  });
+
+export const completeGitHubWorkUnitProjectionRequest = async (
+  token: string
+) => {
+  const [cleared] = await getDatabase()
+    .update(githubPublicFeedHead)
+    .set({
+      projectionRequestToken: null,
+      summaryPolicyDigest: GITHUB_WORK_UNIT_SUMMARY_POLICY_DIGEST,
+    })
+    .where(
+      and(
+        eq(githubPublicFeedHead.id, true),
+        eq(githubPublicFeedHead.projectionRequestToken, token)
+      )
+    )
+    .returning({ id: githubPublicFeedHead.id });
+  return cleared !== undefined;
+};

--- a/src/lib/github-work-unit-store.ts
+++ b/src/lib/github-work-unit-store.ts
@@ -1,4 +1,4 @@
-import { and, asc, eq, inArray, ne, or, sql } from "drizzle-orm";
+import { and, asc, eq, inArray, or, sql } from "drizzle-orm";
 
 import { getDatabase } from "@/db/client";
 import {
@@ -21,6 +21,7 @@ import {
 } from "@/db/schema";
 import { PUBLIC_GITHUB_ACTIVITY_DAY_PAGE_SIZE } from "@/lib/github-activity-store";
 import type {
+  GitHubFileChangeStat,
   GitHubLanguageFact,
   GitHubWorkUnitFileFact,
 } from "@/lib/github-change-evidence";
@@ -43,17 +44,26 @@ import type {
   GitHubWorkUnitProjectionInput,
 } from "@/lib/github-work-unit-core";
 import {
+  acquireGitHubWorkUnitProjectionLock,
+  completeGitHubWorkUnitProjectionRequest,
+  requestGitHubWorkUnitProjection,
+} from "@/lib/github-work-unit-projection-state";
+import {
   buildGitHubWorkUnitSummaryInput,
+  digestGitHubWorkUnitSummaryEvaluation,
   GITHUB_WORK_UNIT_SUMMARY_RECIPE,
 } from "@/lib/github-work-unit-summary";
 import type {
+  GitHubWorkUnitSummaryBuildResult,
   GitHubWorkUnitSummaryCandidate,
+  GitHubWorkUnitSummaryEvaluationEvidence,
   GitHubWorkUnitSummaryOutcomeEvidence,
   GitHubWorkUnitSummaryRepositoryContext,
 } from "@/lib/github-work-unit-summary";
 
-const PROJECTION_LOCK = "github-work-unit-projection-v1";
+const SUMMARY_EVALUATION_LIMIT = 8;
 const SUMMARY_DEBOUNCE_MS = 5 * 60 * 1000;
+const DIGEST = /^[a-f0-9]{64}$/u;
 const SHA = /^[a-f0-9]{40}$/u;
 
 const trackedAuthorUserIds = new Set<string>(
@@ -99,6 +109,8 @@ export interface GitHubWorkUnitProjectionRefreshResult {
   insertedUnits: number;
   orderingRevisionChanged: boolean;
   summaryAttemptsQueued: number;
+  summaryEvaluationsPending: number;
+  summaryEvaluationsSettled: number;
   summaryInputsFailed: number;
   summaryInputsSet: number;
   updatedUnits: number;
@@ -127,6 +139,8 @@ interface CurrentWorkUnitRow {
   pullRequestNodeId: string | null;
   repositoryId: string;
   revision: number;
+  summaryEvaluationDigest: string | null;
+  summaryEvaluatedDigest: string | null;
   summaryInputDigest: string | null;
   visibility: string;
 }
@@ -138,12 +152,20 @@ interface LoadedProjectionSnapshot extends GitHubWorkUnitProjectionSnapshot {
     string,
     GitHubWorkUnitSummaryRepositoryContext
   >;
+  selectedSummaryEvaluationIdentities: ReadonlySet<string>;
+  summaryEvaluationDigests: ReadonlyMap<string, string>;
+  summaryEvaluationEvidence: ReadonlyMap<
+    string,
+    GitHubWorkUnitSummaryEvaluationEvidence
+  >;
+  summaryEvaluationsPending: number;
 }
 
 interface PersistedProjectionUnit {
   id: string;
   projected: GitHubProjectedWorkUnit;
   revision: number;
+  summaryEvaluationDigest: string;
 }
 
 interface ProjectionSwapResult {
@@ -153,6 +175,18 @@ interface ProjectionSwapResult {
   orderingRevisionChanged: boolean;
   summaryCandidates: readonly PersistedProjectionUnit[];
   updatedUnits: number;
+}
+
+interface CommitSummaryEvaluationEvidence {
+  additions: number;
+  deletions: number;
+  fileFactsDigest: string | null;
+}
+
+interface PullRequestSummaryEvaluationEvidence {
+  fileFactsComplete: boolean;
+  fileFactsDigest: string | null;
+  versionId: string;
 }
 
 const bytewiseCompare = (left: string, right: string) =>
@@ -177,8 +211,11 @@ const isRecord = (value: unknown): value is Record<string, unknown> =>
 const checkedFileFacts = (
   value: unknown
 ): readonly GitHubWorkUnitFileFact[] | null => {
-  if (!Array.isArray(value)) {
+  if (value === null) {
     return null;
+  }
+  if (!Array.isArray(value)) {
+    throw new TypeError("Stored GitHub file evidence must be an array.");
   }
   const facts: GitHubWorkUnitFileFact[] = [];
   for (const item of value) {
@@ -196,7 +233,7 @@ const checkedFileFacts = (
         item.previousFilename !== null) ||
       typeof item.status !== "string"
     ) {
-      return null;
+      throw new TypeError("Stored GitHub file evidence is invalid.");
     }
     facts.push({
       additions: item.additions as number,
@@ -212,12 +249,76 @@ const checkedFileFacts = (
   return facts;
 };
 
+const compactFileFacts = sql<unknown>`case
+when ${githubCommits.fileFacts} is null then null
+else coalesce(
+  (
+    select jsonb_agg(
+      jsonb_build_object(
+        'additions', entry.value -> 'additions',
+        'deletions', entry.value -> 'deletions',
+        'filename', entry.value -> 'filename'
+      )
+      order by entry.position
+    )
+    from jsonb_array_elements(${githubCommits.fileFacts})
+      with ordinality as entry(value, position)
+  ),
+  '[]'::jsonb
+)
+end`;
+
+const checkedCompactFileFacts = (
+  value: unknown
+): readonly GitHubFileChangeStat[] | null => {
+  if (value === null) {
+    return null;
+  }
+  if (!Array.isArray(value)) {
+    throw new TypeError(
+      "Stored compact GitHub file evidence must be an array."
+    );
+  }
+  const facts: GitHubFileChangeStat[] = [];
+  for (const item of value) {
+    if (
+      !isRecord(item) ||
+      !Number.isSafeInteger(item.additions) ||
+      (item.additions as number) < 0 ||
+      !Number.isSafeInteger(item.deletions) ||
+      (item.deletions as number) < 0 ||
+      typeof item.filename !== "string"
+    ) {
+      throw new TypeError("Stored compact GitHub file evidence is invalid.");
+    }
+    facts.push({
+      additions: item.additions as number,
+      deletions: item.deletions as number,
+      filename: item.filename,
+    });
+  }
+  return facts;
+};
+
+const checkedDigest = (value: string | null) => {
+  if (value === null) {
+    return null;
+  }
+  if (!DIGEST.test(value)) {
+    throw new Error("A stored GitHub file-evidence digest is invalid.");
+  }
+  return value;
+};
+
 const checkedParentShas = (value: unknown): readonly string[] | null => {
+  if (value === null) {
+    return null;
+  }
   if (
     !Array.isArray(value) ||
     value.some((sha) => typeof sha !== "string" || !SHA.test(sha))
   ) {
-    return null;
+    throw new TypeError("Stored GitHub parent evidence is invalid.");
   }
   return value;
 };
@@ -262,6 +363,8 @@ const currentWorkUnitSelection = {
   pullRequestNodeId: githubWorkUnits.pullRequestNodeId,
   repositoryId: githubWorkUnits.repositoryId,
   revision: githubWorkUnits.revision,
+  summaryEvaluationDigest: githubWorkUnits.summaryEvaluationDigest,
+  summaryEvaluatedDigest: githubWorkUnits.summaryEvaluatedDigest,
   summaryInputDigest: githubWorkUnits.summaryInputDigest,
   visibility: githubWorkUnits.visibility,
 };
@@ -417,10 +520,233 @@ const excludedChangesFrom = (
   );
 };
 
+const summaryUsesPullRequestNetOutcome = (
+  unit: GitHubProjectedWorkUnit,
+  pullRequestsByNodeId: ReadonlyMap<string, GitHubPullRequestProjectionEvidence>
+) =>
+  unit.kind === "pull_request" &&
+  unit.attributionMode === "tracked_authored_pr" &&
+  unit.pullRequestNodeId !== null &&
+  pullRequestsByNodeId.get(unit.pullRequestNodeId)
+    ?.netOutcomeOwnedCompletely === true;
+
+const summaryEvaluationEvidenceFrom = (
+  unit: GitHubProjectedWorkUnit,
+  commitsByLogicalKey: ReadonlyMap<string, CommitSummaryEvaluationEvidence>,
+  pullRequestsByNodeId: ReadonlyMap<
+    string,
+    GitHubPullRequestProjectionEvidence
+  >,
+  pullRequestEvidenceByNodeId: ReadonlyMap<
+    string,
+    PullRequestSummaryEvaluationEvidence
+  >
+): GitHubWorkUnitSummaryEvaluationEvidence => {
+  if (summaryUsesPullRequestNetOutcome(unit, pullRequestsByNodeId)) {
+    const pullRequest =
+      unit.pullRequestNodeId === null
+        ? undefined
+        : pullRequestEvidenceByNodeId.get(unit.pullRequestNodeId);
+    if (pullRequest === undefined) {
+      throw new Error(
+        `A pull-request summary lacks evaluation evidence: ${unit.identityKey}`
+      );
+    }
+    return {
+      fileFactsComplete: pullRequest.fileFactsComplete,
+      fileFactsDigest: pullRequest.fileFactsDigest,
+      mode: "net",
+    };
+  }
+  return {
+    changes: unit.members.map((member) => {
+      const change = commitsByLogicalKey.get(member.logicalKey);
+      if (change === undefined) {
+        throw new Error(
+          `A work-unit summary lacks commit evidence: ${member.logicalKey}`
+        );
+      }
+      const { additions, deletions, fileFactsDigest } = change;
+      if (fileFactsDigest === null) {
+        throw new Error(
+          `An eligible work-unit member lacks a file digest: ${member.logicalKey}`
+        );
+      }
+      return { additions, deletions, fileFactsDigest };
+    }),
+    mode: "composite",
+  };
+};
+
+const summaryEvaluationDigestFrom = (
+  unit: GitHubProjectedWorkUnit,
+  evidence: GitHubWorkUnitSummaryEvaluationEvidence,
+  repository: GitHubWorkUnitSummaryRepositoryContext
+) =>
+  digestGitHubWorkUnitSummaryEvaluation({
+    attributionMode: unit.attributionMode,
+    evidence,
+    kind: unit.kind,
+    membershipDigest: unit.membershipDigest,
+    repository,
+  });
+
+const requiredHydratedFileFacts = (
+  factsByKey: ReadonlyMap<string, readonly GitHubWorkUnitFileFact[] | null>,
+  key: string
+) => {
+  if (!factsByKey.has(key)) {
+    throw new Error(
+      `GitHub summary evidence disappeared while hydrating: ${key}`
+    );
+  }
+  return factsByKey.get(key) ?? null;
+};
+
+const hydrateSelectedSummaryEvidence = async (
+  transaction: GitHubWorkUnitTransaction,
+  input: GitHubWorkUnitProjectionInput,
+  units: readonly GitHubProjectedWorkUnit[],
+  pullRequestEvidenceByNodeId: ReadonlyMap<
+    string,
+    PullRequestSummaryEvaluationEvidence
+  >
+): Promise<GitHubWorkUnitProjectionInput> => {
+  if (units.length === 0) {
+    return input;
+  }
+  const pullRequestsByNodeId = new Map(
+    input.pullRequests.map((pullRequest) => [pullRequest.nodeId, pullRequest])
+  );
+  const netPullRequestNodeIds = new Set<string>();
+  const compositeMembers = new Map<
+    string,
+    { repositoryId: string; sha: string }
+  >();
+  for (const unit of units) {
+    if (summaryUsesPullRequestNetOutcome(unit, pullRequestsByNodeId)) {
+      if (unit.pullRequestNodeId !== null) {
+        netPullRequestNodeIds.add(unit.pullRequestNodeId);
+      }
+      continue;
+    }
+    for (const member of unit.members) {
+      compositeMembers.set(member.logicalKey, {
+        repositoryId: member.logicalRepositoryId,
+        sha: member.logicalSha,
+      });
+    }
+  }
+
+  const memberRows =
+    compositeMembers.size === 0
+      ? []
+      : await transaction
+          .select({
+            fileFacts: githubCommits.fileFacts,
+            repositoryId: githubCommits.repositoryId,
+            sha: githubCommits.sha,
+          })
+          .from(githubCommits)
+          .where(
+            or(
+              ...[...compositeMembers.values()].map((member) =>
+                and(
+                  eq(githubCommits.repositoryId, member.repositoryId),
+                  eq(githubCommits.sha, member.sha)
+                )
+              )
+            )
+          );
+  const rawCommitFactsByLogicalKey = new Map(
+    memberRows.map((row) => [
+      logicalKeyFrom(row.repositoryId, row.sha),
+      checkedFileFacts(row.fileFacts),
+    ])
+  );
+
+  const versionIds = [...netPullRequestNodeIds].map((nodeId) => {
+    const evidence = pullRequestEvidenceByNodeId.get(nodeId);
+    if (evidence === undefined) {
+      throw new Error(
+        `A pull-request summary lacks version evidence: ${nodeId}`
+      );
+    }
+    return evidence.versionId;
+  });
+  const versionRows =
+    versionIds.length === 0
+      ? []
+      : await transaction
+          .select({
+            fileFacts: githubPullRequestVersions.fileFacts,
+            id: githubPullRequestVersions.id,
+          })
+          .from(githubPullRequestVersions)
+          .where(inArray(githubPullRequestVersions.id, versionIds));
+  const rawPullRequestFactsByVersionId = new Map(
+    versionRows.map((row) => [row.id, checkedFileFacts(row.fileFacts)])
+  );
+
+  return {
+    ...input,
+    changes: input.changes.map((change) => {
+      const logicalKey = logicalKeyFrom(
+        change.logicalRepositoryId,
+        change.logicalSha
+      );
+      if (!compositeMembers.has(logicalKey)) {
+        return change;
+      }
+      const fileFacts = requiredHydratedFileFacts(
+        rawCommitFactsByLogicalKey,
+        logicalKey
+      );
+      return {
+        ...change,
+        fileFacts: fileFacts ?? [],
+        fileFactsComplete: change.fileFactsComplete && fileFacts !== null,
+        summaryFileFacts: fileFacts,
+      };
+    }),
+    pullRequests: input.pullRequests.map((pullRequest) => {
+      if (!netPullRequestNodeIds.has(pullRequest.nodeId)) {
+        return pullRequest;
+      }
+      const evidence = pullRequestEvidenceByNodeId.get(pullRequest.nodeId);
+      if (evidence === undefined) {
+        throw new Error(
+          `A pull-request summary lacks version evidence: ${pullRequest.nodeId}`
+        );
+      }
+      const fileFacts = requiredHydratedFileFacts(
+        rawPullRequestFactsByVersionId,
+        evidence.versionId
+      );
+      return {
+        ...pullRequest,
+        netOutcome:
+          fileFacts === null
+            ? null
+            : {
+                complete: evidence.fileFactsComplete,
+                files: fileFacts,
+                providerFileCapReached: false,
+              },
+      };
+    }),
+  };
+};
+
+interface ProjectionSnapshotOptions {
+  lockCurrentUnits: boolean;
+  summaryEvaluationLimit: number;
+}
+
 // oxlint-disable-next-line eslint/complexity -- This is one linear mapping of a transactionally consistent evidence snapshot; splitting ownership decisions across loaders would duplicate the production contract used by the verifier.
 const loadProjectionSnapshot = async (
   transaction: GitHubWorkUnitTransaction,
-  lockCurrentUnits: boolean
+  { lockCurrentUnits, summaryEvaluationLimit }: ProjectionSnapshotOptions
 ): Promise<LoadedProjectionSnapshot> => {
   const currentUnits = await readCurrentUnits(transaction, lockCurrentUnits);
   const repositoryRows = await transaction
@@ -590,8 +916,9 @@ const loadProjectionSnapshot = async (
       committerAt: githubCommits.committerAt,
       deletions: githubCommits.deletions,
       enrichmentState: githubCommits.enrichmentState,
-      fileFacts: githubCommits.fileFacts,
+      fileFacts: compactFileFacts,
       fileFactsComplete: githubCommits.fileFactsComplete,
+      fileFactsDigest: githubCommits.fileFactsDigest,
       firstObservedAt: githubCommits.firstObservedAt,
       parentShas: githubCommits.parentShas,
       providerFileCapReached: githubCommits.providerFileCapReached,
@@ -610,7 +937,7 @@ const loadProjectionSnapshot = async (
     )
   );
   const changes: GitHubLogicalChange[] = commitRows.map((row) => {
-    const fileFacts = checkedFileFacts(row.fileFacts);
+    const fileFacts = checkedCompactFileFacts(row.fileFacts);
     const parentShas = checkedParentShas(row.parentShas);
     const pullRequestCoverageComplete =
       row.pullRequestDiscoveryState === "complete";
@@ -634,8 +961,19 @@ const loadProjectionSnapshot = async (
       pullRequestCoverageComplete,
       repositoryId: row.repositoryId,
       sha: row.sha,
+      summaryFileFacts: null,
     };
   });
+  const commitSummaryEvidenceByLogicalKey = new Map(
+    commitRows.map((row) => [
+      logicalKeyFrom(row.repositoryId, row.sha),
+      {
+        additions: row.additions ?? -1,
+        deletions: row.deletions ?? -1,
+        fileFactsDigest: checkedDigest(row.fileFactsDigest),
+      },
+    ])
+  );
   const eligibleChanges = new Set(
     changes
       .filter((change) =>
@@ -652,14 +990,13 @@ const loadProjectionSnapshot = async (
       baseSha: githubPullRequestVersions.baseSha,
       commitCount: githubPullRequestVersions.commitCount,
       createdAt: githubPullRequests.createdAt,
-      fileFacts: githubPullRequestVersions.fileFacts,
       fileFactsComplete: githubPullRequestVersions.fileFactsComplete,
+      fileFactsDigest: githubPullRequestVersions.fileFactsDigest,
       headSha: githubPullRequestVersions.headSha,
       mergeSnapshot: githubPullRequestVersions.mergeSnapshot,
       membershipComplete: githubPullRequestVersions.membershipComplete,
       nodeId: githubPullRequests.nodeId,
       observedAt: githubPullRequestVersions.observedAt,
-      providerFileCapReached: githubPullRequests.providerFileCapReached,
       repositoryId: githubPullRequests.repositoryId,
       state: githubPullRequests.state,
       versionId: githubPullRequestVersions.id,
@@ -730,15 +1067,6 @@ const loadProjectionSnapshot = async (
       new Set(memberLogicalKeys).size === memberships.length &&
       (memberships.length === 0 ||
         memberships.at(-1)?.commitSha === row.headSha);
-    const netFiles = checkedFileFacts(row.fileFacts);
-    const netOutcome =
-      netFiles === null
-        ? null
-        : {
-            complete: row.fileFactsComplete,
-            files: netFiles,
-            providerFileCapReached: row.providerFileCapReached,
-          };
     pullRequests.push({
       authorUserId: row.authorUserId,
       baseRepositoryId: row.baseRepositoryId ?? row.repositoryId,
@@ -748,7 +1076,7 @@ const loadProjectionSnapshot = async (
       headSha: row.headSha,
       memberLogicalKeys,
       membershipComplete,
-      netOutcome,
+      netOutcome: null,
       netOutcomeOwnedCompletely:
         membershipComplete &&
         memberLogicalKeys.length > 0 &&
@@ -758,6 +1086,16 @@ const loadProjectionSnapshot = async (
       state: row.state,
     });
   }
+  const pullRequestSummaryEvidenceByNodeId = new Map(
+    pullRequestRows.map((row) => [
+      row.nodeId,
+      {
+        fileFactsComplete: row.fileFactsComplete,
+        fileFactsDigest: checkedDigest(row.fileFactsDigest),
+        versionId: row.versionId,
+      },
+    ])
+  );
   const desiredByRef = new Map(
     desiredHeadRows.map((row) => [
       refKeyFrom(row.repositoryId, row.refName),
@@ -789,10 +1127,7 @@ const loadProjectionSnapshot = async (
       {
         branchLineageId: generation.branchLineageId,
         complete: true,
-        contentObservedAt:
-          desired.lastObservedAt > generation.completedAt
-            ? desired.lastObservedAt.toISOString()
-            : generation.completedAt.toISOString(),
+        contentObservedAt: generation.completedAt.toISOString(),
         headSha: generation.headSha,
         memberLogicalKeys: memberships.map((membership) =>
           logicalKeyFrom(membership.commitRepositoryId, membership.commitSha)
@@ -820,7 +1155,7 @@ const loadProjectionSnapshot = async (
       ),
     })
   );
-  const input: GitHubWorkUnitProjectionInput = {
+  const compactInput: GitHubWorkUnitProjectionInput = {
     changes,
     priorActivityAnchors: currentUnits.flatMap((unit) =>
       unit.outcomeDigest === null
@@ -838,8 +1173,99 @@ const loadProjectionSnapshot = async (
     repositories,
     trackedAuthorUserIds,
   };
-  const ownership = indexGitHubWorkUnitOwnershipEvidence(input);
-  const units = projectGitHubWorkUnits(input, ownership);
+  const cachedOutcomeDigests = new Map(
+    currentUnits.map((unit) => [unit.identityKey, unit.outcomeDigest])
+  );
+  const compactOwnership = indexGitHubWorkUnitOwnershipEvidence(compactInput);
+  const compactUnits = projectGitHubWorkUnits(compactInput, compactOwnership, {
+    outcomeDigests: cachedOutcomeDigests,
+  });
+  const repositoryContexts = new Map(
+    repositoryRows.map((repository) => [
+      repository.id,
+      {
+        description: repository.description,
+        fullName: repository.fullName,
+        homepageUrl: repository.homepageUrl,
+        topics: repository.topics ?? [],
+      },
+    ])
+  );
+  const pullRequestsByNodeId = new Map(
+    pullRequests.map((pullRequest) => [pullRequest.nodeId, pullRequest])
+  );
+  const summaryEvaluationEvidence = new Map<
+    string,
+    GitHubWorkUnitSummaryEvaluationEvidence
+  >();
+  const summaryEvaluationDigests = new Map<string, string>();
+  for (const unit of compactUnits) {
+    if (unit.visibility !== "public") {
+      continue;
+    }
+    const repository = repositoryContexts.get(unit.repositoryId);
+    if (repository === undefined) {
+      throw new Error(
+        `A public work unit lacks repository context: ${unit.identityKey}`
+      );
+    }
+    const evidence = summaryEvaluationEvidenceFrom(
+      unit,
+      commitSummaryEvidenceByLogicalKey,
+      pullRequestsByNodeId,
+      pullRequestSummaryEvidenceByNodeId
+    );
+    summaryEvaluationEvidence.set(unit.identityKey, evidence);
+    summaryEvaluationDigests.set(
+      unit.identityKey,
+      summaryEvaluationDigestFrom(unit, evidence, repository)
+    );
+  }
+  const currentByIdentity = new Map(
+    currentUnits.map((unit) => [unit.identityKey, unit])
+  );
+  const pendingSummaryEvaluations = compactUnits
+    .filter((unit) => {
+      const digest = summaryEvaluationDigests.get(unit.identityKey);
+      return (
+        digest !== undefined &&
+        currentByIdentity.get(unit.identityKey)?.summaryEvaluatedDigest !==
+          digest
+      );
+    })
+    .toSorted(
+      (left, right) =>
+        Date.parse(right.activityAt) - Date.parse(left.activityAt) ||
+        Date.parse(right.contentObservedAt) -
+          Date.parse(left.contentObservedAt) ||
+        bytewiseCompare(left.identityKey, right.identityKey)
+    );
+  const selectedSummaryEvaluations = pendingSummaryEvaluations.slice(
+    0,
+    summaryEvaluationLimit
+  );
+  const input = await hydrateSelectedSummaryEvidence(
+    transaction,
+    compactInput,
+    selectedSummaryEvaluations,
+    pullRequestSummaryEvidenceByNodeId
+  );
+  const selectedSummaryIdentities = new Set(
+    selectedSummaryEvaluations.map((unit) => unit.identityKey)
+  );
+  const outcomeDigests = new Map(
+    [...cachedOutcomeDigests].filter(
+      ([identityKey]) => !selectedSummaryIdentities.has(identityKey)
+    )
+  );
+  const ownership =
+    selectedSummaryEvaluations.length === 0
+      ? compactOwnership
+      : indexGitHubWorkUnitOwnershipEvidence(input);
+  const units =
+    selectedSummaryEvaluations.length === 0
+      ? compactUnits
+      : projectGitHubWorkUnits(input, ownership, { outcomeDigests });
   const excludedChanges = excludedChangesFrom(input, units, ownership);
   const issueRows = await transaction
     .select({
@@ -865,17 +1291,12 @@ const loadProjectionSnapshot = async (
     currentUnits,
     input,
     issueDays,
-    repositoryContexts: new Map(
-      repositoryRows.map((repository) => [
-        repository.id,
-        {
-          description: repository.description,
-          fullName: repository.fullName,
-          homepageUrl: repository.homepageUrl,
-          topics: repository.topics ?? [],
-        },
-      ])
-    ),
+    repositoryContexts,
+    summaryEvaluationDigests,
+    selectedSummaryEvaluationIdentities: selectedSummaryIdentities,
+    summaryEvaluationEvidence,
+    summaryEvaluationsPending:
+      pendingSummaryEvaluations.length - selectedSummaryEvaluations.length,
     excludedChanges,
     exclusionReasonCounts: exclusionReasonCountsFrom(excludedChanges),
     units,
@@ -887,7 +1308,10 @@ export const readGitHubWorkUnitProjectionEvidence =
   async (): Promise<GitHubWorkUnitProjectionSnapshot> =>
     await getDatabase().transaction(
       async (transaction) => {
-        const snapshot = await loadProjectionSnapshot(transaction, false);
+        const snapshot = await loadProjectionSnapshot(transaction, {
+          lockCurrentUnits: false,
+          summaryEvaluationLimit: 0,
+        });
         return {
           excludedChanges: snapshot.excludedChanges,
           exclusionReasonCounts: snapshot.exclusionReasonCounts,
@@ -1017,6 +1441,8 @@ const publicPayloadChanged = (
 const projectedValues = (
   projected: GitHubProjectedWorkUnit,
   revision: number,
+  summaryEvaluationDigest: string | null,
+  summaryEvaluatedDigest: string | null,
   summaryInputDigest: string | null
 ) => ({
   activityAnchorAt: new Date(projected.activityAnchorAt),
@@ -1042,6 +1468,8 @@ const projectedValues = (
   pullRequestNodeId: projected.pullRequestNodeId,
   repositoryId: projected.repositoryId,
   revision,
+  summaryEvaluationDigest,
+  summaryEvaluatedDigest,
   summaryInputDigest,
   visibility: projected.visibility,
 });
@@ -1053,6 +1481,153 @@ const membershipValues = (unitId: string, unit: GitHubProjectedWorkUnit) =>
     position: member.position,
     workUnitId: unitId,
   }));
+
+const persistedSummaryCandidate = (
+  snapshot: LoadedProjectionSnapshot,
+  id: string,
+  projected: GitHubProjectedWorkUnit,
+  revision: number
+): PersistedProjectionUnit | null => {
+  if (
+    !snapshot.selectedSummaryEvaluationIdentities.has(projected.identityKey)
+  ) {
+    return null;
+  }
+  const summaryEvaluationDigest = snapshot.summaryEvaluationDigests.get(
+    projected.identityKey
+  );
+  if (summaryEvaluationDigest === undefined) {
+    throw new Error(
+      `A selected summary lacks an evaluation digest: ${projected.identityKey}`
+    );
+  }
+  return { id, projected, revision, summaryEvaluationDigest };
+};
+
+const projectedSummaryEvaluationDigest = (
+  snapshot: LoadedProjectionSnapshot,
+  projected: GitHubProjectedWorkUnit
+) => {
+  const digest = snapshot.summaryEvaluationDigests.get(projected.identityKey);
+  if (projected.visibility === "public" && digest === undefined) {
+    throw new Error(
+      `A public work unit lacks a summary evaluation digest: ${projected.identityKey}`
+    );
+  }
+  return digest ?? null;
+};
+
+const persistProjectedUnit = async (
+  transaction: GitHubWorkUnitTransaction,
+  snapshot: LoadedProjectionSnapshot,
+  projected: GitHubProjectedWorkUnit,
+  current: CurrentWorkUnitRow | undefined
+): Promise<PersistedProjectionUnit | null> => {
+  const summaryEvaluationDigest = projectedSummaryEvaluationDigest(
+    snapshot,
+    projected
+  );
+  if (current === undefined) {
+    const [row] = await transaction
+      .insert(githubWorkUnits)
+      .values(
+        projectedValues(projected, 1, summaryEvaluationDigest, null, null)
+      )
+      .returning({ id: githubWorkUnits.id });
+    if (row === undefined) {
+      throw new Error("A GitHub work unit could not be inserted.");
+    }
+    await transaction
+      .insert(githubWorkUnitMemberships)
+      .values(membershipValues(row.id, projected));
+    return persistedSummaryCandidate(snapshot, row.id, projected, 1);
+  }
+
+  const summaryEvaluationChanged =
+    summaryEvaluationDigest !== current.summaryEvaluationDigest;
+  if (!materialProjectionChanged(current, projected)) {
+    const contentObservedAtChanged =
+      current.contentObservedAt.toISOString() !== projected.contentObservedAt;
+    if (contentObservedAtChanged || summaryEvaluationChanged) {
+      await transaction
+        .update(githubWorkUnits)
+        .set({
+          ...(contentObservedAtChanged
+            ? { contentObservedAt: new Date(projected.contentObservedAt) }
+            : {}),
+          ...(summaryEvaluationChanged ? { summaryEvaluationDigest } : {}),
+        })
+        .where(eq(githubWorkUnits.id, current.id));
+    }
+    return persistedSummaryCandidate(
+      snapshot,
+      current.id,
+      projected,
+      current.revision
+    );
+  }
+
+  const keepPublicSummary = projected.visibility === "public";
+  const revision = current.revision + 1;
+  await transaction
+    .update(githubWorkUnits)
+    .set(
+      projectedValues(
+        projected,
+        revision,
+        keepPublicSummary ? summaryEvaluationDigest : null,
+        keepPublicSummary ? current.summaryEvaluatedDigest : null,
+        keepPublicSummary ? current.summaryInputDigest : null
+      )
+    )
+    .where(eq(githubWorkUnits.id, current.id));
+  await transaction
+    .insert(githubWorkUnitMemberships)
+    .values(membershipValues(current.id, projected));
+  if (!keepPublicSummary) {
+    await transaction
+      .delete(githubWorkUnitSummaryAttempts)
+      .where(eq(githubWorkUnitSummaryAttempts.workUnitId, current.id));
+  }
+  return persistedSummaryCandidate(snapshot, current.id, projected, revision);
+};
+
+const persistSummaryEvaluationTargets = async (
+  transaction: GitHubWorkUnitTransaction,
+  snapshot: LoadedProjectionSnapshot,
+  currentByIdentity: Map<string, CurrentWorkUnitRow>
+) => {
+  const targets = snapshot.units.flatMap((projected) => {
+    const current = currentByIdentity.get(projected.identityKey);
+    const digest = snapshot.summaryEvaluationDigests.get(projected.identityKey);
+    return projected.visibility === "public" &&
+      current !== undefined &&
+      digest !== undefined &&
+      !materialProjectionChanged(current, projected) &&
+      current.summaryEvaluationDigest !== digest
+      ? [{ digest, id: current.id, identityKey: projected.identityKey }]
+      : [];
+  });
+  if (targets.length === 0) {
+    return;
+  }
+  await transaction.execute(sql`
+    update ${githubWorkUnits} as work_unit
+    set summary_evaluation_digest = target.digest
+    from jsonb_to_recordset(${JSON.stringify(targets)}::jsonb)
+      as target(id uuid, digest varchar(64))
+    where work_unit.id = target.id
+  `);
+  for (const target of targets) {
+    const current = currentByIdentity.get(target.identityKey);
+    if (current !== undefined) {
+      currentByIdentity.set(target.identityKey, {
+        ...current,
+        summaryEvaluationDigest: target.digest,
+      });
+    }
+  }
+};
 
 const swapProjection = async (
   transaction: GitHubWorkUnitTransaction,
@@ -1075,15 +1650,6 @@ const swapProjection = async (
     const current = currentByIdentity.get(unit.identityKey);
     return current !== undefined && materialProjectionChanged(current, unit);
   });
-  const summaryCandidateIdentities = new Set([
-    ...inserted.map((unit) => unit.identityKey),
-    ...updated.map((unit) => unit.identityKey),
-    ...snapshot.currentUnits.flatMap((unit) =>
-      unit.visibility === "public" && unit.summaryInputDigest === null
-        ? [unit.identityKey]
-        : []
-    ),
-  ]);
   const publicPayloadIdentities = new Set([
     ...deleted.map((unit) => unit.identityKey),
     ...inserted.map((unit) => unit.identityKey),
@@ -1114,93 +1680,22 @@ const swapProjection = async (
       )
     );
   }
-  const persisted = new Map<string, PersistedProjectionUnit>();
+  await persistSummaryEvaluationTargets(
+    transaction,
+    snapshot,
+    currentByIdentity
+  );
+  const summaryCandidates: PersistedProjectionUnit[] = [];
   for (const projected of snapshot.units) {
-    const current = currentByIdentity.get(projected.identityKey);
-    if (current === undefined) {
-      const [row] = await transaction
-        .insert(githubWorkUnits)
-        .values(projectedValues(projected, 1, null))
-        .returning({ id: githubWorkUnits.id });
-      if (row === undefined) {
-        throw new Error("A GitHub work unit could not be inserted.");
-      }
-      await transaction
-        .insert(githubWorkUnitMemberships)
-        .values(membershipValues(row.id, projected));
-      persisted.set(projected.identityKey, {
-        id: row.id,
-        projected,
-        revision: 1,
-      });
-      continue;
-    }
-    if (!materialProjectionChanged(current, projected)) {
-      if (
-        current.contentObservedAt.toISOString() !== projected.contentObservedAt
-      ) {
-        await transaction
-          .update(githubWorkUnits)
-          .set({ contentObservedAt: new Date(projected.contentObservedAt) })
-          .where(eq(githubWorkUnits.id, current.id));
-      }
-      persisted.set(projected.identityKey, {
-        id: current.id,
-        projected,
-        revision: current.revision,
-      });
-      continue;
-    }
-    const summarySemanticsChanged =
-      current.outcomeDigest !== projected.outcomeDigest ||
-      current.attributionMode !== projected.attributionMode ||
-      projected.visibility !== "public";
-    const revision = current.revision + 1;
-    await transaction
-      .update(githubWorkUnits)
-      .set(
-        projectedValues(
-          projected,
-          revision,
-          summarySemanticsChanged ? null : current.summaryInputDigest
-        )
-      )
-      .where(eq(githubWorkUnits.id, current.id));
-    await transaction
-      .insert(githubWorkUnitMemberships)
-      .values(membershipValues(current.id, projected));
-    if (projected.visibility === "private") {
-      await transaction
-        .delete(githubWorkUnitSummaryAttempts)
-        .where(eq(githubWorkUnitSummaryAttempts.workUnitId, current.id));
-    } else if (summarySemanticsChanged) {
-      await transaction
-        .update(githubWorkUnitSummaryAttempts)
-        .set({
-          acceptedAt: null,
-          completedAt: now,
-          leaseToken: null,
-          leaseUntil: null,
-          outcome: null,
-          requestPayload: null,
-          state: "terminal",
-        })
-        .where(
-          and(
-            eq(githubWorkUnitSummaryAttempts.workUnitId, current.id),
-            inArray(githubWorkUnitSummaryAttempts.state, [
-              "pending",
-              "processing",
-              "retryable",
-            ])
-          )
-        );
-    }
-    persisted.set(projected.identityKey, {
-      id: current.id,
+    const candidate = await persistProjectedUnit(
+      transaction,
+      snapshot,
       projected,
-      revision,
-    });
+      currentByIdentity.get(projected.identityKey)
+    );
+    if (candidate !== null) {
+      summaryCandidates.push(candidate);
+    }
   }
   const orderingRevisionChanged =
     publicOrderingSignature(snapshot.currentUnits) !==
@@ -1243,12 +1738,7 @@ const swapProjection = async (
     feedRevisionChanged,
     insertedUnits: inserted.length,
     orderingRevisionChanged,
-    summaryCandidates: [...persisted.values()].filter(
-      ({ projected }) =>
-        summaryCandidateIdentities.has(projected.identityKey) &&
-        projected.visibility === "public" &&
-        projected.outcomeDigest !== null
-    ),
+    summaryCandidates,
     updatedUnits: updated.length,
   };
 };
@@ -1258,31 +1748,23 @@ const summaryOutcomeFrom = (
   changesByKey: ReadonlyMap<string, GitHubLogicalChange>,
   pullRequestsByNodeId: ReadonlyMap<string, GitHubPullRequestProjectionEvidence>
 ): GitHubWorkUnitSummaryOutcomeEvidence | null => {
-  const compositeChanges = unit.members.map((member) => {
-    const change = changesByKey.get(member.logicalKey);
-    return change === undefined
-      ? null
-      : githubWorkUnitSummaryDiffEvidenceFrom(
-          change.fileFacts,
-          change.additions,
-          change.deletions,
-          change.fileFactsComplete,
-          change.providerFileCapReached
-        );
-  });
-  if (compositeChanges.some((change) => change === null)) {
-    return null;
-  }
   if (unit.kind === "pull_request") {
-    const pullRequest =
-      unit.pullRequestNodeId === null
-        ? undefined
-        : pullRequestsByNodeId.get(unit.pullRequestNodeId);
+    if (unit.pullRequestNodeId === null) {
+      throw new Error("A projected pull-request unit lacks its pull request.");
+    }
+    const pullRequest = pullRequestsByNodeId.get(unit.pullRequestNodeId);
+    if (pullRequest === undefined) {
+      throw new Error(
+        `A projected unit references an unavailable pull request: ${unit.pullRequestNodeId}`
+      );
+    }
     if (
       unit.attributionMode === "tracked_authored_pr" &&
-      pullRequest?.netOutcomeOwnedCompletely === true &&
-      pullRequest.netOutcome !== null
+      pullRequest.netOutcomeOwnedCompletely
     ) {
+      if (pullRequest.netOutcome === null) {
+        return null;
+      }
       const additions = pullRequest.netOutcome.files.reduce(
         (total, file) => total + file.additions,
         0
@@ -1301,6 +1783,26 @@ const summaryOutcomeFrom = (
       return diff === null ? null : { diff, mode: "net" };
     }
   }
+  const compositeChanges = unit.members.map((member) => {
+    const change = changesByKey.get(member.logicalKey);
+    if (change === undefined) {
+      throw new Error(
+        `A projected unit references an unavailable change: ${member.logicalKey}`
+      );
+    }
+    return change.summaryFileFacts === null
+      ? null
+      : githubWorkUnitSummaryDiffEvidenceFrom(
+          change.summaryFileFacts,
+          change.additions,
+          change.deletions,
+          change.fileFactsComplete,
+          change.providerFileCapReached
+        );
+  });
+  if (compositeChanges.some((change) => change === null)) {
+    return null;
+  }
   return {
     changes: compositeChanges as NonNullable<
       (typeof compositeChanges)[number]
@@ -1317,7 +1819,12 @@ const summaryCandidateFrom = (
 ): GitHubWorkUnitSummaryCandidate | null => {
   const repository = snapshot.repositoryContexts.get(unit.repositoryId);
   const outcome = summaryOutcomeFrom(unit, changesByKey, pullRequestsByNodeId);
-  if (repository === undefined || outcome === null) {
+  if (repository === undefined) {
+    throw new Error(
+      `A projected unit references an unavailable repository: ${unit.repositoryId}`
+    );
+  }
+  if (outcome === null) {
     return null;
   }
   return {
@@ -1335,11 +1842,8 @@ const summaryCandidateFrom = (
   };
 };
 
-interface BuiltSummaryInput {
-  build: Extract<
-    Awaited<ReturnType<typeof buildGitHubWorkUnitSummaryInput>>,
-    { eligible: true }
-  >;
+interface SummaryEvaluation {
+  build: GitHubWorkUnitSummaryBuildResult | null;
   unit: PersistedProjectionUnit;
 }
 
@@ -1348,7 +1852,16 @@ const setSummaryInputs = async (
   candidates: readonly PersistedProjectionUnit[],
   now: Date
 ) => {
-  const built: BuiltSummaryInput[] = [];
+  if (candidates.length === 0) {
+    return {
+      failed: 0,
+      publicationChanged: false,
+      queued: 0,
+      set: 0,
+      settled: 0,
+    };
+  }
+  const evaluations: SummaryEvaluation[] = [];
   const changesByKey = new Map(
     snapshot.input.changes.map((change) => [
       logicalKeyFrom(change.logicalRepositoryId, change.logicalSha),
@@ -1361,7 +1874,6 @@ const setSummaryInputs = async (
       pullRequest,
     ])
   );
-  let failed = 0;
   for (const unit of candidates) {
     const candidate = summaryCandidateFrom(
       snapshot,
@@ -1369,44 +1881,40 @@ const setSummaryInputs = async (
       changesByKey,
       pullRequestsByNodeId
     );
-    if (candidate === null) {
-      throw new Error(
-        `A summary candidate lacks complete evidence: ${unit.projected.identityKey}`
-      );
-    }
-    const result = await buildGitHubWorkUnitSummaryInput(candidate);
-    if (!result.eligible) {
-      failed += 1;
-      continue;
-    }
+    const result =
+      candidate === null
+        ? null
+        : await buildGitHubWorkUnitSummaryInput(candidate);
     if (
-      result.outcomeDigest !== unit.projected.outcomeDigest ||
-      result.membershipDigest !== unit.projected.membershipDigest
+      result?.eligible === true &&
+      (result.outcomeDigest !== unit.projected.outcomeDigest ||
+        result.membershipDigest !== unit.projected.membershipDigest)
     ) {
       throw new Error(
         `Summary input diverged from projection: ${unit.projected.identityKey}`
       );
     }
-    built.push({ build: result, unit });
+    evaluations.push({ build: result, unit });
   }
-  if (built.length === 0) {
-    return { failed, queued: 0, set: 0 };
-  }
+  // oxlint-disable-next-line eslint/complexity -- This locked state transition keeps evaluation validation, attempt reuse, and queueing in one auditable transaction.
   const result = await getDatabase().transaction(async (transaction) => {
-    await transaction.execute(
-      sql`select pg_advisory_xact_lock(hashtext(${PROJECTION_LOCK}))`
-    );
-    const unitIds = built.map(({ unit }) => unit.id);
+    await acquireGitHubWorkUnitProjectionLock(transaction);
+    const unitIds = evaluations.map(({ unit }) => unit.id);
     const currentRows = await transaction
       .select({
         attributionMode: githubWorkUnits.attributionMode,
+        description: githubRepositories.description,
         factsDigest: githubWorkUnits.factsDigest,
+        fullName: githubRepositories.fullName,
+        homepageUrl: githubRepositories.homepageUrl,
         id: githubWorkUnits.id,
         membershipDigest: githubWorkUnits.membershipDigest,
         outcomeDigest: githubWorkUnits.outcomeDigest,
         repositoryVisibility: githubRepositories.visibility,
         revision: githubWorkUnits.revision,
+        summaryEvaluationDigest: githubWorkUnits.summaryEvaluationDigest,
         summaryInputDigest: githubWorkUnits.summaryInputDigest,
+        topics: githubRepositories.topics,
         visibility: githubWorkUnits.visibility,
       })
       .from(githubWorkUnits)
@@ -1419,18 +1927,55 @@ const setSummaryInputs = async (
     const currentById = new Map(currentRows.map((row) => [row.id, row]));
     const attemptRows = await transaction
       .select({
+        attributionMode: githubWorkUnitSummaryAttempts.attributionMode,
+        debounceUntil: githubWorkUnitSummaryAttempts.debounceUntil,
+        outcome: githubWorkUnitSummaryAttempts.outcome,
+        outcomeDigest: githubWorkUnitSummaryAttempts.outcomeDigest,
         recipe: githubWorkUnitSummaryAttempts.recipe,
+        requestPayload: githubWorkUnitSummaryAttempts.requestPayload,
         revision: githubWorkUnitSummaryAttempts.revision,
+        state: githubWorkUnitSummaryAttempts.state,
         summaryInputDigest: githubWorkUnitSummaryAttempts.summaryInputDigest,
         workUnitId: githubWorkUnitSummaryAttempts.workUnitId,
       })
       .from(githubWorkUnitSummaryAttempts)
       .where(inArray(githubWorkUnitSummaryAttempts.workUnitId, unitIds));
-    const existingInputs = new Set(
+    const attemptsByInput = new Map<string, (typeof attemptRows)[number]>(
       attemptRows.map(
         (attempt) =>
-          `${attempt.workUnitId}\0${attempt.summaryInputDigest}\0${attempt.recipe}`
+          [
+            `${attempt.workUnitId}\0${attempt.summaryInputDigest}\0${attempt.recipe}`,
+            attempt,
+          ] as const
       )
+    );
+    const acceptedOutcomes = new Map(
+      attemptRows.flatMap((attempt) =>
+        attempt.recipe === GITHUB_WORK_UNIT_SUMMARY_RECIPE &&
+        attempt.state === "accepted" &&
+        attempt.outcome !== null
+          ? [
+              [
+                `${attempt.workUnitId}\0${attempt.summaryInputDigest}\0${attempt.outcomeDigest}\0${attempt.attributionMode}`,
+                attempt.outcome,
+              ] as const,
+            ]
+          : []
+      )
+    );
+    const acceptedOutcomeFor = (
+      workUnitId: string,
+      summaryInputDigest: string | null,
+      outcomeDigest: string | null,
+      attributionMode: string
+    ) =>
+      summaryInputDigest === null || outcomeDigest === null
+        ? null
+        : (acceptedOutcomes.get(
+            `${workUnitId}\0${summaryInputDigest}\0${outcomeDigest}\0${attributionMode}`
+          ) ?? null);
+    const initialPageDays = new Set(
+      initialPageDaysFrom(snapshot.units, snapshot.issueDays)
     );
     const maximumRevisionByUnit = new Map<string, number>();
     for (const attempt of attemptRows) {
@@ -1442,87 +1987,160 @@ const setSummaryInputs = async (
         )
       );
     }
+    let failed = 0;
     let queued = 0;
     let set = 0;
-    for (const item of built) {
+    let settled = 0;
+    let publicationChanged = false;
+    for (const item of evaluations) {
       const current = currentById.get(item.unit.id);
+      const evidence = snapshot.summaryEvaluationEvidence.get(
+        item.unit.projected.identityKey
+      );
+      const currentEvaluationDigest =
+        current === undefined || evidence === undefined
+          ? null
+          : summaryEvaluationDigestFrom(item.unit.projected, evidence, {
+              description: current.description,
+              fullName: current.fullName,
+              homepageUrl: current.homepageUrl,
+              topics: current.topics ?? [],
+            });
       if (
         current === undefined ||
+        currentEvaluationDigest !== item.unit.summaryEvaluationDigest ||
+        current.summaryEvaluationDigest !== item.unit.summaryEvaluationDigest ||
         current.visibility !== "public" ||
         current.repositoryVisibility !== "public" ||
         current.revision !== item.unit.revision ||
         current.factsDigest !== item.unit.projected.factsDigest ||
-        current.membershipDigest !== item.build.membershipDigest ||
-        current.outcomeDigest !== item.build.outcomeDigest ||
+        current.membershipDigest !== item.unit.projected.membershipDigest ||
+        current.outcomeDigest !== item.unit.projected.outcomeDigest ||
         current.attributionMode !== item.unit.projected.attributionMode
       ) {
         continue;
       }
-      if (current.summaryInputDigest !== item.build.summaryInputDigest) {
-        await transaction
-          .update(githubWorkUnitSummaryAttempts)
-          .set({
-            acceptedAt: null,
-            completedAt: now,
-            leaseToken: null,
-            leaseUntil: null,
-            outcome: null,
-            requestPayload: null,
-            state: "terminal",
-          })
-          .where(
-            and(
-              eq(githubWorkUnitSummaryAttempts.workUnitId, current.id),
-              ne(
-                githubWorkUnitSummaryAttempts.summaryInputDigest,
-                item.build.summaryInputDigest
-              ),
-              inArray(githubWorkUnitSummaryAttempts.state, [
-                "pending",
-                "processing",
-                "retryable",
-              ])
-            )
-          );
-        await transaction
-          .update(githubWorkUnits)
-          .set({ summaryInputDigest: item.build.summaryInputDigest })
-          .where(
-            and(
-              eq(githubWorkUnits.id, current.id),
-              eq(githubWorkUnits.revision, current.revision),
-              eq(githubWorkUnits.outcomeDigest, item.build.outcomeDigest),
-              eq(githubWorkUnits.membershipDigest, item.build.membershipDigest),
-              eq(githubWorkUnits.attributionMode, current.attributionMode),
-              eq(githubWorkUnits.visibility, "public")
-            )
-          );
+      const eligibleBuild = item.build?.eligible === true ? item.build : null;
+      const nextSummaryInputDigest = eligibleBuild?.summaryInputDigest ?? null;
+      const [updated] = await transaction
+        .update(githubWorkUnits)
+        .set({
+          summaryEvaluatedDigest: item.unit.summaryEvaluationDigest,
+          summaryInputDigest: nextSummaryInputDigest,
+        })
+        .where(
+          and(
+            eq(githubWorkUnits.id, current.id),
+            eq(githubWorkUnits.revision, current.revision),
+            eq(
+              githubWorkUnits.summaryEvaluationDigest,
+              item.unit.summaryEvaluationDigest
+            ),
+            eq(githubWorkUnits.membershipDigest, current.membershipDigest),
+            eq(githubWorkUnits.attributionMode, current.attributionMode),
+            eq(githubWorkUnits.visibility, "public")
+          )
+        )
+        .returning({ id: githubWorkUnits.id });
+      if (updated === undefined) {
+        continue;
+      }
+      const previousOutcome = acceptedOutcomeFor(
+        current.id,
+        current.summaryInputDigest,
+        current.outcomeDigest,
+        current.attributionMode
+      );
+      const nextOutcome = acceptedOutcomeFor(
+        current.id,
+        nextSummaryInputDigest,
+        current.outcomeDigest,
+        current.attributionMode
+      );
+      publicationChanged ||=
+        previousOutcome !== nextOutcome &&
+        initialPageDays.has(item.unit.projected.activityDay);
+      settled += 1;
+      if (
+        eligibleBuild !== null &&
+        current.summaryInputDigest !== eligibleBuild.summaryInputDigest
+      ) {
         set += 1;
       }
-      const inputKey = `${current.id}\0${item.build.summaryInputDigest}\0${GITHUB_WORK_UNIT_SUMMARY_RECIPE}`;
-      if (existingInputs.has(inputKey)) {
+      if (eligibleBuild === null) {
+        failed += 1;
+        continue;
+      }
+      const inputKey = `${current.id}\0${eligibleBuild.summaryInputDigest}\0${GITHUB_WORK_UNIT_SUMMARY_RECIPE}`;
+      const existingAttempt = attemptsByInput.get(inputKey);
+      if (existingAttempt !== undefined) {
+        if (
+          (existingAttempt.state === "pending" ||
+            existingAttempt.state === "retryable") &&
+          (existingAttempt.requestPayload === null ||
+            current.summaryInputDigest !== eligibleBuild.summaryInputDigest)
+        ) {
+          const debounceUntil = new Date(now.getTime() + SUMMARY_DEBOUNCE_MS);
+          await transaction
+            .update(githubWorkUnitSummaryAttempts)
+            .set({
+              debounceUntil:
+                existingAttempt.debounceUntil < debounceUntil
+                  ? debounceUntil
+                  : existingAttempt.debounceUntil,
+              requestPayload: eligibleBuild.serializedInput,
+            })
+            .where(
+              and(
+                eq(
+                  githubWorkUnitSummaryAttempts.workUnitId,
+                  existingAttempt.workUnitId
+                ),
+                eq(
+                  githubWorkUnitSummaryAttempts.revision,
+                  existingAttempt.revision
+                ),
+                inArray(githubWorkUnitSummaryAttempts.state, [
+                  "pending",
+                  "retryable",
+                ])
+              )
+            );
+        }
         continue;
       }
       const revision = (maximumRevisionByUnit.get(current.id) ?? 0) + 1;
       await transaction.insert(githubWorkUnitSummaryAttempts).values({
         attributionMode: item.unit.projected.attributionMode,
         debounceUntil: new Date(now.getTime() + SUMMARY_DEBOUNCE_MS),
-        inputTokens: item.build.inputTokens,
-        outcomeDigest: item.build.outcomeDigest,
+        inputTokens: eligibleBuild.inputTokens,
+        outcomeDigest: eligibleBuild.outcomeDigest,
         recipe: GITHUB_WORK_UNIT_SUMMARY_RECIPE,
-        requestPayload: item.build.serializedInput,
+        requestPayload: eligibleBuild.serializedInput,
         revision,
-        summaryInputDigest: item.build.summaryInputDigest,
-        unitRevision: current.revision,
+        summaryInputDigest: eligibleBuild.summaryInputDigest,
         workUnitId: current.id,
       });
       maximumRevisionByUnit.set(current.id, revision);
-      existingInputs.add(inputKey);
       queued += 1;
     }
-    return { queued, set };
+    if (publicationChanged) {
+      const [head] = await transaction
+        .update(githubPublicFeedHead)
+        .set({
+          feedRevision: sql`${githubPublicFeedHead.feedRevision} + 1`,
+          headContentRevision: sql`${githubPublicFeedHead.headContentRevision} + 1`,
+          lastPublishedAt: now,
+        })
+        .where(eq(githubPublicFeedHead.id, true))
+        .returning({ id: githubPublicFeedHead.id });
+      if (head === undefined) {
+        throw new Error("The GitHub public feed head is unavailable.");
+      }
+    }
+    return { failed, publicationChanged, queued, set, settled };
   });
-  return { failed, ...result };
+  return result;
 };
 
 /**
@@ -1533,32 +2151,59 @@ export const refreshGitHubWorkUnitProjection = async (
   now = new Date()
 ): Promise<GitHubWorkUnitProjectionRefreshResult> => {
   checkedNow(now);
-  const { snapshot, swap } = await getDatabase().transaction(
-    async (transaction) => {
-      await transaction.execute(
-        sql`select pg_advisory_xact_lock(hashtext(${PROJECTION_LOCK}))`
-      );
-      const snapshot = await loadProjectionSnapshot(transaction, true);
-      return {
-        snapshot,
-        swap: await swapProjection(transaction, snapshot, now),
-      };
-    },
-    { isolationLevel: "repeatable read" }
-  );
+  const { projectionRequestToken, snapshot, swap } =
+    await getDatabase().transaction(
+      async (transaction) => {
+        await acquireGitHubWorkUnitProjectionLock(transaction);
+        const [head] = await transaction
+          .select({
+            projectionRequestToken: githubPublicFeedHead.projectionRequestToken,
+          })
+          .from(githubPublicFeedHead)
+          .where(eq(githubPublicFeedHead.id, true));
+        if (head === undefined) {
+          throw new Error("The GitHub public feed head is unavailable.");
+        }
+        const snapshot = await loadProjectionSnapshot(transaction, {
+          lockCurrentUnits: true,
+          summaryEvaluationLimit: SUMMARY_EVALUATION_LIMIT,
+        });
+        return {
+          projectionRequestToken: head.projectionRequestToken,
+          snapshot,
+          swap: await swapProjection(transaction, snapshot, now),
+        };
+      },
+      { isolationLevel: "repeatable read" }
+    );
   const summaries = await setSummaryInputs(
     snapshot,
     swap.summaryCandidates,
     now
   );
+  const summaryEvaluationsPending =
+    snapshot.summaryEvaluationsPending +
+    swap.summaryCandidates.length -
+    summaries.settled;
+  if (summaryEvaluationsPending > 0 && projectionRequestToken === null) {
+    await requestGitHubWorkUnitProjection(getDatabase());
+  } else if (
+    summaryEvaluationsPending === 0 &&
+    projectionRequestToken !== null
+  ) {
+    await completeGitHubWorkUnitProjectionRequest(projectionRequestToken);
+  }
   return {
     changed: swap.insertedUnits + swap.updatedUnits + swap.deletedUnits > 0,
     deletedUnits: swap.deletedUnits,
     exclusionReasonCounts: snapshot.exclusionReasonCounts,
-    feedRevisionChanged: swap.feedRevisionChanged,
+    feedRevisionChanged:
+      swap.feedRevisionChanged || summaries.publicationChanged,
     insertedUnits: swap.insertedUnits,
     orderingRevisionChanged: swap.orderingRevisionChanged,
     summaryAttemptsQueued: summaries.queued,
+    summaryEvaluationsPending,
+    summaryEvaluationsSettled: summaries.settled,
     summaryInputsFailed: summaries.failed,
     summaryInputsSet: summaries.set,
     updatedUnits: swap.updatedUnits,

--- a/src/lib/github-work-unit-summary-provider.ts
+++ b/src/lib/github-work-unit-summary-provider.ts
@@ -12,6 +12,7 @@ import {
   countGitHubWorkUnitSummaryInputTokens,
   GITHUB_WORK_UNIT_SUMMARY_MAX_INPUT_TOKENS,
   GITHUB_WORK_UNIT_SUMMARY_MAX_PAYLOAD_BYTES,
+  GITHUB_WORK_UNIT_SUMMARY_PROVIDER_POLICY,
   GITHUB_WORK_UNIT_SUMMARY_SYSTEM_PROMPT,
   githubWorkUnitSummaryInputSchema,
   githubWorkUnitSummaryOutputSchema,
@@ -19,14 +20,11 @@ import {
 } from "./github-work-unit-summary";
 import type { GitHubWorkUnitSummaryOutputRejectionReason } from "./github-work-unit-summary";
 
-export const GITHUB_WORK_UNIT_SUMMARY_MODEL = "gpt-5.4-nano-2026-03-17";
-export const GITHUB_WORK_UNIT_SUMMARY_MAX_OUTPUT_TOKENS = 160;
-
 const MAXIMUM_ABORT_SIGNAL_TIMEOUT_MS = 2_147_483_647;
 const summaryOutput = Output.object({
   schema: githubWorkUnitSummaryOutputSchema,
 });
-const summaryModel = openai(GITHUB_WORK_UNIT_SUMMARY_MODEL);
+const summaryModel = openai(GITHUB_WORK_UNIT_SUMMARY_PROVIDER_POLICY.model);
 
 export interface GitHubWorkUnitSummaryProviderRequest {
   readonly deadlineAt: number;
@@ -36,7 +34,7 @@ export interface GitHubWorkUnitSummaryProviderRequest {
 export interface GitHubWorkUnitSummaryProviderResult {
   readonly inputTokens: number | null;
   readonly latencyMs: number;
-  readonly model: typeof GITHUB_WORK_UNIT_SUMMARY_MODEL;
+  readonly model: (typeof GITHUB_WORK_UNIT_SUMMARY_PROVIDER_POLICY)["model"];
   readonly outcome: string;
   readonly outputTokens: number | null;
 }
@@ -131,16 +129,17 @@ export const generateGitHubWorkUnitSummary = async (
   try {
     generated = await generateText({
       abortSignal,
-      maxOutputTokens: GITHUB_WORK_UNIT_SUMMARY_MAX_OUTPUT_TOKENS,
-      maxRetries: 0,
+      maxOutputTokens: GITHUB_WORK_UNIT_SUMMARY_PROVIDER_POLICY.maxOutputTokens,
+      maxRetries: GITHUB_WORK_UNIT_SUMMARY_PROVIDER_POLICY.maxRetries,
       model: summaryModel,
       output: summaryOutput,
       prompt: request.serializedInput,
       providerOptions: {
         openai: {
-          reasoningEffort: "none",
-          store: false,
-          textVerbosity: "low",
+          reasoningEffort:
+            GITHUB_WORK_UNIT_SUMMARY_PROVIDER_POLICY.reasoningEffort,
+          store: GITHUB_WORK_UNIT_SUMMARY_PROVIDER_POLICY.store,
+          textVerbosity: GITHUB_WORK_UNIT_SUMMARY_PROVIDER_POLICY.textVerbosity,
         },
       },
       system: GITHUB_WORK_UNIT_SUMMARY_SYSTEM_PROMPT,
@@ -174,7 +173,7 @@ export const generateGitHubWorkUnitSummary = async (
   return {
     inputTokens: nullableTokenCount(generated.usage.inputTokens),
     latencyMs: Math.max(0, Math.round(performance.now() - startedAt)),
-    model: GITHUB_WORK_UNIT_SUMMARY_MODEL,
+    model: GITHUB_WORK_UNIT_SUMMARY_PROVIDER_POLICY.model,
     outcome: validated.outcome,
     outputTokens: nullableTokenCount(generated.usage.outputTokens),
   };

--- a/src/lib/github-work-unit-summary-store.ts
+++ b/src/lib/github-work-unit-summary-store.ts
@@ -23,7 +23,10 @@ import {
   githubWorkUnitSummaryDailyUsage,
   githubWorkUnits,
 } from "@/db/schema";
+import { env } from "@/env";
 import { PUBLIC_GITHUB_ACTIVITY_DAY_PAGE_SIZE } from "@/lib/github-activity-store";
+import { hasCurrentTrackedGitHubRepositoryAccess } from "@/lib/github-repository-access";
+import { acquireGitHubWorkUnitProjectionLock } from "@/lib/github-work-unit-projection-state";
 import { GITHUB_WORK_UNIT_SUMMARY_RECIPE } from "@/lib/github-work-unit-summary";
 import type { GitHubWorkUnitSummaryAttributionMode } from "@/lib/github-work-unit-summary";
 import type { GitHubWorkUnitSummaryProviderResult } from "@/lib/github-work-unit-summary-provider";
@@ -44,6 +47,13 @@ type SummaryTransaction = Parameters<
   Parameters<ReturnType<typeof getDatabase>["transaction"]>[0]
 >[0];
 
+const acquireSummaryStateLocks = async (transaction: SummaryTransaction) => {
+  await transaction.execute(
+    sql`select pg_advisory_xact_lock(hashtext(${SUMMARY_CLAIM_LOCK}))`
+  );
+  await acquireGitHubWorkUnitProjectionLock(transaction);
+};
+
 export interface GitHubWorkUnitSummaryClaim {
   readonly attributionMode: GitHubWorkUnitSummaryAttributionMode;
   readonly leaseToken: string;
@@ -52,7 +62,6 @@ export interface GitHubWorkUnitSummaryClaim {
   readonly serializedInput: string;
   readonly startedRequests: 1 | 2;
   readonly summaryInputDigest: string;
-  readonly unitRevision: number;
   readonly workUnitId: string;
 }
 
@@ -117,8 +126,6 @@ const checkedClaim = (claim: GitHubWorkUnitSummaryClaim) => {
     !DIGEST.test(claim.summaryInputDigest) ||
     !Number.isSafeInteger(claim.revision) ||
     claim.revision < 1 ||
-    !Number.isSafeInteger(claim.unitRevision) ||
-    claim.unitRevision < 1 ||
     (claim.startedRequests !== 1 && claim.startedRequests !== 2)
   ) {
     throw new TypeError("The GitHub work-unit summary claim is invalid.");
@@ -155,12 +162,16 @@ const checkedProviderResult = (result: GitHubWorkUnitSummaryProviderResult) => {
   return result;
 };
 
-const currentUnitMatchesAttempt = (
+const unitIsPublic = (unit: {
+  repositoryVisibility: string | null;
+  visibility: string;
+}) => unit.visibility === "public" && unit.repositoryVisibility === "public";
+
+const unitDisplaysAttempt = (
   unit: {
     attributionMode: string;
     outcomeDigest: string | null;
     repositoryVisibility: string | null;
-    revision: number;
     summaryInputDigest: string | null;
     visibility: string;
   },
@@ -168,15 +179,87 @@ const currentUnitMatchesAttempt = (
     attributionMode: string;
     outcomeDigest: string;
     summaryInputDigest: string;
-    unitRevision: number;
   }
 ) =>
-  unit.visibility === "public" &&
-  unit.repositoryVisibility === "public" &&
-  unit.revision === attempt.unitRevision &&
+  unitIsPublic(unit) &&
   unit.outcomeDigest === attempt.outcomeDigest &&
   unit.summaryInputDigest === attempt.summaryInputDigest &&
   unit.attributionMode === attempt.attributionMode;
+
+const currentUnitMatchesAttempt = (
+  unit: {
+    attributionMode: string;
+    outcomeDigest: string | null;
+    repositoryVisibility: string | null;
+    summaryEvaluatedDigest: string | null;
+    summaryEvaluationDigest: string | null;
+    summaryInputDigest: string | null;
+    visibility: string;
+  },
+  attempt: {
+    attributionMode: string;
+    outcomeDigest: string;
+    summaryInputDigest: string;
+  }
+) =>
+  unitDisplaysAttempt(unit, attempt) &&
+  unit.summaryEvaluationDigest !== null &&
+  unit.summaryEvaluationDigest === unit.summaryEvaluatedDigest;
+
+const reconcileInactiveSummaryInputs = async (
+  transaction: SummaryTransaction
+) => {
+  await transaction.execute(sql`
+    delete from ${githubWorkUnitSummaryAttempts} as attempt
+    using ${githubWorkUnits} as work_unit,
+      ${githubRepositories} as repository
+    where attempt.work_unit_id = work_unit.id
+      and work_unit.repository_id = repository.id
+      and attempt.state in ('pending', 'retryable')
+      and (
+        work_unit.visibility <> 'public'
+        or repository.visibility <> 'public'
+        or attempt.recipe <> ${GITHUB_WORK_UNIT_SUMMARY_RECIPE}
+        or (
+          attempt.started_requests = 0
+          and (
+            work_unit.summary_evaluation_digest is null
+            or work_unit.summary_evaluation_digest
+              is distinct from work_unit.summary_evaluated_digest
+            or work_unit.outcome_digest is distinct from attempt.outcome_digest
+            or work_unit.summary_input_digest
+              is distinct from attempt.summary_input_digest
+            or work_unit.attribution_mode
+              is distinct from attempt.attribution_mode
+          )
+        )
+      )
+  `);
+  await transaction.execute(sql`
+    update ${githubWorkUnitSummaryAttempts} as attempt
+    set request_payload = null
+    from ${githubWorkUnits} as work_unit,
+      ${githubRepositories} as repository
+    where attempt.work_unit_id = work_unit.id
+      and work_unit.repository_id = repository.id
+      and attempt.state = 'retryable'
+      and attempt.started_requests > 0
+      and attempt.request_payload is not null
+      and attempt.recipe = ${GITHUB_WORK_UNIT_SUMMARY_RECIPE}
+      and work_unit.visibility = 'public'
+      and repository.visibility = 'public'
+      and (
+        work_unit.summary_evaluation_digest is null
+        or work_unit.summary_evaluation_digest
+          is distinct from work_unit.summary_evaluated_digest
+        or work_unit.outcome_digest is distinct from attempt.outcome_digest
+        or work_unit.summary_input_digest
+          is distinct from attempt.summary_input_digest
+        or work_unit.attribution_mode
+          is distinct from attempt.attribution_mode
+      )
+  `);
+};
 
 const recoverExpiredClaims = async (
   transaction: SummaryTransaction,
@@ -198,50 +281,50 @@ const recoverExpiredClaims = async (
     .orderBy(githubWorkUnits.identityKey)
     .for("update", { of: githubWorkUnits });
   const expiredWorkUnitIds = [...new Set(expiredUnits.map(({ id }) => id))];
-  if (expiredWorkUnitIds.length === 0) {
-    return;
+  if (expiredWorkUnitIds.length > 0) {
+    await transaction
+      .update(githubWorkUnitSummaryAttempts)
+      .set({
+        acceptedAt: null,
+        completedAt: now,
+        leaseToken: null,
+        leaseUntil: null,
+        outcome: null,
+        requestPayload: null,
+        state: "terminal",
+      })
+      .where(
+        and(
+          inArray(githubWorkUnitSummaryAttempts.workUnitId, expiredWorkUnitIds),
+          eq(githubWorkUnitSummaryAttempts.state, "processing"),
+          lte(githubWorkUnitSummaryAttempts.leaseUntil, now),
+          gte(
+            githubWorkUnitSummaryAttempts.startedRequests,
+            MAXIMUM_STARTED_REQUESTS
+          )
+        )
+      );
+    await transaction
+      .update(githubWorkUnitSummaryAttempts)
+      .set({
+        debounceUntil: now,
+        leaseToken: null,
+        leaseUntil: null,
+        state: "retryable",
+      })
+      .where(
+        and(
+          inArray(githubWorkUnitSummaryAttempts.workUnitId, expiredWorkUnitIds),
+          eq(githubWorkUnitSummaryAttempts.state, "processing"),
+          lte(githubWorkUnitSummaryAttempts.leaseUntil, now),
+          lt(
+            githubWorkUnitSummaryAttempts.startedRequests,
+            MAXIMUM_STARTED_REQUESTS
+          )
+        )
+      );
   }
-  await transaction
-    .update(githubWorkUnitSummaryAttempts)
-    .set({
-      acceptedAt: null,
-      completedAt: now,
-      leaseToken: null,
-      leaseUntil: null,
-      outcome: null,
-      requestPayload: null,
-      state: "terminal",
-    })
-    .where(
-      and(
-        inArray(githubWorkUnitSummaryAttempts.workUnitId, expiredWorkUnitIds),
-        eq(githubWorkUnitSummaryAttempts.state, "processing"),
-        lte(githubWorkUnitSummaryAttempts.leaseUntil, now),
-        gte(
-          githubWorkUnitSummaryAttempts.startedRequests,
-          MAXIMUM_STARTED_REQUESTS
-        )
-      )
-    );
-  await transaction
-    .update(githubWorkUnitSummaryAttempts)
-    .set({
-      debounceUntil: now,
-      leaseToken: null,
-      leaseUntil: null,
-      state: "retryable",
-    })
-    .where(
-      and(
-        inArray(githubWorkUnitSummaryAttempts.workUnitId, expiredWorkUnitIds),
-        eq(githubWorkUnitSummaryAttempts.state, "processing"),
-        lte(githubWorkUnitSummaryAttempts.leaseUntil, now),
-        lt(
-          githubWorkUnitSummaryAttempts.startedRequests,
-          MAXIMUM_STARTED_REQUESTS
-        )
-      )
-    );
+  await reconcileInactiveSummaryInputs(transaction);
 };
 
 const claimSelection = {
@@ -256,7 +339,6 @@ const claimSelection = {
   startedRequests: githubWorkUnitSummaryAttempts.startedRequests,
   state: githubWorkUnitSummaryAttempts.state,
   summaryInputDigest: githubWorkUnitSummaryAttempts.summaryInputDigest,
-  unitRevision: githubWorkUnitSummaryAttempts.unitRevision,
   workUnitId: githubWorkUnitSummaryAttempts.workUnitId,
 };
 
@@ -295,8 +377,8 @@ async function selectClaimCandidate(
         eq(githubWorkUnits.visibility, "public"),
         eq(githubRepositories.visibility, "public"),
         eq(
-          githubWorkUnits.revision,
-          githubWorkUnitSummaryAttempts.unitRevision
+          githubWorkUnits.summaryEvaluationDigest,
+          githubWorkUnits.summaryEvaluatedDigest
         ),
         eq(
           githubWorkUnits.outcomeDigest,
@@ -336,7 +418,8 @@ const lockedUnit = async (
       attributionMode: githubWorkUnits.attributionMode,
       outcomeDigest: githubWorkUnits.outcomeDigest,
       repositoryVisibility: githubRepositories.visibility,
-      revision: githubWorkUnits.revision,
+      summaryEvaluatedDigest: githubWorkUnits.summaryEvaluatedDigest,
+      summaryEvaluationDigest: githubWorkUnits.summaryEvaluationDigest,
       summaryInputDigest: githubWorkUnits.summaryInputDigest,
       visibility: githubWorkUnits.visibility,
     })
@@ -346,7 +429,7 @@ const lockedUnit = async (
       eq(githubWorkUnits.repositoryId, githubRepositories.id)
     )
     .where(eq(githubWorkUnits.id, workUnitId))
-    .for("update", { of: githubWorkUnits });
+    .for("update", { of: [githubWorkUnits, githubRepositories] });
   return unit ?? null;
 };
 
@@ -366,7 +449,6 @@ const lockedAttempt = async (
       startedRequests: githubWorkUnitSummaryAttempts.startedRequests,
       state: githubWorkUnitSummaryAttempts.state,
       summaryInputDigest: githubWorkUnitSummaryAttempts.summaryInputDigest,
-      unitRevision: githubWorkUnitSummaryAttempts.unitRevision,
     })
     .from(githubWorkUnitSummaryAttempts)
     .where(
@@ -575,7 +657,6 @@ const tryClaimCandidate = async (
     serializedInput: attempt.requestPayload,
     startedRequests,
     summaryInputDigest: attempt.summaryInputDigest,
-    unitRevision: attempt.unitRevision,
     workUnitId: candidate.workUnitId,
   });
 };
@@ -588,7 +669,6 @@ const leaseMatchesClaim = (
   attempt.leaseToken === claim.leaseToken &&
   attempt.startedRequests === claim.startedRequests &&
   attempt.recipe === GITHUB_WORK_UNIT_SUMMARY_RECIPE &&
-  attempt.unitRevision === claim.unitRevision &&
   attempt.outcomeDigest === claim.outcomeDigest &&
   attempt.summaryInputDigest === claim.summaryInputDigest &&
   attempt.attributionMode === claim.attributionMode;
@@ -629,7 +709,8 @@ async function readInitialPageDays(transaction: SummaryTransaction) {
     ),
     and(
       eq(githubWorkUnits.visibility, "private"),
-      inArray(githubRepositories.visibility, ["private", "internal"])
+      inArray(githubRepositories.visibility, ["private", "internal"]),
+      hasCurrentTrackedGitHubRepositoryAccess(githubWorkUnits.repositoryId)
     )
   );
   const issueDay = sql<string>`to_char(${githubIssues.createdAt} AT TIME ZONE 'UTC', 'YYYY-MM-DD')`;
@@ -652,11 +733,13 @@ async function readInitialPageDays(transaction: SummaryTransaction) {
         eq(githubIssues.repositoryId, githubRepositories.id)
       )
       .where(
-        inArray(githubRepositories.visibility, [
-          "public",
-          "private",
-          "internal",
-        ])
+        or(
+          eq(githubRepositories.visibility, "public"),
+          and(
+            inArray(githubRepositories.visibility, ["private", "internal"]),
+            hasCurrentTrackedGitHubRepositoryAccess(githubIssues.repositoryId)
+          )
+        )
       )
       .orderBy(desc(issueDay))
       .limit(PUBLIC_GITHUB_ACTIVITY_DAY_PAGE_SIZE),
@@ -669,34 +752,36 @@ async function readInitialPageDays(transaction: SummaryTransaction) {
   );
 }
 
-async function hasActiveInitialPageSummary(
+async function hasCurrentInitialPageSummaryWork(
   transaction: SummaryTransaction,
   now: Date,
   initialPageDays: ReadonlySet<string>
 ) {
-  if (initialPageDays.size === 0) {
+  if (
+    initialPageDays.size === 0 ||
+    (env.OPENAI_API_KEY?.trim().length ?? 0) === 0
+  ) {
     return false;
   }
   const [active] = await transaction
     .select({ revision: githubWorkUnitSummaryAttempts.revision })
-    .from(githubWorkUnitSummaryAttempts)
-    .innerJoin(
-      githubWorkUnits,
-      eq(githubWorkUnitSummaryAttempts.workUnitId, githubWorkUnits.id)
-    )
+    .from(githubWorkUnits)
     .innerJoin(
       githubRepositories,
       eq(githubWorkUnits.repositoryId, githubRepositories.id)
     )
-    .where(
+    .leftJoin(
+      githubWorkUnitSummaryAttempts,
       and(
-        eq(githubWorkUnitSummaryAttempts.state, "processing"),
-        gt(githubWorkUnitSummaryAttempts.leaseUntil, now),
-        isNotNull(githubWorkUnitSummaryAttempts.requestPayload),
+        eq(githubWorkUnitSummaryAttempts.workUnitId, githubWorkUnits.id),
         eq(
           githubWorkUnitSummaryAttempts.recipe,
           GITHUB_WORK_UNIT_SUMMARY_RECIPE
-        ),
+        )
+      )
+    )
+    .where(
+      and(
         eq(githubWorkUnits.visibility, "public"),
         eq(githubRepositories.visibility, "public"),
         gte(
@@ -704,21 +789,46 @@ async function hasActiveInitialPageSummary(
           new Date(now.getTime() - RECENT_WINDOW_MS)
         ),
         inArray(githubWorkUnits.activityDay, [...initialPageDays]),
-        eq(
-          githubWorkUnits.revision,
-          githubWorkUnitSummaryAttempts.unitRevision
-        ),
-        eq(
-          githubWorkUnits.outcomeDigest,
-          githubWorkUnitSummaryAttempts.outcomeDigest
-        ),
-        eq(
-          githubWorkUnits.summaryInputDigest,
-          githubWorkUnitSummaryAttempts.summaryInputDigest
-        ),
-        eq(
-          githubWorkUnits.attributionMode,
-          githubWorkUnitSummaryAttempts.attributionMode
+        or(
+          and(
+            isNotNull(githubWorkUnits.summaryEvaluationDigest),
+            sql`${githubWorkUnits.summaryEvaluationDigest} IS DISTINCT FROM ${githubWorkUnits.summaryEvaluatedDigest}`
+          ),
+          and(
+            eq(
+              githubWorkUnits.summaryEvaluationDigest,
+              githubWorkUnits.summaryEvaluatedDigest
+            ),
+            eq(
+              githubWorkUnits.outcomeDigest,
+              githubWorkUnitSummaryAttempts.outcomeDigest
+            ),
+            eq(
+              githubWorkUnits.summaryInputDigest,
+              githubWorkUnitSummaryAttempts.summaryInputDigest
+            ),
+            eq(
+              githubWorkUnits.attributionMode,
+              githubWorkUnitSummaryAttempts.attributionMode
+            ),
+            isNotNull(githubWorkUnitSummaryAttempts.requestPayload),
+            or(
+              and(
+                inArray(githubWorkUnitSummaryAttempts.state, [
+                  "pending",
+                  "retryable",
+                ]),
+                lt(
+                  githubWorkUnitSummaryAttempts.startedRequests,
+                  MAXIMUM_STARTED_REQUESTS
+                )
+              ),
+              and(
+                eq(githubWorkUnitSummaryAttempts.state, "processing"),
+                gt(githubWorkUnitSummaryAttempts.leaseUntil, now)
+              )
+            )
+          )
         )
       )
     )
@@ -737,7 +847,7 @@ async function revisePublicSummaryHead(
   initialPageDays: ReadonlySet<string>,
   mutation: PublicHeadMutation = {}
 ) {
-  const summarizing = await hasActiveInitialPageSummary(
+  const summarizing = await hasCurrentInitialPageSummaryWork(
     transaction,
     now,
     initialPageDays
@@ -790,9 +900,7 @@ export const claimGitHubWorkUnitSummary = async (
   const leaseDurationMs = checkedLeaseDuration(options.leaseDurationMs);
   const recentSince = new Date(now.getTime() - RECENT_WINDOW_MS);
   return await getDatabase().transaction(async (transaction) => {
-    await transaction.execute(
-      sql`select pg_advisory_xact_lock(hashtext(${SUMMARY_CLAIM_LOCK}))`
-    );
+    await acquireSummaryStateLocks(transaction);
     await recoverExpiredClaims(transaction, now);
     const usage = await readSummaryUsage(transaction, now);
     let claim: GitHubWorkUnitSummaryClaim | null = null;
@@ -842,7 +950,7 @@ export const claimGitHubWorkUnitSummary = async (
   });
 };
 
-/** Accepts provider output only while every current public summary key matches. */
+/** Stores valid public-input output, including reusable stale evaluations. */
 export const completeGitHubWorkUnitSummary = async (
   uncheckedClaim: GitHubWorkUnitSummaryClaim,
   uncheckedResult: GitHubWorkUnitSummaryProviderResult,
@@ -852,9 +960,7 @@ export const completeGitHubWorkUnitSummary = async (
   const result = checkedProviderResult(uncheckedResult);
   const now = checkedDate(completedAt, "completion timestamp");
   return await getDatabase().transaction(async (transaction) => {
-    await transaction.execute(
-      sql`select pg_advisory_xact_lock(hashtext(${SUMMARY_CLAIM_LOCK}))`
-    );
+    await acquireSummaryStateLocks(transaction);
     await recoverExpiredClaims(transaction, now);
     const initialPageDays = await readInitialPageDays(transaction);
     const settleHead = async (mutation?: PublicHeadMutation) =>
@@ -878,29 +984,14 @@ export const completeGitHubWorkUnitSummary = async (
       await settleHead();
       return { accepted: false };
     }
-    if (!currentUnitMatchesAttempt(unit, attempt)) {
+    if (!unitIsPublic(unit)) {
       await terminalizeLockedAttempt(transaction, claim, now);
       await settleHead();
       return { accepted: false };
     }
-    const [priorAcceptedOutcome] = await transaction
-      .select({ revision: githubWorkUnitSummaryAttempts.revision })
-      .from(githubWorkUnitSummaryAttempts)
-      .where(
-        and(
-          eq(githubWorkUnitSummaryAttempts.workUnitId, claim.workUnitId),
-          eq(githubWorkUnitSummaryAttempts.state, "accepted"),
-          eq(githubWorkUnitSummaryAttempts.outcomeDigest, claim.outcomeDigest),
-          eq(
-            githubWorkUnitSummaryAttempts.attributionMode,
-            claim.attributionMode
-          ),
-          isNotNull(githubWorkUnitSummaryAttempts.acceptedAt),
-          isNotNull(githubWorkUnitSummaryAttempts.outcome)
-        )
-      )
-      .limit(1);
-    const initialPageChanged = initialPageDays.has(unit.activityDay);
+    const currentlyVisible = unitDisplaysAttempt(unit, attempt);
+    const initialPageChanged =
+      currentlyVisible && initialPageDays.has(unit.activityDay);
     const [accepted] = await transaction
       .update(githubWorkUnitSummaryAttempts)
       .set({
@@ -932,7 +1023,7 @@ export const completeGitHubWorkUnitSummary = async (
     await settleHead(
       initialPageChanged
         ? {
-            feedRevisionChanged: priorAcceptedOutcome === undefined,
+            feedRevisionChanged: true,
             initialPageContentChanged: true,
           }
         : undefined
@@ -956,9 +1047,7 @@ export const deferGitHubWorkUnitSummary = async (
     );
   }
   return await getDatabase().transaction(async (transaction) => {
-    await transaction.execute(
-      sql`select pg_advisory_xact_lock(hashtext(${SUMMARY_CLAIM_LOCK}))`
-    );
+    await acquireSummaryStateLocks(transaction);
     await recoverExpiredClaims(transaction, now);
     const initialPageDays = await readInitialPageDays(transaction);
     const settleHead = async () =>
@@ -977,20 +1066,24 @@ export const deferGitHubWorkUnitSummary = async (
       await settleHead();
       return "stale";
     }
-    if (
-      !currentUnitMatchesAttempt(unit, attempt) ||
-      attempt.startedRequests >= MAXIMUM_STARTED_REQUESTS
-    ) {
+    if (!unitIsPublic(unit)) {
       await terminalizeLockedAttempt(transaction, claim, now);
       await settleHead();
       return "terminal";
     }
+    if (attempt.startedRequests >= MAXIMUM_STARTED_REQUESTS) {
+      await terminalizeLockedAttempt(transaction, claim, now);
+      await settleHead();
+      return "terminal";
+    }
+    const remainsCurrent = currentUnitMatchesAttempt(unit, attempt);
     const [deferred] = await transaction
       .update(githubWorkUnitSummaryAttempts)
       .set({
         debounceUntil: retry,
         leaseToken: null,
         leaseUntil: null,
+        requestPayload: remainsCurrent ? attempt.requestPayload : null,
         state: "retryable",
       })
       .where(
@@ -1003,7 +1096,7 @@ export const deferGitHubWorkUnitSummary = async (
       )
       .returning({ revision: githubWorkUnitSummaryAttempts.revision });
     await settleHead();
-    return deferred === undefined ? "stale" : "deferred";
+    return deferred === undefined || !remainsCurrent ? "stale" : "deferred";
   });
 };
 
@@ -1015,9 +1108,7 @@ export const terminalGitHubWorkUnitSummary = async (
   const claim = checkedClaim(uncheckedClaim);
   const now = checkedDate(terminalAt, "terminal timestamp");
   return await getDatabase().transaction(async (transaction) => {
-    await transaction.execute(
-      sql`select pg_advisory_xact_lock(hashtext(${SUMMARY_CLAIM_LOCK}))`
-    );
+    await acquireSummaryStateLocks(transaction);
     await recoverExpiredClaims(transaction, now);
     const initialPageDays = await readInitialPageDays(transaction);
     const attempt = await lockedAttempt(
@@ -1040,9 +1131,7 @@ export const reconcileGitHubWorkUnitSummaryStatus = async (
 ): Promise<boolean> => {
   const now = checkedDate(reconciledAt, "status timestamp");
   return await getDatabase().transaction(async (transaction) => {
-    await transaction.execute(
-      sql`select pg_advisory_xact_lock(hashtext(${SUMMARY_CLAIM_LOCK}))`
-    );
+    await acquireSummaryStateLocks(transaction);
     await recoverExpiredClaims(transaction, now);
     const initialPageDays = await readInitialPageDays(transaction);
     return await revisePublicSummaryHead(transaction, now, initialPageDays);

--- a/src/lib/github-work-unit-summary.ts
+++ b/src/lib/github-work-unit-summary.ts
@@ -7,12 +7,27 @@ import { z } from "zod";
 export const GITHUB_WORK_UNIT_SUMMARY_RECIPE = "github-work-unit-outcome-v1";
 export const GITHUB_WORK_UNIT_SUMMARY_MAX_INPUT_TOKENS = 32_000;
 export const GITHUB_WORK_UNIT_SUMMARY_MAX_PAYLOAD_BYTES = 384 * 1024;
-export const GITHUB_WORK_UNIT_SUMMARY_MAX_OUTCOME_CHARACTERS = 320;
-export const GITHUB_WORK_UNIT_SUMMARY_MAX_OUTCOME_WORDS = 60;
+const GITHUB_WORK_UNIT_SUMMARY_MAX_OUTCOME_CHARACTERS = 320;
+const GITHUB_WORK_UNIT_SUMMARY_MAX_OUTCOME_WORDS = 60;
+export const GITHUB_WORK_UNIT_SUMMARY_PROVIDER_POLICY = {
+  maxOutputTokens: 160,
+  maxRetries: 0,
+  model: "gpt-5.4-nano-2026-03-17",
+  reasoningEffort: "none",
+  store: false,
+  textVerbosity: "low",
+} as const;
 
 const REQUEST_FRAMING_TOKEN_RESERVE = 128;
+const MAXIMUM_OUTCOME_SENTENCES = 2;
 const MEMBERSHIP_DIGEST_RECIPE = "github-work-unit-membership-v1";
 const OUTCOME_DIGEST_RECIPE = "github-work-unit-outcome-diff-v1";
+const SUMMARY_INPUT_VERSION = 1;
+const SUMMARY_NORMALIZATION_POLICY = "github-work-unit-normalization-v1";
+const SUMMARY_OUTPUT_VALIDATION_POLICY =
+  "github-work-unit-output-validation-v1";
+const SUMMARY_EVALUATION_DIGEST_RECIPE =
+  "github-work-unit-summary-evaluation-v1";
 const SUMMARY_INPUT_DIGEST_RECIPE = "github-work-unit-summary-input-v1";
 const NO_DISALLOWED_SPECIAL_TOKENS = new Set<string>();
 
@@ -94,6 +109,31 @@ export interface GitHubWorkUnitSummaryCandidate {
   readonly repository: GitHubWorkUnitSummaryRepositoryContext;
 }
 
+interface GitHubWorkUnitSummaryEvaluationChange {
+  readonly additions: number;
+  readonly deletions: number;
+  readonly fileFactsDigest: string;
+}
+
+export type GitHubWorkUnitSummaryEvaluationEvidence =
+  | Readonly<{
+      fileFactsComplete: boolean;
+      fileFactsDigest: string | null;
+      mode: "net";
+    }>
+  | Readonly<{
+      changes: readonly GitHubWorkUnitSummaryEvaluationChange[];
+      mode: "composite";
+    }>;
+
+interface GitHubWorkUnitSummaryEvaluationInput {
+  readonly attributionMode: GitHubWorkUnitSummaryAttributionMode;
+  readonly evidence: GitHubWorkUnitSummaryEvaluationEvidence;
+  readonly kind: GitHubWorkUnitKind;
+  readonly membershipDigest: string;
+  readonly repository: GitHubWorkUnitSummaryRepositoryContext;
+}
+
 export interface NormalizedGitHubWorkUnitSummaryFile {
   readonly additions: number;
   readonly deletions: number;
@@ -127,7 +167,7 @@ export interface GitHubWorkUnitSummaryInput {
   readonly kind: GitHubWorkUnitKind;
   readonly recipe: typeof GITHUB_WORK_UNIT_SUMMARY_RECIPE;
   readonly repository: GitHubWorkUnitSummaryRepositoryContext;
-  readonly version: 1;
+  readonly version: typeof SUMMARY_INPUT_VERSION;
 }
 
 export type GitHubWorkUnitSummaryFactsOnlyReason =
@@ -354,7 +394,7 @@ export const githubWorkUnitSummaryInputSchema = z
         topics: z.array(z.string()),
       })
       .strict(),
-    version: z.literal(1),
+    version: z.literal(SUMMARY_INPUT_VERSION),
   })
   .strict()
   .superRefine((input, context) => {
@@ -438,6 +478,30 @@ const compareText = (left: string, right: string) =>
 
 const sha256 = (domain: string, value: string) =>
   createHash("sha256").update(domain).update("\0").update(value).digest("hex");
+
+export const GITHUB_WORK_UNIT_SUMMARY_POLICY_DIGEST = sha256(
+  "github-work-unit-summary-policy-v1",
+  JSON.stringify({
+    framingTokenReserve: REQUEST_FRAMING_TOKEN_RESERVE,
+    inputVersion: SUMMARY_INPUT_VERSION,
+    maxInputTokens: GITHUB_WORK_UNIT_SUMMARY_MAX_INPUT_TOKENS,
+    maxOutcomeCharacters: GITHUB_WORK_UNIT_SUMMARY_MAX_OUTCOME_CHARACTERS,
+    maxOutcomeSentences: MAXIMUM_OUTCOME_SENTENCES,
+    maxOutcomeWords: GITHUB_WORK_UNIT_SUMMARY_MAX_OUTCOME_WORDS,
+    maxPayloadBytes: GITHUB_WORK_UNIT_SUMMARY_MAX_PAYLOAD_BYTES,
+    normalization: SUMMARY_NORMALIZATION_POLICY,
+    outputValidation: SUMMARY_OUTPUT_VALIDATION_POLICY,
+    provider: {
+      maxOutputTokens: GITHUB_WORK_UNIT_SUMMARY_PROVIDER_POLICY.maxOutputTokens,
+      model: GITHUB_WORK_UNIT_SUMMARY_PROVIDER_POLICY.model,
+      reasoningEffort: GITHUB_WORK_UNIT_SUMMARY_PROVIDER_POLICY.reasoningEffort,
+      textVerbosity: GITHUB_WORK_UNIT_SUMMARY_PROVIDER_POLICY.textVerbosity,
+    },
+    recipe: GITHUB_WORK_UNIT_SUMMARY_RECIPE,
+    systemPrompt: GITHUB_WORK_UNIT_SUMMARY_SYSTEM_PROMPT,
+    tokenizer: GITHUB_WORK_UNIT_SUMMARY_PROVIDER_POLICY.model,
+  })
+);
 
 const checkedKey = (value: string, label: string) => {
   if (value.length === 0 || value.includes("\0")) {
@@ -797,20 +861,18 @@ export const digestGitHubWorkUnitOutcome = (
   };
 };
 
-export const digestGitHubWorkUnitSummaryInput = (
+const digestGitHubWorkUnitSummaryInput = (
   serializedInput: string,
   outcomeDigest: string,
-  attributionMode: GitHubWorkUnitSummaryAttributionMode,
-  recipe = GITHUB_WORK_UNIT_SUMMARY_RECIPE
+  attributionMode: GitHubWorkUnitSummaryAttributionMode
 ) =>
   sha256(
     SUMMARY_INPUT_DIGEST_RECIPE,
     JSON.stringify({
       attributionMode,
       outcomeDigest,
-      recipe,
+      policyDigest: GITHUB_WORK_UNIT_SUMMARY_POLICY_DIGEST,
       serializedInput,
-      systemPrompt: GITHUB_WORK_UNIT_SUMMARY_SYSTEM_PROMPT,
     })
   );
 
@@ -819,7 +881,7 @@ const normalizedOptionalText = (value: string | null) => {
   return normalized.length === 0 ? null : normalized;
 };
 
-const normalizedRepository = (
+const canonicalRepository = (
   repository: GitHubWorkUnitSummaryRepositoryContext
 ): GitHubWorkUnitSummaryRepositoryContext => {
   const fullName = repository.fullName.trim();
@@ -835,6 +897,62 @@ const normalizedRepository = (
     homepageUrl: normalizedOptionalText(repository.homepageUrl),
     topics,
   };
+};
+
+const digestPattern = /^[a-f0-9]{64}$/u;
+
+export const digestGitHubWorkUnitSummaryEvaluation = (
+  input: GitHubWorkUnitSummaryEvaluationInput
+) => {
+  if (
+    !attributionShapeIsValid(
+      input.attributionMode,
+      input.kind,
+      input.evidence.mode
+    ) ||
+    !digestPattern.test(input.membershipDigest)
+  ) {
+    throw new TypeError("The GitHub summary evaluation identity is invalid.");
+  }
+  const evidence: GitHubWorkUnitSummaryEvaluationEvidence =
+    input.evidence.mode === "net"
+      ? {
+          fileFactsComplete: input.evidence.fileFactsComplete,
+          fileFactsDigest: input.evidence.fileFactsDigest,
+          mode: "net",
+        }
+      : {
+          changes: input.evidence.changes.map(
+            ({ additions, deletions, fileFactsDigest }) => ({
+              additions,
+              deletions,
+              fileFactsDigest,
+            })
+          ),
+          mode: "composite",
+        };
+  const fingerprints =
+    evidence.mode === "net"
+      ? [evidence.fileFactsDigest]
+      : evidence.changes.map((change) => change.fileFactsDigest);
+  if (
+    fingerprints.some(
+      (fingerprint) => fingerprint !== null && !digestPattern.test(fingerprint)
+    )
+  ) {
+    throw new TypeError("The GitHub summary evidence digest is invalid.");
+  }
+  return sha256(
+    SUMMARY_EVALUATION_DIGEST_RECIPE,
+    JSON.stringify({
+      attributionMode: input.attributionMode,
+      evidence,
+      kind: input.kind,
+      membershipDigest: input.membershipDigest,
+      policyDigest: GITHUB_WORK_UNIT_SUMMARY_POLICY_DIGEST,
+      repository: canonicalRepository(input.repository),
+    })
+  );
 };
 
 const tightenedLimit = (value: number | undefined, hardLimit: number) => {
@@ -884,13 +1002,14 @@ export const buildGitHubWorkUnitSummaryInput = async (
     return { eligible: false, reason: outcome.reason };
   }
   const membershipDigest = digestGitHubWorkUnitMembership(candidate.membership);
+  const repository = canonicalRepository(candidate.repository);
   const input = deepFreeze({
     attributionMode: candidate.attributionMode,
     evidence: outcome.normalized,
     kind: candidate.kind,
     recipe: GITHUB_WORK_UNIT_SUMMARY_RECIPE,
-    repository: normalizedRepository(candidate.repository),
-    version: 1 as const,
+    repository,
+    version: SUMMARY_INPUT_VERSION,
   }) satisfies GitHubWorkUnitSummaryInput;
   githubWorkUnitSummaryInputSchema.parse(input);
   const serializedInput = JSON.stringify(input);
@@ -1011,7 +1130,7 @@ export const validateGitHubWorkUnitSummaryOutput = (
   ) {
     return { ok: false, reason: "overlength" };
   }
-  if (sentenceCount(outcome) > 2) {
+  if (sentenceCount(outcome) > MAXIMUM_OUTCOME_SENTENCES) {
     return { ok: false, reason: "too_many_sentences" };
   }
   return { ok: true, outcome };

--- a/tests/github-activity-feed-postgres.test.mjs
+++ b/tests/github-activity-feed-postgres.test.mjs
@@ -13,6 +13,7 @@ import { migrate } from "drizzle-orm/postgres-js/migrator";
 import postgres from "postgres";
 
 import { env } from "../src/env.ts";
+import { GITHUB_WORK_UNIT_SUMMARY_RECIPE } from "../src/lib/github-work-unit-summary.ts";
 
 setDefaultTimeout(30_000);
 
@@ -231,37 +232,53 @@ describe.skipIf(!dockerAvailable)("GitHub work-unit feed projection", () => {
           'https://github.com/unknown-owner/unknown-repository-sentinel/issues/9')
     `;
     await admin`
+      insert into github_repository_inventory_heads (
+        account_login, account_user_id, completed_at, generation, updated_at
+      ) values (
+        'f0rr0', '8574219', '2026-08-31T10:00:00Z', 1,
+        '2026-08-31T10:00:00Z'
+      )
+    `;
+    await admin`
+      insert into github_account_repository_catalogs (
+        account_user_id, active_access, inventory_generation, observed_at,
+        repository_id
+      ) values (
+        '8574219', true, 1, '2026-08-31T10:00:00Z', '201'
+      )
+    `;
+    await admin`
       insert into github_work_unit_summary_attempts (
         accepted_at, attribution_mode, completed_at, debounce_until,
         outcome, outcome_digest, recipe, revision, state,
-        summary_input_digest, unit_revision, work_unit_id
+        summary_input_digest, work_unit_id
       ) values
         (
           '2026-08-30T12:02:00Z', 'tracked_authored_pr',
           '2026-08-30T12:02:00Z', '2026-08-30T12:00:00Z',
           'Explains the current pull request outcome.', ${digest("a")},
-          'work-unit-outcome-v1', 1, 'accepted', ${digest("1")}, 1,
+          ${GITHUB_WORK_UNIT_SUMMARY_RECIPE}, 1, 'accepted', ${digest("1")},
           '00000000-0000-4000-8000-000000000101'
         ),
         (
           '2026-08-30T12:03:00Z', 'tracked_authored_pr',
           '2026-08-30T12:03:00Z', '2026-08-30T12:00:00Z',
           'Stale outcome must remain hidden.', ${digest("b")},
-          'work-unit-outcome-v1', 2, 'accepted', ${digest("2")}, 2,
+          ${GITHUB_WORK_UNIT_SUMMARY_RECIPE}, 2, 'accepted', ${digest("2")},
           '00000000-0000-4000-8000-000000000101'
         ),
         (
           '2026-08-30T12:04:00Z', 'tracked_authored_pr',
           '2026-08-30T12:04:00Z', '2026-08-30T12:00:00Z',
           'Stale input must remain hidden.', ${digest("a")},
-          'work-unit-outcome-v1', 3, 'accepted', ${digest("3")}, 2,
+          ${GITHUB_WORK_UNIT_SUMMARY_RECIPE}, 3, 'accepted', ${digest("3")},
           '00000000-0000-4000-8000-000000000101'
         ),
         (
           '2026-08-30T12:05:00Z', 'branch_owned_composite',
           '2026-08-30T12:05:00Z', '2026-08-30T12:00:00Z',
           'Wrong attribution must remain hidden.', ${digest("a")},
-          'corrupt-mode-test', 4, 'accepted', ${digest("1")}, 2,
+          'corrupt-mode-test', 4, 'accepted', ${digest("1")},
           '00000000-0000-4000-8000-000000000101'
         )
     `;

--- a/tests/github-activity-worker.test.mjs
+++ b/tests/github-activity-worker.test.mjs
@@ -6,13 +6,11 @@ import {
 } from "../src/lib/github-activity-processor.ts";
 import {
   boundedWorkerLimit,
-  DEFAULT_GITHUB_ACTIVITY_WORKER_BATCH_SIZE,
   githubActivityRetryAt,
   githubPullRequestSnapshotDisposition,
   githubPrReconciliationCutoff,
   githubSummaryCanStart,
   GITHUB_PR_RECONCILIATION_MAX_AGE_DAYS,
-  MAXIMUM_GITHUB_ACTIVITY_WORKER_BATCH_SIZE,
   nextGitHubPullRequestReconciliationAt,
   workerBatchSizeFrom,
   workerDeadlineReached,
@@ -97,9 +95,7 @@ describe("GitHub activity terminal gaps", () => {
 
 describe("GitHub activity worker bounds", () => {
   test("accepts only deliberately small batches", () => {
-    expect(DEFAULT_GITHUB_ACTIVITY_WORKER_BATCH_SIZE).toBe(4);
-    expect(MAXIMUM_GITHUB_ACTIVITY_WORKER_BATCH_SIZE).toBe(8);
-    expect(boundedWorkerLimit()).toBe(4);
+    expect(boundedWorkerLimit()).toBe(8);
     expect(boundedWorkerLimit(8)).toBe(8);
     expect(() => boundedWorkerLimit(0)).toThrow("batch size");
     expect(() => boundedWorkerLimit(9)).toThrow("batch size");
@@ -116,8 +112,8 @@ describe("GitHub activity worker bounds", () => {
   });
 
   test("starts summary work only with a complete provider budget", () => {
-    expect(githubSummaryCanStart(6000, 1000)).toBe(true);
-    expect(githubSummaryCanStart(5999, 1000)).toBe(false);
+    expect(githubSummaryCanStart(26_000, 1000)).toBe(true);
+    expect(githubSummaryCanStart(25_999, 1000)).toBe(false);
     expect(() => githubSummaryCanStart(Number.NaN, 1000)).toThrow(RangeError);
   });
 

--- a/tests/github-backfill.test.mjs
+++ b/tests/github-backfill.test.mjs
@@ -503,7 +503,6 @@ describe("GitHub factual history backfill", () => {
       accounts: ["f0rr0"],
       includeProjection: false,
       includeRefs: false,
-      includeSummaries: false,
       scope: {
         repositoryId: null,
         sinceAt: request.sinceAt,
@@ -538,7 +537,6 @@ describe("GitHub factual history backfill", () => {
         runWorker: async (options) => {
           workerPasses += 1;
           expect(options.includeProjection).toBe(false);
-          expect(options.includeSummaries).toBe(false);
           return workerResult({
             commits: emptyWorkerStage({
               claimed: 1,

--- a/tests/github-pull-request-store.test.mjs
+++ b/tests/github-pull-request-store.test.mjs
@@ -259,6 +259,46 @@ describe.skipIf(!dockerAvailable)("GitHub pull request persistence", () => {
     expect(verified.mergeShaVerifiedAt).not.toBeNull();
   });
 
+  test("signals an equal-time terminal promotion despite a conflicting head", async () => {
+    const nodeId = "PR_pr_store_terminal_head_race_8301";
+    await persistGitHubWebhookPullRequest(
+      "00000000-0000-4000-8000-000000000011",
+      "f0rr0",
+      pullRequest({ nodeId, number: 318 })
+    );
+    await admin`
+      update github_public_feed_head set projection_request_token = null
+      where id
+    `;
+
+    await persistGitHubWebhookPullRequest(
+      "00000000-0000-4000-8000-000000000012",
+      "f0rr0",
+      pullRequest({
+        action: "closed",
+        closedAt: providerUpdatedAt,
+        headSha: secondHeadSha,
+        merged: true,
+        mergedAt: providerUpdatedAt,
+        nodeId,
+        number: 318,
+        state: "closed",
+      })
+    );
+
+    expect(
+      await admin`
+        select state from github_pull_requests where node_id = ${nodeId}
+      `
+    ).toEqual([{ state: "merged" }]);
+    expect(
+      await admin`
+        select projection_request_token is not null as "projectionRequested"
+        from github_public_feed_head
+      `
+    ).toEqual([{ projectionRequested: true }]);
+  });
+
   test("round-trips the completed authored-PR traversal digest", async () => {
     expect(
       await readGitHubPullRequestBackfillDigest("yuppiestechdev")
@@ -357,6 +397,60 @@ describe.skipIf(!dockerAvailable)("GitHub pull request persistence", () => {
       )
       .orderBy(schema.githubPullRequestMemberships.position);
     expect(currentMembership).toEqual([{ sha: secondHeadSha }]);
+  });
+
+  test("signals projection only when a newer snapshot changes projection evidence", async () => {
+    const nodeId = "PR_pr_store_projection_signal_8301";
+    await persistGitHubPullRequestSnapshot(
+      "f0rr0",
+      pullRequest({
+        changedFiles: null,
+        commitCount: null,
+        nodeId,
+        number: 317,
+      })
+    );
+    await admin`
+      update github_public_feed_head set projection_request_token = null
+      where id
+    `;
+
+    const metadataOnly = await persistGitHubPullRequestSnapshot(
+      "f0rr0",
+      pullRequest({
+        body: "Only explanatory copy changed.",
+        changedFiles: 2,
+        commitCount: 2,
+        nodeId,
+        number: 317,
+        providerUpdatedAt: "2026-08-30T12:01:00.000Z",
+        title: "A revised title that is not public feed evidence",
+      })
+    );
+    expect(metadataOnly).toMatchObject({ snapshotChanged: false });
+    expect(
+      await admin`
+        select projection_request_token as "projectionRequestToken"
+        from github_public_feed_head
+      `
+    ).toEqual([{ projectionRequestToken: null }]);
+
+    const changedHead = await persistGitHubPullRequestSnapshot(
+      "f0rr0",
+      pullRequest({
+        headSha: secondHeadSha,
+        nodeId,
+        number: 317,
+        providerUpdatedAt: "2026-08-30T12:02:00.000Z",
+      })
+    );
+    expect(changedHead).toMatchObject({ snapshotChanged: true });
+    expect(
+      await admin`
+        select projection_request_token is not null as "projectionRequested"
+        from github_public_feed_head
+      `
+    ).toEqual([{ projectionRequested: true }]);
   });
 
   test("replaces same-head membership after a base retarget", async () => {

--- a/tests/github-repository-inventory.test.mjs
+++ b/tests/github-repository-inventory.test.mjs
@@ -188,6 +188,7 @@ describe.skipIf(!dockerAvailable)("GitHub repository inventory", () => {
     /** @type {string[]} */
     const paths = [];
     const headSha = "a".repeat(40);
+    let sideHeadSha = "b".repeat(40);
     globalThis.fetch = async (input) => {
       const url =
         input instanceof Request ? new URL(input.url) : new URL(input);
@@ -196,7 +197,10 @@ describe.skipIf(!dockerAvailable)("GitHub repository inventory", () => {
         return Response.json([repositoryResponse()]);
       }
       if (url.pathname === "/repos/f0rr0/example/branches") {
-        return Response.json([{ commit: { sha: headSha }, name: "main" }]);
+        return Response.json([
+          { commit: { sha: headSha }, name: "main" },
+          { commit: { sha: sideHeadSha }, name: "unmerged-side" },
+        ]);
       }
       throw new Error(`Unexpected GitHub request: ${url.pathname}`);
     };
@@ -210,21 +214,59 @@ describe.skipIf(!dockerAvailable)("GitHub repository inventory", () => {
         token: "token",
       });
     const first = await runBatch();
+    const [afterFirst] = await admin`
+      select projection_request_token as "projectionRequestToken"
+      from github_public_feed_head
+    `;
     const second = await runBatch();
+    const [afterUnchanged] = await admin`
+      select projection_request_token as "projectionRequestToken"
+      from github_public_feed_head
+    `;
 
     expect(first).toEqual({
       complete: true,
       knownCommits: 0,
       pages: 1,
       pushes: 0,
-      refs: 1,
+      refs: 2,
       repositories: 1,
     });
     expect(second).toEqual(first);
+    expect(afterFirst.projectionRequestToken).toMatch(/^[0-9a-f-]{36}$/u);
+    expect(afterUnchanged.projectionRequestToken).toBe(
+      afterFirst.projectionRequestToken
+    );
+    expect(
+      await admin`
+        select projection_relevant as "projectionRelevant"
+        from github_repository_refs
+        where repository_id = '101' and ref_name = 'refs/heads/unmerged-side'
+      `
+    ).toEqual([{ projectionRelevant: false }]);
+    await admin`
+      update github_public_feed_head set projection_request_token = null
+      where id
+    `;
+    sideHeadSha = "c".repeat(40);
+    await runBatch();
+    expect(
+      await admin`
+        select projection_relevant as "projectionRelevant"
+        from github_repository_refs
+        where repository_id = '101' and ref_name = 'refs/heads/unmerged-side'
+      `
+    ).toEqual([{ projectionRelevant: true }]);
+    expect(
+      await admin`
+        select projection_request_token is not null as "projectionRequested"
+        from github_public_feed_head
+      `
+    ).toEqual([{ projectionRequested: true }]);
     expect({
       branches: paths.filter((path) => path.endsWith("/branches")).length,
       inventory: paths.filter((path) => path === "/user/repos").length,
-    }).toEqual({ branches: 2, inventory: 1 });
+    }).toEqual({ branches: 3, inventory: 1 });
     expect(
       await admin`
         select
@@ -260,6 +302,67 @@ describe.skipIf(!dockerAvailable)("GitHub repository inventory", () => {
         topics: ["example", "typescript"],
       },
     ]);
+  });
+
+  test("requests projection when a scanned head returns to its complete generation", async () => {
+    let desiredHeadSha = sha("a");
+    globalThis.fetch = async (input) => {
+      const url =
+        input instanceof Request ? new URL(input.url) : new URL(input);
+      if (url.pathname === "/user/repos") {
+        return Response.json([repositoryResponse()]);
+      }
+      if (url.pathname === "/repos/f0rr0/example/branches") {
+        return Response.json([
+          { commit: { sha: desiredHeadSha }, name: "main" },
+        ]);
+      }
+      throw new Error(`Unexpected GitHub request: ${url.pathname}`);
+    };
+    const runBatch = () =>
+      reconcileGitHubRepositoryRefBatch({
+        account: "f0rr0",
+        deadlineAt: Date.now() + 15_000,
+        kind: "head",
+        repositoryLimit: 1,
+        token: "token",
+      });
+
+    await runBatch();
+    const [ref] = await admin`
+      select branch_lineage_id as "branchLineageId"
+      from github_repository_refs
+      where repository_id = '101' and ref_name = 'refs/heads/main'
+    `;
+    await admin`
+      insert into github_ref_generations (
+        branch_lineage_id, completed_at, coverage_since_at, generation,
+        head_sha, ref_name, repository_id
+      ) values (
+        ${ref.branchLineageId}, '2026-09-01T12:00:00.000Z',
+        '2026-08-01T00:00:00.000Z', 1, ${desiredHeadSha},
+        'refs/heads/main', '101'
+      )
+    `;
+
+    desiredHeadSha = sha("b");
+    await runBatch();
+    await admin`
+      update github_public_feed_head set projection_request_token = null
+      where id
+    `;
+    desiredHeadSha = sha("a");
+    await runBatch();
+
+    expect(
+      await admin`
+        select projection_request_token is not null as "projectionRequested"
+        from github_public_feed_head
+      `
+    ).toEqual([{ projectionRequested: true }]);
+    expect(
+      await claimGitHubRefRepairs({ limit: 1, repositoryId: "101" })
+    ).toEqual([]);
   });
 
   test("publishes metadata when sparse facts arrive during inventory traversal", async () => {
@@ -467,7 +570,7 @@ describe.skipIf(!dockerAvailable)("GitHub repository inventory", () => {
     ]);
   });
 
-  test("invalidates only affected public summaries when repository context changes", async () => {
+  test("requests bounded summary reevaluation when repository context changes", async () => {
     const startedAt = new Date("2026-09-01T12:00:00.000Z");
     const startedAtIso = startedAt.toISOString();
     let providerRepositories = [repositoryResponse()];
@@ -496,7 +599,8 @@ describe.skipIf(!dockerAvailable)("GitHub repository inventory", () => {
         facts_digest, file_count, first_activity_at, id, identity_key, kind,
         last_activity_at, member_count, membership_digest,
         newest_commit_repository_id, newest_commit_sha, outcome_digest,
-        repository_id, summary_input_digest, visibility
+        repository_id, summary_evaluated_digest, summary_input_digest,
+        visibility
       ) values
         (
           ${startedAtIso}, ${startedAtIso}, '2026-09-01', 1,
@@ -505,7 +609,7 @@ describe.skipIf(!dockerAvailable)("GitHub repository inventory", () => {
           '20000000-0000-4000-8000-000000000101',
           'branch:10000000-0000-4000-8000-000000000101', 'branch',
           ${startedAtIso}, 1, ${digest("b")}, '101', ${sha("a")}, ${digest("c")},
-          '101', ${digest("d")}, 'public'
+          '101', ${digest("7")}, ${digest("d")}, 'public'
         ),
         (
           ${startedAtIso}, ${startedAtIso}, '2026-09-01', 1,
@@ -514,7 +618,7 @@ describe.skipIf(!dockerAvailable)("GitHub repository inventory", () => {
           '20000000-0000-4000-8000-000000000102',
           'branch:10000000-0000-4000-8000-000000000102', 'branch',
           ${startedAtIso}, 1, ${digest("f")}, '101', ${sha("a")}, ${digest("1")},
-          '101', ${digest("2")}, 'private'
+          '101', ${digest("8")}, null, 'public'
         ),
         (
           ${startedAtIso}, ${startedAtIso}, '2026-09-01', 1,
@@ -523,7 +627,7 @@ describe.skipIf(!dockerAvailable)("GitHub repository inventory", () => {
           '20000000-0000-4000-8000-000000000103',
           'branch:10000000-0000-4000-8000-000000000103', 'branch',
           ${startedAtIso}, 1, ${digest("4")}, '202', ${sha("b")}, ${digest("5")},
-          '202', ${digest("6")}, 'public'
+          '202', ${digest("9")}, ${digest("6")}, 'public'
         )
     `;
 
@@ -535,24 +639,33 @@ describe.skipIf(!dockerAvailable)("GitHub repository inventory", () => {
     });
     expect(
       await admin`
-        select id::text, summary_input_digest as "summaryInputDigest"
+        select id::text,
+          summary_evaluated_digest as "summaryEvaluatedDigest",
+          summary_input_digest as "summaryInputDigest"
         from github_work_units
         order by id
       `
     ).toEqual([
       {
         id: "20000000-0000-4000-8000-000000000101",
+        summaryEvaluatedDigest: digest("7"),
         summaryInputDigest: digest("d"),
       },
       {
         id: "20000000-0000-4000-8000-000000000102",
-        summaryInputDigest: digest("2"),
+        summaryEvaluatedDigest: digest("8"),
+        summaryInputDigest: null,
       },
       {
         id: "20000000-0000-4000-8000-000000000103",
+        summaryEvaluatedDigest: digest("9"),
         summaryInputDigest: digest("6"),
       },
     ]);
+    const [beforeContextChange] = await admin`
+      select projection_request_token as "projectionRequestToken"
+      from github_public_feed_head
+    `;
 
     await getDatabase().transaction(async (transaction) => {
       await upsertGitHubRepository(
@@ -561,6 +674,16 @@ describe.skipIf(!dockerAvailable)("GitHub repository inventory", () => {
         new Date(startedAt.getTime() + 2)
       );
     });
+    const [afterContextChange] = await admin`
+      select projection_request_token as "projectionRequestToken"
+      from github_public_feed_head
+    `;
+    expect(afterContextChange.projectionRequestToken).toMatch(
+      /^[0-9a-f-]{36}$/u
+    );
+    expect(afterContextChange.projectionRequestToken).not.toBe(
+      beforeContextChange.projectionRequestToken
+    );
     expect(
       await admin`
         select description, full_name as "fullName",
@@ -578,16 +701,25 @@ describe.skipIf(!dockerAvailable)("GitHub repository inventory", () => {
     ]);
     expect(
       await admin`
-        select summary_input_digest as "summaryInputDigest"
+        select id::text,
+          summary_evaluated_digest as "summaryEvaluatedDigest",
+          summary_input_digest as "summaryInputDigest"
         from github_work_units
-        where id = '20000000-0000-4000-8000-000000000101'
+        where repository_id = '101'
+        order by id
       `
-    ).toEqual([{ summaryInputDigest: null }]);
-    await admin`
-      update github_work_units
-      set summary_input_digest = ${digest("d")}
-      where id = '20000000-0000-4000-8000-000000000101'
-    `;
+    ).toEqual([
+      {
+        id: "20000000-0000-4000-8000-000000000101",
+        summaryEvaluatedDigest: digest("7"),
+        summaryInputDigest: digest("d"),
+      },
+      {
+        id: "20000000-0000-4000-8000-000000000102",
+        summaryEvaluatedDigest: digest("8"),
+        summaryInputDigest: null,
+      },
+    ]);
 
     providerRepositories = [
       repositoryResponse({
@@ -629,21 +761,26 @@ describe.skipIf(!dockerAvailable)("GitHub repository inventory", () => {
     ]);
     expect(
       await admin`
-        select id::text, summary_input_digest as "summaryInputDigest"
+        select id::text,
+          summary_evaluated_digest as "summaryEvaluatedDigest",
+          summary_input_digest as "summaryInputDigest"
         from github_work_units
         order by id
       `
     ).toEqual([
       {
         id: "20000000-0000-4000-8000-000000000101",
-        summaryInputDigest: null,
+        summaryEvaluatedDigest: digest("7"),
+        summaryInputDigest: digest("d"),
       },
       {
         id: "20000000-0000-4000-8000-000000000102",
-        summaryInputDigest: digest("2"),
+        summaryEvaluatedDigest: digest("8"),
+        summaryInputDigest: null,
       },
       {
         id: "20000000-0000-4000-8000-000000000103",
+        summaryEvaluatedDigest: digest("9"),
         summaryInputDigest: digest("6"),
       },
     ]);

--- a/tests/github-work-unit-core.test.mjs
+++ b/tests/github-work-unit-core.test.mjs
@@ -55,6 +55,7 @@ const change = (character, overrides = {}) => {
     pullRequestCoverageComplete: true,
     repositoryId: "1",
     sha: sha(character),
+    summaryFileFacts: fileFacts,
     ...overrides,
   };
 };
@@ -403,6 +404,39 @@ describe("deterministic GitHub work ownership", () => {
     expect(after.membershipDigest).not.toBe(before.membershipDigest);
     expect(after.facts.memberCount).toBe(1);
     expect(after.activityAt).toBe(before.activityAt);
+  });
+
+  test("uses an explicitly cached outcome without conflating it with a missing cache entry", () => {
+    const work = change("7");
+    const key = logicalKeyFrom(work);
+    const input = {
+      changes: [work],
+      pullRequests: [],
+      refs: [ref("refs/heads/main", [key])],
+      repositories: [repository()],
+      trackedAuthorUserIds: trackedIds,
+    };
+    const [calculated] = projectGitHubWorkUnits(input);
+    const { identityKey } = calculated;
+    const cachedDigest = "f".repeat(64);
+
+    expect(calculated.outcomeDigest).toMatch(/^[a-f0-9]{64}$/u);
+    expect(calculated.outcomeDigest).not.toBe(cachedDigest);
+    expect(
+      projectGitHubWorkUnits(input, undefined, {
+        outcomeDigests: new Map([[identityKey, cachedDigest]]),
+      })[0].outcomeDigest
+    ).toBe(cachedDigest);
+    expect(
+      projectGitHubWorkUnits(input, undefined, {
+        outcomeDigests: new Map([[identityKey, null]]),
+      })[0].outcomeDigest
+    ).toBeNull();
+    expect(
+      projectGitHubWorkUnits(input, undefined, {
+        outcomeDigests: new Map([["canonical:other:2026-08-30", null]]),
+      })[0].outcomeDigest
+    ).toBe(calculated.outcomeDigest);
   });
 
   test("uses only owned commit evidence when a tracked-authored PR includes collaborator work", () => {

--- a/tests/github-work-unit-crosswalk.test.mjs
+++ b/tests/github-work-unit-crosswalk.test.mjs
@@ -12,16 +12,12 @@ const change = ({
   additions = 1,
   character,
   deletions = 0,
+  enrichmentComplete = true,
   mergedPullRequestLanding = false,
   parentCount = 1,
   repositoryId = "1",
-}) => ({
-  additions,
-  authorUserId: trackedUserId,
-  contentObservedAt: activityAt,
-  deletions,
-  enrichmentComplete: true,
-  fileFacts:
+}) => {
+  const fileFacts =
     additions + deletions === 0
       ? []
       : [
@@ -35,19 +31,28 @@ const change = ({
             previousFilename: null,
             status: "modified",
           },
-        ],
-  fileFactsComplete: true,
-  mergedPullRequestLanding,
-  logicalActivityAt: activityAt,
-  logicalRepositoryId: repositoryId,
-  logicalSha: sha(character),
-  parentCount,
-  parentLogicalKeys: [],
-  providerFileCapReached: false,
-  pullRequestCoverageComplete: true,
-  repositoryId,
-  sha: sha(character),
-});
+        ];
+  return {
+    additions,
+    authorUserId: trackedUserId,
+    contentObservedAt: activityAt,
+    deletions,
+    enrichmentComplete,
+    fileFacts,
+    fileFactsComplete: true,
+    mergedPullRequestLanding,
+    logicalActivityAt: activityAt,
+    logicalRepositoryId: repositoryId,
+    logicalSha: sha(character),
+    parentCount,
+    parentLogicalKeys: [],
+    providerFileCapReached: false,
+    pullRequestCoverageComplete: true,
+    repositoryId,
+    sha: sha(character),
+    summaryFileFacts: fileFacts,
+  };
+};
 
 const pullRequest = ({
   authorUserId = trackedUserId,
@@ -129,6 +134,7 @@ const snapshot = () => {
     }),
     change({ character: "d", parentCount: 2, repositoryId: "1" }),
     change({ additions: 0, character: "e", repositoryId: "1" }),
+    change({ character: "5", enrichmentComplete: false, repositoryId: "2" }),
     change({ character: "6", repositoryId: "1" }),
     change({
       character: "7",
@@ -255,8 +261,12 @@ describe("GitHub work-unit crosswalk", () => {
       until: "2026-08-08",
     });
 
-    expect(report.categories.trackedChangeCandidates.count).toBe(9);
+    expect(report.categories.trackedChangeCandidates.count).toBe(10);
     expect(report.categories.eligibleTrackedChanges.count).toBe(7);
+    expect(report.categories.commitEnrichmentBacklog).toEqual({
+      count: 1,
+      ids: [logicalKey("2", "5")],
+    });
     expect(report.categories.integrationMerges).toEqual({
       count: 1,
       ids: [logicalKey("1", "d")],
@@ -310,10 +320,14 @@ describe("GitHub work-unit crosswalk", () => {
       repository_visibility_unknown: 1,
     });
     expect(report.invariants).toEqual({
-      failures: ["projection_coverage_gap", "repository_visibility_gap"],
+      failures: [
+        "commit_enrichment_backlog",
+        "projection_coverage_gap",
+        "repository_visibility_gap",
+      ],
       passed: false,
     });
-    expect(report.version).toBe(2);
+    expect(report.version).toBe(3);
   });
 
   test("treats deterministic policy exclusions as complete coverage", () => {

--- a/tests/github-work-unit-store-postgres.test.mjs
+++ b/tests/github-work-unit-store-postgres.test.mjs
@@ -43,6 +43,14 @@ const fileFact = (filename) => ({
   status: "modified",
 });
 
+const summaryResult = (outcome) => ({
+  inputTokens: 20,
+  latencyMs: 1,
+  model: "gpt-5.4-nano-2026-03-17",
+  outcome,
+  outputTokens: 8,
+});
+
 const checkedOutput = (result, operation) => {
   if (result.exitCode !== 0) {
     throw new Error(
@@ -57,10 +65,19 @@ describe.skipIf(!dockerAvailable)("GitHub work-unit projection store", () => {
   let closeDatabase;
   let containerId;
   let database;
+  let claimGitHubWorkUnitSummary;
+  let completeGitHubWorkUnitSummary;
+  let deferGitHubWorkUnitSummary;
   let originalDatabaseUrl;
   let persistGitHubWebhookIssue;
+  let completeGitHubWorkUnitProjectionRequest;
+  let ensureGitHubWorkUnitProjectionRequest;
+  let readPublicGitHubActivityPage;
   let refreshGitHubWorkUnitProjection;
+  let requestGitHubWorkUnitProjection;
+  let runGitHubActivityWorker;
   let schema;
+  let terminalGitHubWorkUnitSummary;
 
   beforeAll(async () => {
     originalDatabaseUrl = env.DATABASE_URL;
@@ -122,6 +139,21 @@ describe.skipIf(!dockerAvailable)("GitHub work-unit projection store", () => {
       await import("../src/lib/github-work-unit-store.ts"));
     ({ persistGitHubWebhookIssue } =
       await import("../src/lib/github-commits-store.ts"));
+    ({
+      claimGitHubWorkUnitSummary,
+      completeGitHubWorkUnitSummary,
+      deferGitHubWorkUnitSummary,
+      terminalGitHubWorkUnitSummary,
+    } = await import("../src/lib/github-work-unit-summary-store.ts"));
+    ({ readPublicGitHubActivityPage } =
+      await import("../src/lib/github-activity-store.ts"));
+    ({ runGitHubActivityWorker } =
+      await import("../src/lib/github-activity-worker.ts"));
+    ({
+      completeGitHubWorkUnitProjectionRequest,
+      ensureGitHubWorkUnitProjectionRequest,
+      requestGitHubWorkUnitProjection,
+    } = await import("../src/lib/github-work-unit-projection-state.ts"));
 
     await database.insert(schema.githubRepositories).values({
       defaultBranch: "main",
@@ -196,6 +228,154 @@ describe.skipIf(!dockerAvailable)("GitHub work-unit projection store", () => {
     }
   });
 
+  test("keeps generated file-evidence fingerprints in sync with stored facts", async () => {
+    const pullRequestDigestNodeId = "PR_file_digest_7001";
+    const pullRequestVersionId = "70010000-0000-4000-8000-000000000099";
+    await database.insert(schema.githubPullRequests).values({
+      account: "f0rr0",
+      authorUserId: "8574219",
+      baseRepositoryId: repositoryId,
+      baseSha: firstSha,
+      commitCount: 0,
+      createdAt: observedAt,
+      headRepositoryId: repositoryId,
+      headSha: firstSha,
+      nodeId: pullRequestDigestNodeId,
+      number: 99,
+      providerUpdatedAt: observedAt,
+      repositoryId,
+      state: "open",
+      title: "digest fixture",
+      titleSnapshot: "digest fixture",
+      url: "https://github.com/f0rr0/projection-store-test/pull/99",
+    });
+    await database.insert(schema.githubPullRequestVersions).values({
+      baseRepositoryId: repositoryId,
+      baseSha: firstSha,
+      commitCount: 0,
+      fileFacts: [fileFact("src/pr-before.ts")],
+      fileFactsComplete: true,
+      headRepositoryId: repositoryId,
+      headSha: firstSha,
+      id: pullRequestVersionId,
+      membershipComplete: true,
+      observedAt,
+      providerUpdatedAt: observedAt,
+      pullRequestNodeId: pullRequestDigestNodeId,
+    });
+
+    const [commitBefore] = await database
+      .select({ digest: schema.githubCommits.fileFactsDigest })
+      .from(schema.githubCommits)
+      .where(
+        and(
+          eq(schema.githubCommits.repositoryId, repositoryId),
+          eq(schema.githubCommits.sha, firstSha)
+        )
+      );
+    const [pullRequestBefore] = await database
+      .select({ digest: schema.githubPullRequestVersions.fileFactsDigest })
+      .from(schema.githubPullRequestVersions)
+      .where(eq(schema.githubPullRequestVersions.id, pullRequestVersionId));
+
+    expect(commitBefore.digest).toMatch(/^[a-f0-9]{64}$/u);
+    expect(pullRequestBefore.digest).toMatch(/^[a-f0-9]{64}$/u);
+
+    await database
+      .update(schema.githubCommits)
+      .set({ fileFacts: [fileFact("src/commit-after.ts")] })
+      .where(
+        and(
+          eq(schema.githubCommits.repositoryId, repositoryId),
+          eq(schema.githubCommits.sha, firstSha)
+        )
+      );
+    await database
+      .update(schema.githubPullRequestVersions)
+      .set({ fileFacts: [fileFact("src/pr-after.ts")] })
+      .where(eq(schema.githubPullRequestVersions.id, pullRequestVersionId));
+
+    const [commitAfter] = await database
+      .select({ digest: schema.githubCommits.fileFactsDigest })
+      .from(schema.githubCommits)
+      .where(
+        and(
+          eq(schema.githubCommits.repositoryId, repositoryId),
+          eq(schema.githubCommits.sha, firstSha)
+        )
+      );
+    const [pullRequestAfter] = await database
+      .select({ digest: schema.githubPullRequestVersions.fileFactsDigest })
+      .from(schema.githubPullRequestVersions)
+      .where(eq(schema.githubPullRequestVersions.id, pullRequestVersionId));
+
+    expect(commitAfter.digest).not.toBe(commitBefore.digest);
+    expect(pullRequestAfter.digest).not.toBe(pullRequestBefore.digest);
+
+    await database
+      .update(schema.githubCommits)
+      .set({ fileFacts: [fileFact("src/first.ts")] })
+      .where(
+        and(
+          eq(schema.githubCommits.repositoryId, repositoryId),
+          eq(schema.githubCommits.sha, firstSha)
+        )
+      );
+    await database
+      .delete(schema.githubPullRequests)
+      .where(eq(schema.githubPullRequests.nodeId, pullRequestDigestNodeId));
+  });
+
+  test("rejects malformed stored evidence instead of silently losing work", async () => {
+    await database
+      .update(schema.githubCommits)
+      .set({ fileFacts: [{ filename: "src/malformed.ts" }] })
+      .where(
+        and(
+          eq(schema.githubCommits.repositoryId, repositoryId),
+          eq(schema.githubCommits.sha, firstSha)
+        )
+      );
+    try {
+      await expect(
+        refreshGitHubWorkUnitProjection(new Date("2026-08-30T12:00:30.000Z"))
+      ).rejects.toThrow(TypeError);
+    } finally {
+      await database
+        .update(schema.githubCommits)
+        .set({ fileFacts: [fileFact("src/first.ts")] })
+        .where(
+          and(
+            eq(schema.githubCommits.repositoryId, repositoryId),
+            eq(schema.githubCommits.sha, firstSha)
+          )
+        );
+    }
+  });
+
+  test("clears only the projection request token it observed", async () => {
+    const first = await requestGitHubWorkUnitProjection(database);
+    expect(await ensureGitHubWorkUnitProjectionRequest()).toBe(first);
+
+    const replacement = await requestGitHubWorkUnitProjection(database);
+    expect(replacement).not.toBe(first);
+    expect(await completeGitHubWorkUnitProjectionRequest(first)).toBe(false);
+    expect(await ensureGitHubWorkUnitProjectionRequest()).toBe(replacement);
+
+    expect(await completeGitHubWorkUnitProjectionRequest(replacement)).toBe(
+      true
+    );
+    expect(await ensureGitHubWorkUnitProjectionRequest()).toBeNull();
+
+    await database
+      .update(schema.githubPublicFeedHead)
+      .set({ summaryPolicyDigest: "f".repeat(64) })
+      .where(eq(schema.githubPublicFeedHead.id, true));
+    expect(await ensureGitHubWorkUnitProjectionRequest()).toMatch(
+      /^[0-9a-f-]{36}$/u
+    );
+  });
+
   test("atomically swaps public facts, revisions, and summary eligibility", async () => {
     const first = await refreshGitHubWorkUnitProjection(observedAt);
     expect(first).toMatchObject({
@@ -218,6 +398,7 @@ describe.skipIf(!dockerAvailable)("GitHub work-unit projection store", () => {
       visibility: "public",
     });
     expect(unit.summaryInputDigest).toMatch(/^[a-f0-9]{64}$/u);
+    expect(unit.summaryEvaluatedDigest).toMatch(/^[a-f0-9]{64}$/u);
     expect(head).toMatchObject({
       feedRevision: 1,
       headContentRevision: 1,
@@ -248,6 +429,155 @@ describe.skipIf(!dockerAvailable)("GitHub work-unit projection store", () => {
       headContentRevision: 1,
       orderingRevision: 1,
     });
+  });
+
+  test("reactivates an exact cached summary and revises the public head", async () => {
+    const firstClaim = await claimGitHubWorkUnitSummary({
+      now: new Date("2026-08-30T12:06:00.000Z"),
+    });
+    expect(firstClaim).not.toBeNull();
+    await completeGitHubWorkUnitSummary(
+      firstClaim,
+      summaryResult("Cached outcome A."),
+      new Date("2026-08-30T12:06:01.000Z")
+    );
+    const [firstUnit] = await database.select().from(schema.githubWorkUnits);
+    const inputA = firstUnit.summaryInputDigest;
+
+    await database
+      .update(schema.githubRepositories)
+      .set({ description: "Temporary repository context B." })
+      .where(eq(schema.githubRepositories.id, repositoryId));
+    await refreshGitHubWorkUnitProjection(new Date("2026-08-30T12:07:00.000Z"));
+    const secondClaim = await claimGitHubWorkUnitSummary({
+      now: new Date("2026-08-30T12:13:00.000Z"),
+    });
+    expect(secondClaim).not.toBeNull();
+    await completeGitHubWorkUnitSummary(
+      secondClaim,
+      summaryResult("Current outcome B."),
+      new Date("2026-08-30T12:13:01.000Z")
+    );
+
+    await database
+      .update(schema.githubRepositories)
+      .set({ description: null })
+      .where(eq(schema.githubRepositories.id, repositoryId));
+    const [beforeReversion] = await database
+      .select()
+      .from(schema.githubPublicFeedHead);
+    const reverted = await refreshGitHubWorkUnitProjection(
+      new Date("2026-08-30T12:14:00.000Z")
+    );
+    const [revertedUnit] = await database.select().from(schema.githubWorkUnits);
+    const [afterReversion] = await database
+      .select()
+      .from(schema.githubPublicFeedHead);
+    const page = await readPublicGitHubActivityPage(null, 1);
+    const [publicUnit] = page.days[0].repositories[0].items;
+
+    expect(reverted).toMatchObject({
+      feedRevisionChanged: true,
+      summaryAttemptsQueued: 0,
+    });
+    expect(revertedUnit.summaryInputDigest).toBe(inputA);
+    expect(afterReversion.feedRevision).toBe(beforeReversion.feedRevision + 1);
+    expect(afterReversion.headContentRevision).toBe(
+      beforeReversion.headContentRevision + 1
+    );
+    expect(publicUnit).toMatchObject({ outcome: "Cached outcome A." });
+  });
+
+  test("reuses a superseded paid input without resetting its request budget", async () => {
+    await database
+      .update(schema.githubRepositories)
+      .set({ description: "Retryable context C." })
+      .where(eq(schema.githubRepositories.id, repositoryId));
+    await refreshGitHubWorkUnitProjection(new Date("2026-08-30T12:15:00.000Z"));
+    const firstClaim = await claimGitHubWorkUnitSummary({
+      now: new Date("2026-08-30T12:21:00.000Z"),
+    });
+    expect(firstClaim).not.toBeNull();
+
+    await database
+      .update(schema.githubRepositories)
+      .set({ description: "Superseding context D." })
+      .where(eq(schema.githubRepositories.id, repositoryId));
+    await refreshGitHubWorkUnitProjection(new Date("2026-08-30T12:22:00.000Z"));
+    expect(
+      await deferGitHubWorkUnitSummary(
+        firstClaim,
+        new Date("2026-08-30T12:24:00.000Z"),
+        new Date("2026-08-30T12:22:01.000Z")
+      )
+    ).toBe("stale");
+    const [parked] = await database
+      .select()
+      .from(schema.githubWorkUnitSummaryAttempts)
+      .where(
+        and(
+          eq(
+            schema.githubWorkUnitSummaryAttempts.workUnitId,
+            firstClaim.workUnitId
+          ),
+          eq(schema.githubWorkUnitSummaryAttempts.revision, firstClaim.revision)
+        )
+      );
+    expect(parked).toMatchObject({
+      requestPayload: null,
+      startedRequests: 1,
+      state: "retryable",
+    });
+
+    await database
+      .update(schema.githubRepositories)
+      .set({ description: "Retryable context C." })
+      .where(eq(schema.githubRepositories.id, repositoryId));
+    const reactivated = await refreshGitHubWorkUnitProjection(
+      new Date("2026-08-30T12:23:00.000Z")
+    );
+    expect(reactivated).toMatchObject({ summaryAttemptsQueued: 0 });
+    const [rehydrated] = await database
+      .select()
+      .from(schema.githubWorkUnitSummaryAttempts)
+      .where(
+        and(
+          eq(
+            schema.githubWorkUnitSummaryAttempts.workUnitId,
+            firstClaim.workUnitId
+          ),
+          eq(schema.githubWorkUnitSummaryAttempts.revision, firstClaim.revision)
+        )
+      );
+    expect(rehydrated).toMatchObject({
+      debounceUntil: new Date("2026-08-30T12:28:00.000Z"),
+      requestPayload: firstClaim.serializedInput,
+      startedRequests: 1,
+      state: "retryable",
+    });
+    expect(
+      await claimGitHubWorkUnitSummary({
+        now: new Date("2026-08-30T12:27:59.999Z"),
+      })
+    ).toBeNull();
+    const secondClaim = await claimGitHubWorkUnitSummary({
+      now: new Date("2026-08-30T12:28:00.000Z"),
+    });
+    expect(secondClaim).toMatchObject({
+      revision: firstClaim.revision,
+      startedRequests: 2,
+      workUnitId: firstClaim.workUnitId,
+    });
+    await terminalGitHubWorkUnitSummary(
+      secondClaim,
+      new Date("2026-08-30T12:28:01.000Z")
+    );
+
+    await database
+      .update(schema.githubRepositories)
+      .set({ description: null })
+      .where(eq(schema.githubRepositories.id, repositoryId));
+    await refreshGitHubWorkUnitProjection(new Date("2026-08-30T13:02:00.000Z"));
   });
 
   test("withholds only a same-repository merged-PR landing until the association clears", async () => {
@@ -551,14 +881,82 @@ describe.skipIf(!dockerAvailable)("GitHub work-unit projection store", () => {
       )
     ).toEqual(["src/owned-only.ts"]);
 
+    const replacementSha = "7".repeat(40);
+    await database.insert(schema.githubCommits).values({
+      additions: 1,
+      author: "f0rr0",
+      authorUserId: "8574219",
+      committedAt: new Date(activityAt.getTime() + 30_000),
+      committerAt: new Date(activityAt.getTime() + 30_000),
+      deletions: 1,
+      enrichmentState: "complete",
+      fileFacts: [fileFact("src/owned-only.ts")],
+      fileFactsComplete: true,
+      firstObservedAt: new Date(activityAt.getTime() + 30_000),
+      message: "equivalent replacement",
+      parentShas: [baseSha],
+      pullRequestDiscoveryState: "complete",
+      repositoryId: collaborativeRepositoryId,
+      sha: replacementSha,
+    });
+    await database
+      .delete(schema.githubPullRequestMemberships)
+      .where(
+        and(
+          eq(schema.githubPullRequestMemberships.versionId, versionId),
+          eq(schema.githubPullRequestMemberships.commitSha, ownedSha)
+        )
+      );
+    await database.insert(schema.githubPullRequestMemberships).values({
+      commitRepositoryId: collaborativeRepositoryId,
+      commitSha: replacementSha,
+      position: 0,
+      versionId,
+    });
+
+    const rewritten = await refreshGitHubWorkUnitProjection(
+      new Date(activityAt.getTime() + 30_000)
+    );
+    const [rewrittenUnit] = await database
+      .select()
+      .from(schema.githubWorkUnits)
+      .where(eq(schema.githubWorkUnits.id, unit.id));
+    const [rewrittenAttempt] = await database
+      .select()
+      .from(schema.githubWorkUnitSummaryAttempts)
+      .where(eq(schema.githubWorkUnitSummaryAttempts.workUnitId, unit.id));
+    expect(rewritten).toMatchObject({
+      summaryAttemptsQueued: 0,
+      summaryEvaluationsSettled: 1,
+      summaryInputsSet: 0,
+      updatedUnits: 1,
+    });
+    expect(rewrittenUnit.revision).toBeGreaterThan(unit.revision);
+    expect(rewrittenUnit.summaryInputDigest).toBe(unit.summaryInputDigest);
+    expect(rewrittenAttempt).toMatchObject({
+      revision: attempt.revision,
+      state: "pending",
+      summaryInputDigest: attempt.summaryInputDigest,
+    });
+    const claim = await claimGitHubWorkUnitSummary({
+      now: new Date(activityAt.getTime() + 6 * 60_000),
+    });
+    expect(claim).toMatchObject({
+      revision: attempt.revision,
+      workUnitId: unit.id,
+    });
+    if (claim === null) {
+      throw new Error("The outcome-identical rewrite was not claimable.");
+    }
+    await terminalGitHubWorkUnitSummary(
+      claim,
+      new Date(activityAt.getTime() + 6 * 60_000 + 1)
+    );
+
     const attemptsBeforeUnrelatedChange = await database
       .select()
       .from(schema.githubWorkUnitSummaryAttempts)
       .where(eq(schema.githubWorkUnitSummaryAttempts.workUnitId, unit.id));
-    await database
-      .update(schema.githubRepositories)
-      .set({ fullName: "" })
-      .where(eq(schema.githubRepositories.id, collaborativeRepositoryId));
     await database
       .update(schema.githubRepositories)
       .set({ visibility: "public" })
@@ -578,11 +976,6 @@ describe.skipIf(!dockerAvailable)("GitHub work-unit projection store", () => {
       updatedUnits: 0,
     });
     expect(attemptsAfterUnrelatedChange).toEqual(attemptsBeforeUnrelatedChange);
-
-    await database
-      .update(schema.githubRepositories)
-      .set({ fullName: "f0rr0/collaborative-pr-test" })
-      .where(eq(schema.githubRepositories.id, collaborativeRepositoryId));
   });
 
   test("bumps the durable feed head once for newly visible issue intake", async () => {
@@ -811,5 +1204,232 @@ describe.skipIf(!dockerAvailable)("GitHub work-unit projection store", () => {
       feedRevisionChanged: true,
       updatedUnits: 1,
     });
+  });
+
+  test("settles facts-only summary evidence once instead of retrying it forever", async () => {
+    const factsOnlyRepositoryId = "7091";
+    const factsOnlySha = "8".repeat(40);
+    const factsOnlyLineageId = "70910000-0000-4000-8000-000000000001";
+    const factsOnlyAt = new Date("2026-09-20T10:00:00.000Z");
+    await database.insert(schema.githubRepositories).values({
+      defaultBranch: "main",
+      factsVerifiedAt: factsOnlyAt,
+      firstObservedAt: factsOnlyAt,
+      fullName: "f0rr0/facts-only-projection-test",
+      headsLastReconciledAt: factsOnlyAt,
+      id: factsOnlyRepositoryId,
+      lastObservedAt: factsOnlyAt,
+      visibility: "public",
+    });
+    await database.insert(schema.githubRepositoryRefs).values({
+      active: true,
+      branchLineageId: factsOnlyLineageId,
+      firstObservedAt: factsOnlyAt,
+      headSha: factsOnlySha,
+      kind: "head",
+      lastObservedAt: factsOnlyAt,
+      projectionRelevant: true,
+      refName: "refs/heads/main",
+      repositoryId: factsOnlyRepositoryId,
+    });
+    await database.insert(schema.githubCommits).values({
+      additions: 1,
+      author: "f0rr0",
+      authorUserId: "8574219",
+      committedAt: factsOnlyAt,
+      committerAt: factsOnlyAt,
+      deletions: 1,
+      enrichmentState: "complete",
+      fileFacts: [
+        {
+          ...fileFact("src/unavailable.ts"),
+          patch: null,
+          patchComplete: false,
+        },
+      ],
+      fileFactsComplete: true,
+      firstObservedAt: factsOnlyAt,
+      message: "facts without a usable patch",
+      parentShas: [],
+      pullRequestDiscoveryState: "complete",
+      repositoryId: factsOnlyRepositoryId,
+      sha: factsOnlySha,
+    });
+    await database.insert(schema.githubRefGenerations).values({
+      branchLineageId: factsOnlyLineageId,
+      completedAt: factsOnlyAt,
+      coverageSinceAt: new Date("2026-09-01T00:00:00.000Z"),
+      generation: 1,
+      headSha: factsOnlySha,
+      refName: "refs/heads/main",
+      repositoryId: factsOnlyRepositoryId,
+    });
+    await database.insert(schema.githubRefMemberships).values({
+      commitRepositoryId: factsOnlyRepositoryId,
+      commitSha: factsOnlySha,
+      generation: 1,
+      position: 0,
+      refName: "refs/heads/main",
+      repositoryId: factsOnlyRepositoryId,
+    });
+
+    const first = await refreshGitHubWorkUnitProjection(factsOnlyAt);
+    const [unit] = await database
+      .select()
+      .from(schema.githubWorkUnits)
+      .where(
+        eq(
+          schema.githubWorkUnits.identityKey,
+          `canonical:${factsOnlyRepositoryId}:2026-09-20`
+        )
+      );
+    expect(first).toMatchObject({
+      summaryEvaluationsSettled: 1,
+      summaryInputsFailed: 1,
+    });
+    expect(unit).toMatchObject({
+      outcomeDigest: null,
+      summaryInputDigest: null,
+    });
+    expect(unit.summaryEvaluatedDigest).toMatch(/^[a-f0-9]{64}$/u);
+
+    const second = await refreshGitHubWorkUnitProjection(
+      new Date("2026-09-20T10:01:00.000Z")
+    );
+    const [unchanged] = await database
+      .select()
+      .from(schema.githubWorkUnits)
+      .where(eq(schema.githubWorkUnits.id, unit.id));
+    expect(second).toMatchObject({
+      summaryEvaluationsSettled: 0,
+      summaryInputsFailed: 0,
+    });
+    expect(unchanged.summaryEvaluatedDigest).toBe(unit.summaryEvaluatedDigest);
+  });
+
+  test("an idle worker drains summary evaluation recent-first without clearing a partial request", async () => {
+    const batchRepositoryId = "7092";
+    const batchLineageId = "70920000-0000-4000-8000-000000000001";
+    const completedAt = new Date("2026-09-10T12:00:00.000Z");
+    const commits = Array.from({ length: 9 }, (_, index) => {
+      const day = index + 1;
+      return {
+        day: `2026-09-${String(day).padStart(2, "0")}`,
+        sha: (index + 1).toString(16).repeat(40).slice(0, 40),
+      };
+    });
+    await database.insert(schema.githubRepositories).values({
+      defaultBranch: "main",
+      factsVerifiedAt: completedAt,
+      firstObservedAt: completedAt,
+      fullName: "f0rr0/summary-batch-projection-test",
+      headsLastReconciledAt: completedAt,
+      id: batchRepositoryId,
+      lastObservedAt: completedAt,
+      visibility: "public",
+    });
+    await database.insert(schema.githubRepositoryRefs).values({
+      active: true,
+      branchLineageId: batchLineageId,
+      firstObservedAt: completedAt,
+      headSha: commits.at(-1).sha,
+      kind: "head",
+      lastObservedAt: completedAt,
+      projectionRelevant: true,
+      refName: "refs/heads/main",
+      repositoryId: batchRepositoryId,
+    });
+    await database.insert(schema.githubCommits).values(
+      commits.map((commit, index) => ({
+        additions: 1,
+        author: "f0rr0",
+        authorUserId: "8574219",
+        committedAt: new Date(`${commit.day}T12:00:00.000Z`),
+        committerAt: new Date(`${commit.day}T12:00:00.000Z`),
+        deletions: 1,
+        enrichmentState: "complete",
+        fileFacts: [fileFact(`src/day-${String(index + 1)}.ts`)],
+        fileFactsComplete: true,
+        firstObservedAt: completedAt,
+        message: `day ${String(index + 1)}`,
+        parentShas: index === 0 ? [] : [commits[index - 1].sha],
+        pullRequestDiscoveryState: "complete",
+        repositoryId: batchRepositoryId,
+        sha: commit.sha,
+      }))
+    );
+    await database.insert(schema.githubRefGenerations).values({
+      branchLineageId: batchLineageId,
+      completedAt,
+      coverageSinceAt: new Date("2026-09-01T00:00:00.000Z"),
+      generation: 1,
+      headSha: commits.at(-1).sha,
+      refName: "refs/heads/main",
+      repositoryId: batchRepositoryId,
+    });
+    await database.insert(schema.githubRefMemberships).values(
+      commits.map((commit, position) => ({
+        commitRepositoryId: batchRepositoryId,
+        commitSha: commit.sha,
+        generation: 1,
+        position,
+        refName: "refs/heads/main",
+        repositoryId: batchRepositoryId,
+      }))
+    );
+    const token = await requestGitHubWorkUnitProjection(database);
+    const workerOptions = {
+      accounts: ["f0rr0"],
+      includeRefs: false,
+      maximumDurationMs: 3000,
+      scope: {
+        repositoryId: batchRepositoryId,
+        sinceAt: new Date("2026-09-01T00:00:00.000Z"),
+        untilAt: new Date("2026-09-11T00:00:00.000Z"),
+      },
+    };
+
+    const first = await runGitHubActivityWorker(workerOptions);
+    expect(first).toMatchObject({
+      commits: { claimed: 0 },
+      observations: { claimed: 0 },
+      projection: {
+        summaryAttemptsQueued: 8,
+        summaryEvaluationsPending: 1,
+        summaryEvaluationsSettled: 8,
+      },
+      pullRequestDiscovery: { claimed: 0 },
+      pullRequestSignals: { claimed: 0 },
+      pullRequests: { claimed: 0 },
+    });
+    expect(await ensureGitHubWorkUnitProjectionRequest()).toBe(token);
+    const afterFirst = await database
+      .select({
+        activityDay: schema.githubWorkUnits.activityDay,
+        summaryEvaluatedDigest: schema.githubWorkUnits.summaryEvaluatedDigest,
+      })
+      .from(schema.githubWorkUnits)
+      .where(eq(schema.githubWorkUnits.repositoryId, batchRepositoryId))
+      .orderBy(schema.githubWorkUnits.activityDay);
+    expect(
+      afterFirst
+        .filter(({ summaryEvaluatedDigest }) => summaryEvaluatedDigest === null)
+        .map(({ activityDay }) => activityDay)
+    ).toEqual(["2026-09-01"]);
+
+    const second = await runGitHubActivityWorker(workerOptions);
+    expect(second).toMatchObject({
+      commits: { claimed: 0 },
+      observations: { claimed: 0 },
+      projection: {
+        summaryAttemptsQueued: 1,
+        summaryEvaluationsPending: 0,
+        summaryEvaluationsSettled: 1,
+      },
+      pullRequestDiscovery: { claimed: 0 },
+      pullRequestSignals: { claimed: 0 },
+      pullRequests: { claimed: 0 },
+    });
+    expect(await ensureGitHubWorkUnitProjectionRequest()).toBeNull();
   });
 });

--- a/tests/github-work-unit-summary-provider.test.mjs
+++ b/tests/github-work-unit-summary-provider.test.mjs
@@ -4,10 +4,9 @@ import { NoObjectGeneratedError, NoOutputGeneratedError } from "ai";
 
 import {
   generateGitHubWorkUnitSummary,
-  GITHUB_WORK_UNIT_SUMMARY_MAX_OUTPUT_TOKENS,
-  GITHUB_WORK_UNIT_SUMMARY_MODEL,
   GitHubWorkUnitSummaryInvalidInputError,
 } from "../src/lib/github-work-unit-summary-provider.ts";
+import { GITHUB_WORK_UNIT_SUMMARY_PROVIDER_POLICY } from "../src/lib/github-work-unit-summary.ts";
 
 const summaryInput = (overrides = {}) => ({
   attributionMode: "tracked_authored_pr",
@@ -79,9 +78,11 @@ describe("GitHub work-unit summary provider", () => {
     });
 
     expect(call).toBeDefined();
-    expect(call.model.modelId).toBe(GITHUB_WORK_UNIT_SUMMARY_MODEL);
+    expect(call.model.modelId).toBe(
+      GITHUB_WORK_UNIT_SUMMARY_PROVIDER_POLICY.model
+    );
     expect(call.maxOutputTokens).toBe(
-      GITHUB_WORK_UNIT_SUMMARY_MAX_OUTPUT_TOKENS
+      GITHUB_WORK_UNIT_SUMMARY_PROVIDER_POLICY.maxOutputTokens
     );
     expect(call.maxRetries).toBe(0);
     expect(call.providerOptions).toEqual({
@@ -106,7 +107,7 @@ describe("GitHub work-unit summary provider", () => {
     });
     expect(result).toMatchObject({
       inputTokens: 12,
-      model: GITHUB_WORK_UNIT_SUMMARY_MODEL,
+      model: GITHUB_WORK_UNIT_SUMMARY_PROVIDER_POLICY.model,
       outcome: "Added resilient session recovery.",
       outputTokens: 6,
     });
@@ -163,7 +164,7 @@ describe("GitHub work-unit summary provider", () => {
           finishReason: "stop",
           response: {
             id: "response-id",
-            modelId: GITHUB_WORK_UNIT_SUMMARY_MODEL,
+            modelId: GITHUB_WORK_UNIT_SUMMARY_PROVIDER_POLICY.model,
             timestamp: new Date(0),
           },
           text: JSON.stringify({ outcome: "Safe.", extra: true }),

--- a/tests/github-work-unit-summary-store.test.mjs
+++ b/tests/github-work-unit-summary-store.test.mjs
@@ -55,6 +55,7 @@ describe.skipIf(!dockerAvailable)("GitHub work-unit summary store", () => {
   let containerId;
   let deferGitHubWorkUnitSummary;
   let originalDatabaseUrl;
+  let originalOpenAiApiKey;
   let reconcileGitHubWorkUnitSummaryStatus;
   let sequence = 0;
   let terminalGitHubWorkUnitSummary;
@@ -71,8 +72,10 @@ describe.skipIf(!dockerAvailable)("GitHub work-unit summary store", () => {
     requestPayload,
     startedRequests = 0,
     state = "pending",
+    summaryEvaluationDigest = digest("e"),
+    summaryEvaluatedDigest = summaryEvaluationDigest,
     summaryInputDigest = digest("b"),
-    unitRevision = 1,
+    workUnitRevision = 1,
   }) => {
     sequence += 1;
     const suffix = String(sequence).padStart(12, "0");
@@ -96,14 +99,16 @@ describe.skipIf(!dockerAvailable)("GitHub work-unit summary store", () => {
         facts_digest, file_count, first_activity_at, id, identity_key, kind,
         last_activity_at, member_count, membership_digest,
         newest_commit_repository_id, newest_commit_sha, outcome_digest,
-        repository_id, revision, summary_input_digest, visibility
+        repository_id, revision, summary_evaluated_digest,
+        summary_evaluation_digest, summary_input_digest, visibility
       ) values (
         ${instant(activityAt)}, ${instant(activityAt)}, ${activityDay}, 3,
         'branch_owned_composite', ${branchLineageId}, ${instant(contentObservedAt)}, 1,
         ${digest("c")}, 1, ${instant(activityAt)}, ${workUnitId},
         ${`branch:${branchLineageId}`}, 'branch', ${instant(activityAt)}, 1,
         ${digest("d")}, ${repositoryId}, ${sha}, ${outcomeDigest},
-        ${repositoryId}, ${unitRevision}, ${summaryInputDigest}, 'public'
+        ${repositoryId}, ${workUnitRevision}, ${summaryEvaluatedDigest},
+        ${summaryEvaluationDigest}, ${summaryInputDigest}, 'public'
       )
     `;
     await admin`
@@ -111,22 +116,19 @@ describe.skipIf(!dockerAvailable)("GitHub work-unit summary store", () => {
         attribution_mode, created_at, debounce_until, input_tokens,
         last_started_at, lease_token, lease_until, outcome_digest, recipe,
         request_payload, revision, started_requests, state,
-        summary_input_digest, unit_revision, work_unit_id
+        summary_input_digest, work_unit_id
       ) values (
         'branch_owned_composite', ${instant(contentObservedAt)},
         ${instant(debounceUntil)}, 37, ${instant(lastStartedAt)}, ${leaseToken},
         ${instant(leaseUntil)}, ${outcomeDigest},
         ${recipe}, ${payload}, ${attemptRevision}, ${startedRequests}, ${state},
-        ${summaryInputDigest}, ${unitRevision}, ${workUnitId}
+        ${summaryInputDigest}, ${workUnitId}
       )
     `;
     return {
-      activityDay,
       outcomeDigest,
       payload,
       revision: attemptRevision,
-      summaryInputDigest,
-      unitRevision,
       workUnitId,
     };
   };
@@ -164,6 +166,8 @@ describe.skipIf(!dockerAvailable)("GitHub work-unit summary store", () => {
 
   beforeAll(async () => {
     originalDatabaseUrl = env.DATABASE_URL;
+    originalOpenAiApiKey = env.OPENAI_API_KEY;
+    env.OPENAI_API_KEY = "summary-status-test-key";
     const started = Bun.spawnSync([
       "docker",
       "run",
@@ -257,6 +261,11 @@ describe.skipIf(!dockerAvailable)("GitHub work-unit summary store", () => {
     } else {
       env.DATABASE_URL = originalDatabaseUrl;
     }
+    if (originalOpenAiApiKey === undefined) {
+      delete env.OPENAI_API_KEY;
+    } else {
+      env.OPENAI_API_KEY = originalOpenAiApiKey;
+    }
     if (containerId !== undefined) {
       Bun.spawnSync(["docker", "stop", "--time", "1", containerId], {
         stderr: "ignore",
@@ -308,10 +317,7 @@ describe.skipIf(!dockerAvailable)("GitHub work-unit summary store", () => {
       serializedInput: older.payload,
       workUnitId: older.workUnitId,
     });
-    expect(await readAttempt(stale)).toMatchObject({
-      started_requests: 0,
-      state: "pending",
-    });
+    expect(await readAttempt(stale)).toBeUndefined();
   });
 
   test("does not claim a stale public payload after its repository becomes private", async () => {
@@ -326,10 +332,84 @@ describe.skipIf(!dockerAvailable)("GitHub work-unit summary store", () => {
     `;
 
     expect(await claimGitHubWorkUnitSummary({ now })).toBeNull();
+    expect(await readAttempt(unit)).toBeUndefined();
+  });
+
+  test("discards completed output after repository access is revoked", async () => {
+    const now = new Date("2026-09-01T12:00:00.000Z");
+    const unit = await seedUnit({
+      activityAt: new Date("2026-09-01T11:30:00.000Z"),
+      debounceUntil: new Date("2026-09-01T11:00:00.000Z"),
+    });
+    const claim = await claimGitHubWorkUnitSummary({ now });
+    await admin`
+      update github_repositories set visibility = 'private'
+      where id = ${repositoryId}
+    `;
+
+    expect(
+      await completeGitHubWorkUnitSummary(
+        claim,
+        providerResult("This private result must be discarded."),
+        now
+      )
+    ).toEqual({ accepted: false });
     expect(await readAttempt(unit)).toMatchObject({
-      request_payload: unit.payload,
-      started_requests: 0,
-      state: "pending",
+      outcome: null,
+      request_payload: null,
+      state: "terminal",
+    });
+  });
+
+  test("discards retry payloads after repository access is revoked", async () => {
+    const now = new Date("2026-09-01T12:00:00.000Z");
+    const unit = await seedUnit({
+      activityAt: new Date("2026-09-01T11:30:00.000Z"),
+      debounceUntil: new Date("2026-09-01T11:00:00.000Z"),
+    });
+    const claim = await claimGitHubWorkUnitSummary({ now });
+    await admin`
+      update github_repositories set visibility = 'private'
+      where id = ${repositoryId}
+    `;
+
+    expect(
+      await deferGitHubWorkUnitSummary(
+        claim,
+        new Date("2026-09-01T13:00:00.000Z"),
+        now
+      )
+    ).toBe("terminal");
+    expect(await readAttempt(unit)).toMatchObject({
+      request_payload: null,
+      state: "terminal",
+    });
+  });
+
+  test("compacts a superseded input without resetting its retry budget", async () => {
+    const now = new Date("2026-09-01T12:00:00.000Z");
+    const unit = await seedUnit({
+      activityAt: new Date("2026-09-01T11:30:00.000Z"),
+      debounceUntil: new Date("2026-09-01T11:00:00.000Z"),
+    });
+    const claim = await claimGitHubWorkUnitSummary({ now });
+    await admin`
+      update github_work_units
+      set summary_evaluation_digest = ${digest("f")}
+      where id = ${unit.workUnitId}
+    `;
+
+    expect(
+      await deferGitHubWorkUnitSummary(
+        claim,
+        new Date("2026-09-01T13:00:00.000Z"),
+        now
+      )
+    ).toBe("stale");
+    expect(await readAttempt(unit)).toMatchObject({
+      request_payload: null,
+      started_requests: 1,
+      state: "retryable",
     });
   });
 
@@ -539,12 +619,8 @@ describe.skipIf(!dockerAvailable)("GitHub work-unit summary store", () => {
     });
   });
 
-  test("does not present pending, debounced, or historical work as active", async () => {
+  test("presents recent queued work but not historical work as active", async () => {
     const now = new Date("2026-09-06T12:00:00.000Z");
-    await seedUnit({
-      activityAt: new Date("2026-09-06T10:00:00.000Z"),
-      debounceUntil: new Date("2026-09-06T13:00:00.000Z"),
-    });
     await seedUnit({
       activityAt: new Date("2026-07-01T10:00:00.000Z"),
       debounceUntil: new Date("2026-09-06T10:00:00.000Z"),
@@ -560,6 +636,81 @@ describe.skipIf(!dockerAvailable)("GitHub work-unit summary store", () => {
       head_content_revision: "0",
       summarizing: false,
     });
+
+    await seedUnit({
+      activityAt: new Date("2026-09-06T10:00:00.000Z"),
+      debounceUntil: new Date("2026-09-06T13:00:00.000Z"),
+    });
+    expect(await reconcileGitHubWorkUnitSummaryStatus(now)).toBe(true);
+    expect(await readHead()).toMatchObject({
+      head_content_revision: "1",
+      summarizing: true,
+    });
+
+    delete env.OPENAI_API_KEY;
+    try {
+      expect(await reconcileGitHubWorkUnitSummaryStatus(now)).toBe(false);
+    } finally {
+      env.OPENAI_API_KEY = "summary-status-test-key";
+    }
+  });
+
+  test("presents a recent initial-page reevaluation before its input is built", async () => {
+    const now = new Date("2026-09-06T12:00:00.000Z");
+    const unit = await seedUnit({
+      activityAt: new Date("2026-09-06T10:00:00.000Z"),
+      debounceUntil: new Date("2026-09-06T13:00:00.000Z"),
+      summaryEvaluatedDigest: digest("f"),
+    });
+    await admin`
+      delete from github_work_unit_summary_attempts
+      where work_unit_id = ${unit.workUnitId}
+    `;
+
+    expect(await reconcileGitHubWorkUnitSummaryStatus(now)).toBe(true);
+    expect(await readHead()).toMatchObject({
+      head_content_revision: "1",
+      summarizing: true,
+    });
+  });
+
+  test("ignores revoked private issue days when tracking initial-page work", async () => {
+    const now = new Date("2026-09-06T12:00:00.000Z");
+    const revokedRepositoryId = "999001";
+    await admin`
+      insert into github_repositories (
+        facts_verified_at, full_name, id, visibility
+      ) values (
+        '2026-09-01T00:00:00Z', 'private/revoked-summary-test',
+        ${revokedRepositoryId}, 'private'
+      ) on conflict (id) do update set visibility = 'private'
+    `;
+    for (const day of [1, 2, 3, 4, 5]) {
+      await admin`
+        insert into github_issues (
+          account, author_user_id, created_at, node_id, number,
+          repository_id, title_snapshot, url_snapshot
+        ) values (
+          'f0rr0', '8574219',
+          ${`2026-09-0${String(day)}T12:00:00.000Z`},
+          ${`ISSUE_revoked_summary_${String(day)}`}, ${day},
+          ${revokedRepositoryId}, 'Revoked private issue',
+          ${`https://github.com/private/revoked-summary-test/issues/${String(day)}`}
+        )
+      `;
+    }
+    await seedUnit({
+      activityAt: new Date("2026-08-31T12:00:00.000Z"),
+      debounceUntil: new Date("2026-08-31T12:00:00.000Z"),
+      lastStartedAt: new Date("2026-09-06T11:00:00.000Z"),
+      leaseToken: "20000000-0000-4000-8000-000000000099",
+      leaseUntil: new Date("2026-09-06T13:00:00.000Z"),
+      startedRequests: 1,
+      state: "processing",
+    });
+
+    expect(await reconcileGitHubWorkUnitSummaryStatus(now)).toBe(true);
+    expect(await readHead()).toMatchObject({ summarizing: true });
   });
 
   test("keeps one active transition while another current summary settles", async () => {
@@ -604,8 +755,8 @@ describe.skipIf(!dockerAvailable)("GitHub work-unit summary store", () => {
     ).toBe("deferred");
     expect(await readHead()).toMatchObject({
       feed_revision: "1",
-      head_content_revision: "3",
-      summarizing: false,
+      head_content_revision: "2",
+      summarizing: true,
     });
   });
 
@@ -637,8 +788,8 @@ describe.skipIf(!dockerAvailable)("GitHub work-unit summary store", () => {
     });
 
     const afterExpiry = new Date("2026-09-01T13:00:00.000Z");
-    expect(await reconcileGitHubWorkUnitSummaryStatus(afterExpiry)).toBe(false);
-    expect(await reconcileGitHubWorkUnitSummaryStatus(afterExpiry)).toBe(false);
+    expect(await reconcileGitHubWorkUnitSummaryStatus(afterExpiry)).toBe(true);
+    expect(await reconcileGitHubWorkUnitSummaryStatus(afterExpiry)).toBe(true);
     expect(await readAttempt(retryable)).toMatchObject({
       request_payload: retryable.payload,
       state: "retryable",
@@ -648,8 +799,8 @@ describe.skipIf(!dockerAvailable)("GitHub work-unit summary store", () => {
       state: "terminal",
     });
     expect(await readHead()).toMatchObject({
-      head_content_revision: "2",
-      summarizing: false,
+      head_content_revision: "1",
+      summarizing: true,
     });
   });
 
@@ -667,12 +818,18 @@ describe.skipIf(!dockerAvailable)("GitHub work-unit summary store", () => {
     expect(await reconcileGitHubWorkUnitSummaryStatus(now)).toBe(true);
 
     for (const day of [1, 2, 3, 4, 5]) {
-      await seedUnit({
-        activityAt: new Date(
-          `2026-09-${String(day).padStart(2, "0")}T12:00:00.000Z`
-        ),
-        debounceUntil: new Date("2026-09-07T00:00:00.000Z"),
-      });
+      await admin`
+        insert into github_issues (
+          account, author_user_id, created_at, node_id, number,
+          repository_id, title_snapshot, url_snapshot
+        ) values (
+          'f0rr0', '8574219',
+          ${`2026-09-0${String(day)}T12:00:00.000Z`},
+          ${`ISSUE_initial_page_${String(day)}`}, ${day},
+          ${repositoryId}, 'Initial-page issue',
+          ${`https://github.com/f0rr0/summary-store-test/issues/${String(day)}`}
+        )
+      `;
     }
     expect(await reconcileGitHubWorkUnitSummaryStatus(now)).toBe(false);
     expect(await readAttempt(active)).toMatchObject({ state: "processing" });
@@ -721,7 +878,7 @@ describe.skipIf(!dockerAvailable)("GitHub work-unit summary store", () => {
     expect(head).toMatchObject({
       feed_revision: "1",
       head_content_revision: "2",
-      summarizing: false,
+      summarizing: true,
     });
     expect(new Date(head.last_published_at).getTime()).toBe(now.getTime());
 
@@ -742,12 +899,12 @@ describe.skipIf(!dockerAvailable)("GitHub work-unit summary store", () => {
     head = await readHead();
     expect(head).toMatchObject({
       feed_revision: "1",
-      head_content_revision: "10",
+      head_content_revision: "3",
       summarizing: false,
     });
   });
 
-  test("recipe rewrites avoid a live revision and stale or invalid output stays facts-only", async () => {
+  test("publishes exact rewrites, caches stale output, and rejects invalid output", async () => {
     const now = new Date("2026-09-01T12:00:00.000Z");
     const rewrite = await seedUnit({
       activityAt: new Date("2026-08-31T12:00:00.000Z"),
@@ -759,14 +916,14 @@ describe.skipIf(!dockerAvailable)("GitHub work-unit summary store", () => {
         accepted_at, attribution_mode, completed_at, debounce_until,
         input_tokens, last_started_at, latency_ms, model, outcome,
         outcome_digest, output_tokens, recipe, revision, started_requests,
-        state, summary_input_digest, unit_revision, work_unit_id
+        state, summary_input_digest, work_unit_id
       ) values (
         '2026-08-31T13:00:00Z', 'branch_owned_composite',
         '2026-08-31T13:00:00Z', '2026-08-31T12:00:00Z', 40,
         '2026-08-31T13:00:00Z', 10, 'previous-model',
         'Prior prose for the same outcome.', ${rewrite.outcomeDigest}, 10,
         'github-work-unit-outcome-v0', 1, 1, 'accepted', ${digest("e")},
-        ${rewrite.unitRevision}, ${rewrite.workUnitId}
+        ${rewrite.workUnitId}
       )
     `;
     const rewriteClaim = await claimGitHubWorkUnitSummary({ now });
@@ -779,9 +936,8 @@ describe.skipIf(!dockerAvailable)("GitHub work-unit summary store", () => {
     ).toEqual({ accepted: true });
     let head = await readHead();
     expect(head).toMatchObject({
-      feed_revision: "0",
+      feed_revision: "1",
       head_content_revision: "2",
-      last_published_at: null,
       summarizing: false,
     });
 
@@ -798,14 +954,14 @@ describe.skipIf(!dockerAvailable)("GitHub work-unit summary store", () => {
     expect(
       await completeGitHubWorkUnitSummary(
         staleClaim,
-        providerResult("Must not be accepted."),
+        providerResult("Reusable output for the prior evidence."),
         now
       )
-    ).toEqual({ accepted: false });
+    ).toEqual({ accepted: true });
     expect(await readAttempt(stale)).toMatchObject({
-      outcome: null,
+      outcome: "Reusable output for the prior evidence.",
       request_payload: null,
-      state: "terminal",
+      state: "accepted",
     });
 
     const invalid = await seedUnit({
@@ -825,7 +981,7 @@ describe.skipIf(!dockerAvailable)("GitHub work-unit summary store", () => {
     expect(new Date(invalidAttempt.completed_at).getTime()).toBe(now.getTime());
     head = await readHead();
     expect(head).toMatchObject({
-      feed_revision: "0",
+      feed_revision: "1",
       head_content_revision: "6",
       summarizing: false,
     });

--- a/tests/github-work-unit-summary.test.mjs
+++ b/tests/github-work-unit-summary.test.mjs
@@ -4,6 +4,7 @@ import {
   buildGitHubWorkUnitSummaryInput,
   digestGitHubWorkUnitMembership,
   digestGitHubWorkUnitOutcome,
+  digestGitHubWorkUnitSummaryEvaluation,
   GITHUB_WORK_UNIT_SUMMARY_MAX_INPUT_TOKENS,
   GITHUB_WORK_UNIT_SUMMARY_MAX_PAYLOAD_BYTES,
   githubWorkUnitSummaryInputSchema,
@@ -66,6 +67,59 @@ const objectKeys = (value) => {
 };
 
 describe("GitHub work-unit summary evidence", () => {
+  test("fingerprints representative semantic evaluation changes", () => {
+    const membershipDigest = "a".repeat(64);
+    const fileFactsDigest = "b".repeat(64);
+    const evaluation = {
+      attributionMode: "tracked_authored_pr",
+      evidence: {
+        fileFactsComplete: true,
+        fileFactsDigest,
+        mode: "net",
+      },
+      kind: "pull_request",
+      membershipDigest,
+      repository: candidate().repository,
+    };
+    const original = digestGitHubWorkUnitSummaryEvaluation(evaluation);
+    const normalizedEquivalent = digestGitHubWorkUnitSummaryEvaluation({
+      ...evaluation,
+      repository: {
+        ...evaluation.repository,
+        description: ` ${evaluation.repository.description} `,
+        fullName: ` ${evaluation.repository.fullName} `,
+        topics: ["sessions", "web", "sessions"],
+      },
+    });
+
+    expect(original).toMatch(/^[a-f0-9]{64}$/u);
+    expect(normalizedEquivalent).toBe(original);
+    expect(
+      digestGitHubWorkUnitSummaryEvaluation({
+        ...evaluation,
+        evidence: {
+          ...evaluation.evidence,
+          fileFactsDigest: "c".repeat(64),
+        },
+      })
+    ).not.toBe(original);
+    expect(
+      digestGitHubWorkUnitSummaryEvaluation({
+        ...evaluation,
+        membershipDigest: "d".repeat(64),
+      })
+    ).not.toBe(original);
+    expect(
+      digestGitHubWorkUnitSummaryEvaluation({
+        ...evaluation,
+        repository: {
+          ...evaluation.repository,
+          description: "A materially different repository.",
+        },
+      })
+    ).not.toBe(original);
+  });
+
   test("serializes an immutable, public-safe net-outcome request", async () => {
     const result = await buildGitHubWorkUnitSummaryInput(candidate());
 


### PR DESCRIPTION
## Summary

- make projection requests durable and drain bounded summary evaluation across idle worker runs
- keep commit/PR/ref ownership deterministic across rewrites, A→B→A ref movement, same-time PR races, privacy revocation, and current repository access
- load compact file evidence for the corpus and raw patches only for the recent-first summary batch
- preserve exact summary reuse and paid request accounting with payload-free stale tombstones, realistic provider deadlines, and minimal recent-work status
- make the real-data crosswalk fail on commit-enrichment backlog and keep the historical backfill bounded, resumable, and visibly incomplete
- remove dead fields/options/helpers and document the remaining webhook-ordering coverage boundary

## Verification

- 271 tests passing
- typecheck and lint passing
- production Next.js build passing
- Drizzle schema generation/check reports no drift
- PostgreSQL behavior tests cover idle 8+1 drain, exact reuse, ref A→B→A, same-time terminal PR promotion, privacy revocation, and one repository header per day

## Operations after merge

- production applies migration 0016
- run the bounded August backfill until factual backlog reaches zero
- verify August, a recent week, and random slices with the v3 crosswalk before judging the live timeline
