### PR TITLE
fix(github): converge timeline ownership and summaries

### DIFF
--- a/docs/github-activity-work-units.md
+++ b/docs/github-activity-work-units.md
@@ -63,24 +63,24 @@ tracked-authored commit. This is why work-unit counts can differ from GitHub's
 authored-PR count.
 
 There is no patch-equality aliasing or inferred squash, rebase, or cherry-pick
-lineage. A logical change is the exact repository ID plus commit SHA. One
-narrow landing rule prevents duplication: when GitHub associates a commit with
-a merged PR whose base repository is that commit's repository, but the commit
-is absent from every effective PR membership, canonical-day ownership is
-suppressed as a `merged_pr_landing` policy exclusion. A complete active side
-head may still own it. Open, closed-unmerged, and foreign-base PR associations
-do not suppress ref ownership.
+lineage. A logical change is the exact repository ID plus commit SHA. One narrow
+landing rule prevents duplication: a provider-verified merge SHA for a merged
+PR in the same repository is excluded from canonical and side-ref ownership
+when it is absent from effective PR membership. It is reported as a
+`merged_pr_landing` policy exclusion. Associations alone do not establish
+landing identity and never suppress current-ref ownership.
 
 ## Deterministic ownership
 
 The projector evaluates current complete evidence in this order:
 
-| Priority | Evidence                                  | Owner                    |
-| -------- | ----------------------------------------- | ------------------------ |
-| 1        | Member of an effective PR snapshot        | Pull-request unit        |
-| 2        | Reachable from the current canonical head | Repository + UTC day     |
-| 3        | Reachable from an active side head        | Persisted branch lineage |
-| 4        | No current complete owner                 | Not published            |
+| Priority | Evidence                                            | Owner                    |
+| -------- | --------------------------------------------------- | ------------------------ |
+| 1        | Member of an effective PR snapshot                  | Pull-request unit        |
+| 2        | Verified merge landing without effective membership | Not published            |
+| 3        | Reachable from the current canonical head           | Repository + UTC day     |
+| 4        | Reachable from an active side head                  | Persisted branch lineage |
+| 5        | No current complete owner                           | Not published            |
 
 For an open PR, the effective snapshot is its current complete version. For a
 closed or merged PR, it is its final complete version. When several effective
@@ -158,12 +158,15 @@ batch.
 - `last_published_at`; and
 - `summarizing`;
 - an internal projection-request token; and
-- the last completely evaluated semantic summary-policy digest.
+- the last applied projection-and-summary pipeline policy digest.
 
 Evidence writers replace the projection token in the same transaction as the
 evidence change. A refresh clears only the token it observed and only after its
 bounded summary-evaluation backlog is empty. A semantic policy change creates a
-token until the current corpus has been reevaluated.
+token until the affected corpus has been reevaluated. The combined policy digest
+also makes ownership changes self-activating after a rolling deployment. Each
+bounded refresh still publishes its current factual projection; historical
+summary reevaluation does not hold factual changes back.
 
 The public feed reads at most five UTC days per page in a read-only repeatable
 read transaction. Pagination cursors are HMAC-signed and bound to the ordering
@@ -207,7 +210,9 @@ Summary identity includes the semantic policy, recipe, prompt, normalized
 input, outcome digest, and attribution mode. Transport retries and storage
 configuration do not invalidate prose. A five-minute debounce absorbs active
 rewrites. Up to eight recent-first inputs are deterministically evaluated per
-projection refresh, while the provider worker still starts at most one claim.
+projection refresh. A separate bounded worker starts at most one provider claim,
+so a historical evaluation backlog cannot consume the provider request's
+runtime window.
 Valid public-input output remains cacheable if its input becomes stale while
 the request runs; it is displayed only when the current public unit's exact
 recipe, outcome, attribution, and summary-input keys match. A force push with
@@ -252,17 +257,20 @@ Three inputs converge on the same durable worker queues:
 
 Supabase Cron invokes:
 
-| Route                     | Schedule                              | Bound                                                                |
-| ------------------------- | ------------------------------------- | -------------------------------------------------------------------- |
-| `/api/cron/github-sync`   | every 5 minutes                       | 15-second request                                                    |
-| `/api/cron/github-worker` | every 5 minutes, offset by 2 minutes  | 60-second request; default eight items per factual queue and one ref |
-| `/api/cron/github-refs`   | every 15 minutes, offset by 4 minutes | 15-second request; eight ref pages/repositories per account          |
+| Route                      | Schedule                              | Bound                                                                |
+| -------------------------- | ------------------------------------- | -------------------------------------------------------------------- |
+| `/api/cron/github-sync`    | every 5 minutes                       | 15-second request                                                    |
+| `/api/cron/github-worker`  | every 5 minutes, offset by 2 minutes  | 60-second request; default eight items per factual queue and one ref |
+| `/api/cron/github-summary` | every 5 minutes, offset by 3 minutes  | 60-second request; at most one provider claim                        |
+| `/api/cron/github-refs`    | every 15 minutes, offset by 4 minutes | 15-second request; eight ref pages/repositories per account          |
 
 The worker processes factual queues and current-ref repair before recomputing
-the projection. It then reconciles the minimal summary status and may claim one
-summary. Webhooks shorten discovery, but they do not render a page directly;
-publication still waits for the bounded worker. Timeline payloads are read from
-the current projection and are never held in a shared response cache.
+the projection and reconciling the minimal summary status. The separate summary
+worker may claim one provider request, so historical input reevaluation cannot
+consume its provider budget. Webhooks shorten discovery, but they do not render
+a page directly; publication still waits for the bounded factual worker.
+Timeline payloads are read from the current projection and are never held in a
+shared response cache.
 
 ## Historical backfill
 
@@ -283,6 +291,11 @@ The backfill:
 6. drains only the scoped factual queues without projecting after every batch;
    and
 7. refreshes the projection once when the scoped factual backlog reaches zero.
+
+Routine due or leased reconciliation for an otherwise complete open PR is not
+factual backlog. Missing current membership, required PR diff facts, unresolved
+merged-PR identity, or a reconciliation error remains blocking and is reported
+explicitly.
 
 The command does not generate summaries and does not wait in process for a
 durably deferred provider claim. It exits non-zero with a structured stop
@@ -338,8 +351,9 @@ builds a deterministic, read-only crosswalk for a half-open interval. It emits
 stable IDs and counts for tracked candidates, eligible changes, integration
 merges, ineligible changes, PR/canonical/branch units, owned changes, visibility
 gaps, commit-enrichment backlog, authored PRs without a current owned member,
-and each coverage or policy-exclusion reason. Any enrichment backlog fails the
-crosswalk. `merged_pr_landing` and
+verified-landing ref-ownership violations, and each coverage or policy-exclusion
+reason. Any enrichment backlog or verified landing in a canonical/branch unit
+fails the crosswalk. `merged_pr_landing` and
 `no_current_owner` are policy exclusions; unknown canonical branch, incomplete
 head generation, incomplete PR coverage, and unknown visibility are coverage
 gaps that fail the crosswalk.
@@ -356,7 +370,7 @@ class names:
 | ----------------------------------------------------------------------- | ----------------------------------------------------- |
 | merge, empty, or foreign-authored commit                                | no work-unit membership                               |
 | effective PR also reachable from canonical/side refs                    | PR owns it once                                       |
-| same-repository merged landing absent from effective PR membership      | canonical suppressed; active side head may own it     |
+| verified same-repository landing absent from effective PR membership    | no canonical or side-ref row                          |
 | PR rewrite with unchanged net outcome                                   | stable identity, anchor, and reusable prose           |
 | changed PR/ref membership                                               | removed SHA loses its old ownership                   |
 | ref head A → B → A                                                      | final A is projected rather than suppressed           |
@@ -368,6 +382,7 @@ class names:
 | same-day repository rows                                                | one header and a count derived from final groups      |
 | summary budget/retry/expiry                                             | hard caps and facts-only terminal state               |
 | nine pending summary evaluations                                        | eight settle, then one on the next refresh            |
+| recent summary ready during historical policy reevaluation              | separate summary worker may claim it                  |
 | paid input A superseded by B then current again                         | count retained and debounce re-armed                  |
 
 Run the complete local gate with:

--- a/docs/github-commits.md
+++ b/docs/github-commits.md
@@ -35,16 +35,19 @@ The worker leases small batches and can safely resume after a deadline. It:
    evidence, and complete PR net file facts;
 4. recomputes the current work-unit projection from durable evidence and swaps
    units, memberships, and public feed revisions atomically; and
-5. evaluates summary inputs in recent-first batches of eight, then claims at
-   most one eligible public summary. Valid public-input output can be cached
-   after becoming stale; display still requires exact current recipe, outcome,
-   attribution, and input digests.
+5. evaluates summary inputs in recent-first batches of eight.
+
+A separate bounded summary worker claims at most one eligible public summary.
+Historical input reevaluation therefore cannot consume the provider request's
+runtime budget. Valid public-input output can be cached after becoming stale;
+display still requires exact current recipe, outcome, attribution, and input
+digests.
 
 Multi-parent merge commits and commits with neither file facts nor churn are not
-separate timeline work. A same-repository merged-PR association suppresses
-canonical ownership only when the commit is absent from effective PR
-membership; a complete side head can still own it. The system does not infer
-aliases from messages, timestamps, patches, or fingerprints.
+separate timeline work. A provider-verified same-repository merge SHA is
+excluded from canonical and side-ref ownership when it is absent from effective
+PR membership. Associations alone do not suppress ref ownership. The system
+does not infer aliases from messages, timestamps, patches, or fingerprints.
 
 ## Projection and publication
 
@@ -73,11 +76,13 @@ the public feed head; replayed deliveries and unknown visibility do not.
 The public reader groups a repository once per UTC day and reads complete days
 against the current ordered-set revision. `github_public_feed_head` contains
 the monotone feed/content/order revisions, last publication time, a durable
-projection-request token, the applied semantic summary-policy digest, and
+projection-request token, the applied pipeline-policy digest, and
 whether configured recent initial-page summary work is being evaluated, queued,
 retried, or processed. Evidence writers set the token transactionally;
 projection clears the observed token only after its bounded summary-evaluation
-backlog reaches zero.
+backlog reaches zero. The stored pipeline-policy digest covers both projection
+ownership and summary semantics, so a new worker requests the required refresh
+after activation even if an older worker cleared a deployment-time token.
 
 ## Runtime configuration
 
@@ -104,6 +109,7 @@ Routine entry points are:
 - `POST /api/cron/github-sync`
 - `POST /api/cron/github-refs`
 - `POST /api/cron/github-worker`
+- `POST /api/cron/github-summary`
 - `GET /api/github/activity`
 - `GET /api/github/activity/head`
 

--- a/scripts/configure-supabase-cron.ts
+++ b/scripts/configure-supabase-cron.ts
@@ -6,6 +6,7 @@ import {
   GITHUB_EVENTS_CRON_JOB,
   GITHUB_HEAD_REFS_CRON_JOB,
   GITHUB_REF_REPOSITORY_BATCH_SIZE,
+  GITHUB_SUMMARY_CRON_JOB,
   GITHUB_WORKER_HTTP_TIMEOUT_MS,
   GITHUB_WORKER_CRON_JOB,
 } from "../src/lib/github-cron-config";
@@ -16,6 +17,7 @@ const SECRET_DESCRIPTION = "Vercel GitHub sync cron configuration";
 const SECRET_NAME = "github_sync_bearer_secret";
 const URL_NAME = "github_sync_url";
 const HEAD_REFS_URL_NAME = "github_head_refs_url";
+const SUMMARY_URL_NAME = "github_summary_url";
 const WORKER_URL_NAME = "github_worker_url";
 const LEGACY_JOB_NAME = "github-sync-every-three-hours";
 const LEGACY_REFS_JOB_NAME = "github-refs-every-fifteen-minutes";
@@ -67,6 +69,7 @@ export const supabaseCronUrlsFrom = (configuredSiteUrl: string) => {
   return {
     events,
     headRefs: headRefs.toString(),
+    summary: new URL("/api/cron/github-summary", siteUrl).toString(),
     worker: new URL("/api/cron/github-worker", siteUrl).toString(),
   };
 };
@@ -176,6 +179,10 @@ export const configureSupabaseCron = async (
         value: urls.headRefs,
       });
       await upsertVaultSecret(transaction, {
+        name: SUMMARY_URL_NAME,
+        value: urls.summary,
+      });
+      await upsertVaultSecret(transaction, {
         name: WORKER_URL_NAME,
         value: urls.worker,
       });
@@ -193,6 +200,7 @@ export const configureSupabaseCron = async (
           ${LEGACY_TAG_REFS_JOB_NAME},
           ${GITHUB_EVENTS_CRON_JOB.name},
           ${GITHUB_HEAD_REFS_CRON_JOB.name},
+          ${GITHUB_SUMMARY_CRON_JOB.name},
           ${GITHUB_WORKER_CRON_JOB.name}
         )
       `;
@@ -218,18 +226,26 @@ export const configureSupabaseCron = async (
           ${cronHttpPostCommand(WORKER_URL_NAME, GITHUB_WORKER_HTTP_TIMEOUT_MS)}
         ) as "jobId"
       `;
+      const [summaryJob] = await transaction<{ jobId: number }[]>`
+        select cron.schedule(
+          ${GITHUB_SUMMARY_CRON_JOB.name},
+          ${GITHUB_SUMMARY_CRON_JOB.schedule},
+          ${cronHttpPostCommand(SUMMARY_URL_NAME, GITHUB_WORKER_HTTP_TIMEOUT_MS)}
+        ) as "jobId"
+      `;
       if (
         eventsJob === undefined ||
         headRefsJob === undefined ||
+        summaryJob === undefined ||
         workerJob === undefined
       ) {
         throw new Error("Supabase did not return every scheduled cron job.");
       }
-      return { eventsJob, headRefsJob, workerJob };
+      return { eventsJob, headRefsJob, summaryJob, workerJob };
     });
 
     process.stdout.write(
-      `Configured Supabase cron jobs ${String(jobs.eventsJob.jobId)}, ${String(jobs.headRefsJob.jobId)}, and ${String(jobs.workerJob.jobId)} for GitHub intake, head refs, and processing.\n`
+      `Configured Supabase cron jobs ${String(jobs.eventsJob.jobId)}, ${String(jobs.headRefsJob.jobId)}, ${String(jobs.workerJob.jobId)}, and ${String(jobs.summaryJob.jobId)} for GitHub intake, head refs, factual processing, and summaries.\n`
     );
     return jobs;
   } finally {

--- a/src/app/api/cron/github-summary/route.ts
+++ b/src/app/api/cron/github-summary/route.ts
@@ -1,0 +1,27 @@
+import { env } from "@/env";
+import { GITHUB_WORKER_EXECUTION_DURATION_MS } from "@/lib/github-cron-config";
+import type { GITHUB_WORKER_MAX_DURATION_SECONDS } from "@/lib/github-cron-config";
+import { runGitHubWorkUnitSummaryWorker } from "@/lib/github-work-unit-summary-worker";
+import { reportOperationalError } from "@/lib/operational-error";
+import { hasBearerSecret } from "@/lib/request-auth";
+
+export const dynamic = "force-dynamic";
+export const maxDuration =
+  60 satisfies typeof GITHUB_WORKER_MAX_DURATION_SECONDS;
+export const runtime = "nodejs";
+
+export async function POST(request: Request) {
+  if (!hasBearerSecret(request.headers.get("authorization"), env.CRON_SECRET)) {
+    return Response.json({ ok: false }, { status: 401 });
+  }
+
+  try {
+    const summary = await runGitHubWorkUnitSummaryWorker(
+      GITHUB_WORKER_EXECUTION_DURATION_MS
+    );
+    return Response.json({ ok: true, summary });
+  } catch (error) {
+    const errorName = reportOperationalError("github_summary", error);
+    return Response.json({ error: errorName, ok: false }, { status: 503 });
+  }
+}

--- a/src/lib/github-activity-worker-core.ts
+++ b/src/lib/github-activity-worker-core.ts
@@ -4,7 +4,6 @@ export const GITHUB_PR_RECONCILIATION_MAX_AGE_DAYS = Number.POSITIVE_INFINITY;
 
 const DEFAULT_RETRY_DELAY_MS = 15 * 60 * 1000;
 const MAXIMUM_RETRY_DELAY_MS = 24 * 60 * 60 * 1000;
-const GITHUB_SUMMARY_MINIMUM_REMAINING_MS = 25_000;
 
 export const boundedWorkerLimit = (
   value: number | undefined,
@@ -89,13 +88,6 @@ export const workerDeadlineReached = (
     throw new RangeError("The GitHub activity worker deadline is invalid.");
   }
   return now - startedAt >= maximumDurationMs;
-};
-
-export const githubSummaryCanStart = (deadlineAt: number, now = Date.now()) => {
-  if (!Number.isFinite(deadlineAt) || !Number.isFinite(now)) {
-    throw new RangeError("The GitHub summary deadline is invalid.");
-  }
-  return deadlineAt - now >= GITHUB_SUMMARY_MINIMUM_REMAINING_MS;
 };
 
 export const nextGitHubPullRequestReconciliationAt = (

--- a/src/lib/github-activity-worker.ts
+++ b/src/lib/github-activity-worker.ts
@@ -1,4 +1,3 @@
-import { env } from "@/env";
 import {
   ActivityProcessingError,
   fetchGitHubActivityCommitSource,
@@ -13,7 +12,6 @@ import {
 import {
   boundedWorkerLimit,
   GITHUB_PR_RECONCILIATION_MAX_AGE_DAYS,
-  githubSummaryCanStart,
   workerDeadlineReached,
 } from "@/lib/github-activity-worker-core";
 import {
@@ -75,24 +73,11 @@ import {
 import { ensureGitHubWorkUnitProjectionRequest } from "@/lib/github-work-unit-projection-state";
 import { refreshGitHubWorkUnitProjection } from "@/lib/github-work-unit-store";
 import type { GitHubWorkUnitProjectionRefreshResult } from "@/lib/github-work-unit-store";
-import {
-  GitHubWorkUnitSummaryInvalidInputError,
-  GitHubWorkUnitSummaryInvalidOutputError,
-  generateGitHubWorkUnitSummary,
-} from "@/lib/github-work-unit-summary-provider";
-import {
-  claimGitHubWorkUnitSummary,
-  completeGitHubWorkUnitSummary,
-  deferGitHubWorkUnitSummary,
-  reconcileGitHubWorkUnitSummaryStatus,
-  terminalGitHubWorkUnitSummary,
-} from "@/lib/github-work-unit-summary-store";
+import { reconcileGitHubWorkUnitSummaryStatus } from "@/lib/github-work-unit-summary-store";
 
 const DEFAULT_WORKER_MAXIMUM_DURATION_MS = 90_000;
 const MAXIMUM_PUBLICATION_RESERVE_MS = 30_000;
 const MINIMUM_FACTUAL_PROCESSING_MS = 8000;
-const SUMMARY_SETTLEMENT_RESERVE_MS = 3000;
-const SUMMARY_RETRY_DELAY_MS = 15 * 60_000;
 const TERMINAL_GITHUB_STATUSES = new Set([403, 404, 410, 422]);
 const TERMINAL_ACTIVITY_PROCESSING_CODES = new Set([
   "membership_incomplete",
@@ -130,7 +115,6 @@ export interface GitHubActivityWorkerResult {
   pullRequestDiscovery: StageResult;
   pullRequestSignals: StageResult;
   refs: StageResult;
-  summaries: StageResult;
 }
 
 export interface GitHubActivityWorkerOptions {
@@ -601,62 +585,6 @@ const processPullRequests = async (
   result.failed = result.deferred + result.unavailable;
 };
 
-const processSummary = async (context: WorkerContext, result: StageResult) => {
-  if (
-    context.deadlineReached() ||
-    !githubSummaryCanStart(context.deadlineAt) ||
-    (env.OPENAI_API_KEY?.trim().length ?? 0) === 0
-  ) {
-    return;
-  }
-  const claim = await claimGitHubWorkUnitSummary({ now: new Date() });
-  if (claim === null) {
-    return;
-  }
-  result.claimed = 1;
-  try {
-    const generated = await generateGitHubWorkUnitSummary({
-      deadlineAt: context.deadlineAt,
-      serializedInput: claim.serializedInput,
-    });
-    const completion = await completeGitHubWorkUnitSummary(
-      claim,
-      generated,
-      new Date()
-    );
-    if (completion.accepted) {
-      result.completed = 1;
-    } else {
-      result.failed = 1;
-    }
-  } catch (error) {
-    if (
-      error instanceof GitHubWorkUnitSummaryInvalidInputError ||
-      error instanceof GitHubWorkUnitSummaryInvalidOutputError
-    ) {
-      if (await terminalGitHubWorkUnitSummary(claim, new Date())) {
-        result.unavailable = 1;
-      } else {
-        result.failed = 1;
-      }
-      return;
-    }
-    const deferredAt = new Date();
-    const disposition = await deferGitHubWorkUnitSummary(
-      claim,
-      new Date(deferredAt.getTime() + SUMMARY_RETRY_DELAY_MS),
-      deferredAt
-    );
-    if (disposition === "deferred") {
-      result.deferred = 1;
-    } else if (disposition === "terminal") {
-      result.unavailable = 1;
-    } else {
-      result.failed = 1;
-    }
-  }
-};
-
 const checkedWorkerAccounts = (
   accounts: readonly TrackedGitHubAccount[] | undefined
 ) => {
@@ -737,7 +665,6 @@ export const runGitHubActivityWorker = async (
   const pullRequestDiscovery = emptyStageResult();
   const pullRequestSignals = emptyStageResult();
   const refs = emptyStageResult();
-  const summaries = emptyStageResult();
   const activeAccounts = await activeTrackedAccounts(requestedAccounts);
   const context: WorkerContext = {
     activeAccounts,
@@ -747,9 +674,6 @@ export const runGitHubActivityWorker = async (
   };
   const overallDeadlineReached = () =>
     workerDeadlineReached(startedAt, maximumDurationMs);
-  const summaryDeadlineAt =
-    startedAt + Math.max(0, maximumDurationMs - SUMMARY_SETTLEMENT_RESERVE_MS);
-
   await processObservations(context, observationLimit, observations);
   await processPullRequestSignals(
     context,
@@ -772,16 +696,6 @@ export const runGitHubActivityWorker = async (
       ? await refreshGitHubWorkUnitProjection(new Date())
       : null;
   await reconcileGitHubWorkUnitSummaryStatus(new Date());
-  if (options.includeProjection !== false) {
-    await processSummary(
-      {
-        ...context,
-        deadlineAt: summaryDeadlineAt,
-        deadlineReached: () => Date.now() >= summaryDeadlineAt,
-      },
-      summaries
-    );
-  }
 
   return {
     commits,
@@ -792,6 +706,5 @@ export const runGitHubActivityWorker = async (
     pullRequestDiscovery,
     pullRequestSignals,
     refs,
-    summaries,
   };
 };

--- a/src/lib/github-backfill-store.ts
+++ b/src/lib/github-backfill-store.ts
@@ -1,20 +1,11 @@
-import {
-  and,
-  eq,
-  gt,
-  gte,
-  inArray,
-  isNotNull,
-  isNull,
-  lte,
-  or,
-} from "drizzle-orm";
+import { and, eq, gte, inArray, isNotNull, isNull, or } from "drizzle-orm";
 
 import { getDatabase } from "@/db/client";
 import {
   githubAccountCheckpoints,
   githubCommits,
   githubPullRequests,
+  githubPullRequestVersions,
   githubPullRequestSignals,
   githubPushObservations,
   githubRepositories,
@@ -166,14 +157,22 @@ export const readGitHubFactualWorkerBacklog = async (input: {
         );
       const pullRequests = await transaction
         .select({
-          attempts: githubPullRequests.reconcileAttempts,
-          error: githubPullRequests.reconcileError,
           retryAt: githubPullRequests.nextReconcileAt,
         })
         .from(githubPullRequests)
         .innerJoin(
           githubRepositories,
           eq(githubRepositories.id, githubPullRequests.repositoryId)
+        )
+        .leftJoin(
+          githubPullRequestVersions,
+          and(
+            eq(
+              githubPullRequestVersions.pullRequestNodeId,
+              githubPullRequests.nodeId
+            ),
+            eq(githubPullRequestVersions.isCurrent, true)
+          )
         )
         .where(
           and(
@@ -189,17 +188,19 @@ export const readGitHubFactualWorkerBacklog = async (input: {
               inArray(githubPullRequests.state, ["closed", "merged"])
             ),
             or(
+              isNotNull(githubPullRequests.reconcileError),
+              isNull(githubPullRequestVersions.id),
+              eq(githubPullRequestVersions.membershipComplete, false),
               and(
-                isNotNull(githubPullRequests.nextReconcileAt),
-                or(
-                  lte(githubPullRequests.nextReconcileAt, now),
-                  gt(githubPullRequests.reconcileAttempts, 0),
-                  isNotNull(githubPullRequests.reconcileError)
-                )
+                isNotNull(githubPullRequests.changedFiles),
+                eq(githubPullRequestVersions.fileFactsComplete, false)
               ),
               and(
-                isNull(githubPullRequests.nextReconcileAt),
-                isNotNull(githubPullRequests.reconcileError)
+                eq(githubPullRequests.state, "merged"),
+                or(
+                  isNull(githubPullRequests.mergeShaVerifiedAt),
+                  eq(githubPullRequestVersions.mergeSnapshot, false)
+                )
               )
             )
           )
@@ -252,9 +253,7 @@ export const readGitHubFactualWorkerBacklog = async (input: {
             enrichmentState === "complete" && pullRequestState === "unavailable"
         ).length +
         signals.filter(({ state }) => state === "unavailable").length +
-        pullRequests.filter(
-          ({ error, retryAt }) => error !== null && retryAt === null
-        ).length;
+        pullRequests.filter(({ retryAt }) => retryAt === null).length;
       return {
         pending,
         retryAt: retryAtFrom(retryRows, now),

--- a/src/lib/github-cron-config.ts
+++ b/src/lib/github-cron-config.ts
@@ -8,6 +8,11 @@ export const GITHUB_WORKER_CRON_JOB = {
   schedule: "2-57/5 * * * *",
 } as const;
 
+export const GITHUB_SUMMARY_CRON_JOB = {
+  name: "github-summary-worker-every-five-minutes",
+  schedule: "3-58/5 * * * *",
+} as const;
+
 export const GITHUB_HEAD_REFS_CRON_JOB = {
   name: "github-head-refs-every-fifteen-minutes",
   schedule: "4,19,34,49 * * * *",

--- a/src/lib/github-pull-request-store.ts
+++ b/src/lib/github-pull-request-store.ts
@@ -157,12 +157,12 @@ export const persistPullRequestSnapshotInTransaction = async (
         existing.headRepositoryId !== pullRequest.headRepository.id) ||
       existing.repositoryId !== pullRequest.repository.id ||
       existing.state !== state);
+  const mergeLandingChanged =
+    existing !== undefined &&
+    (existing.mergeSha !== mergeSha ||
+      (existing.mergeShaVerifiedAt === null) !== (mergeShaVerifiedAt === null));
   const persistedEvidenceChanged =
-    projectionEvidenceChanged ||
-    (existing !== undefined &&
-      (existing.mergeSha !== mergeSha ||
-        (existing.mergeShaVerifiedAt === null) !==
-          (mergeShaVerifiedAt === null)));
+    projectionEvidenceChanged || mergeLandingChanged;
   const retryLifecycleReset =
     existing !== undefined &&
     (disposition === "newer" || persistedEvidenceChanged);
@@ -460,7 +460,7 @@ export const persistPullRequestSnapshotInTransaction = async (
   }
 
   const projectionInputChanged =
-    projectionEvidenceChanged ||
+    persistedEvidenceChanged ||
     version === undefined ||
     !version.isCurrent ||
     storedMembershipInvalid ||

--- a/src/lib/github-work-unit-core.ts
+++ b/src/lib/github-work-unit-core.ts
@@ -31,7 +31,6 @@ export interface GitHubLogicalChange {
   enrichmentComplete: boolean;
   fileFacts: readonly GitHubFileChangeStat[];
   fileFactsComplete: boolean;
-  mergedPullRequestLanding: boolean;
   logicalActivityAt: string;
   logicalRepositoryId: string;
   logicalSha: string;
@@ -42,6 +41,7 @@ export interface GitHubLogicalChange {
   repositoryId: string;
   sha: string;
   summaryFileFacts: readonly GitHubWorkUnitFileFact[] | null;
+  verifiedMergeLanding: boolean;
 }
 
 export interface GitHubRepositoryProjectionEvidence {
@@ -594,6 +594,9 @@ const chooseOwnerFor = (
   if (pullRequest !== null) {
     return { kind: "pull_request", pullRequest };
   }
+  if (change.verifiedMergeLanding) {
+    return null;
+  }
 
   const repository = ownership.repositoriesById.get(change.repositoryId);
   if (
@@ -612,7 +615,7 @@ const chooseOwnerFor = (
   const canonicalRef = reachableRefs.find(
     (ref) => ref.refName === canonicalRefName
   );
-  if (canonicalRef !== undefined && !change.mergedPullRequestLanding) {
+  if (canonicalRef !== undefined) {
     return {
       activityDay: utcDayFrom(change.logicalActivityAt),
       kind: "canonical_day",

--- a/src/lib/github-work-unit-crosswalk.ts
+++ b/src/lib/github-work-unit-crosswalk.ts
@@ -65,16 +65,17 @@ interface GitHubWorkUnitCrosswalkReasonBuckets<
 
 export interface GitHubWorkUnitCrosswalk {
   categories: {
-    associatedOrRemovedUnreachableChanges: GitHubWorkUnitCrosswalkBucket;
     authoredPullRequestsWithoutOwnedCurrentMember: GitHubWorkUnitCrosswalkBucket;
     commitEnrichmentBacklog: GitHubWorkUnitCrosswalkBucket;
     eligibleTrackedChanges: GitHubWorkUnitCrosswalkBucket;
     integrationMerges: GitHubWorkUnitCrosswalkBucket;
+    policyExcludedChanges: GitHubWorkUnitCrosswalkBucket;
     projectedBranchUnits: GitHubWorkUnitCrosswalkBucket;
     projectedCanonicalUnits: GitHubWorkUnitCrosswalkBucket;
     projectedOwnedChanges: GitHubWorkUnitCrosswalkBucket;
     projectedPullRequestUnits: GitHubWorkUnitCrosswalkBucket;
     trackedChangeCandidates: GitHubWorkUnitCrosswalkBucket;
+    verifiedMergeLandingOwnershipViolations: GitHubWorkUnitCrosswalkBucket;
     visibilityGaps: GitHubWorkUnitCrosswalkBucket;
     zeroDiffOrIneligibleChanges: GitHubWorkUnitCrosswalkBucket;
   };
@@ -92,11 +93,12 @@ export interface GitHubWorkUnitCrosswalk {
       | "commit_enrichment_backlog"
       | "projection_coverage_gap"
       | "repository_visibility_gap"
+      | "verified_merge_landing_owned"
     )[];
     passed: boolean;
   };
   policyExclusions: GitHubWorkUnitCrosswalkReasonBuckets<GitHubWorkUnitPolicyExclusionReason>;
-  version: 3;
+  version: 4;
 }
 
 const bytewiseCompare = (left: string, right: string) =>
@@ -277,13 +279,26 @@ export const buildGitHubWorkUnitCrosswalk = (
     unit.members.some((member) => eligibleKeys.has(member.logicalKey))
   );
   const projectedOwnedKeys = new Set<string>();
+  const projectedRefOwnedKeys = new Set<string>();
   for (const unit of unitsInScope) {
     for (const member of unit.members) {
       if (eligibleKeys.has(member.logicalKey)) {
         projectedOwnedKeys.add(member.logicalKey);
+        if (unit.kind !== "pull_request") {
+          projectedRefOwnedKeys.add(member.logicalKey);
+        }
       }
     }
   }
+  const verifiedMergeLandingOwnershipViolationKeys = new Set(
+    eligibleChanges
+      .filter(
+        (change) =>
+          change.verifiedMergeLanding &&
+          projectedRefOwnedKeys.has(logicalKeyFrom(change))
+      )
+      .map(logicalKeyFrom)
+  );
   const filteredExcludedChanges = snapshot.excludedChanges.filter((change) =>
     eligibleKeys.has(change.logicalKey)
   );
@@ -360,17 +375,20 @@ export const buildGitHubWorkUnitCrosswalk = (
   if (visibilityGapIds.length > 0) {
     failures.add("repository_visibility_gap");
   }
+  if (verifiedMergeLandingOwnershipViolationKeys.size > 0) {
+    failures.add("verified_merge_landing_owned");
+  }
   const orderedFailures = [...failures].toSorted(bytewiseCompare);
 
   return {
     categories: {
-      associatedOrRemovedUnreachableChanges: bucketFrom(policyExclusions.ids),
       authoredPullRequestsWithoutOwnedCurrentMember: bucketFrom(
         authoredPullRequestsWithoutOwnedCurrentMember
       ),
       commitEnrichmentBacklog: bucketFrom(enrichmentBacklogKeys),
       eligibleTrackedChanges: bucketFrom(eligibleKeys),
       integrationMerges: bucketFrom(integrationMergeKeys),
+      policyExcludedChanges: bucketFrom(policyExclusions.ids),
       projectedBranchUnits: bucketFrom(
         unitsInScope
           .filter((unit) => unit.kind === "branch")
@@ -388,6 +406,9 @@ export const buildGitHubWorkUnitCrosswalk = (
           .map((unit) => unit.identityKey)
       ),
       trackedChangeCandidates: bucketFrom(trackedChangeKeys),
+      verifiedMergeLandingOwnershipViolations: bucketFrom(
+        verifiedMergeLandingOwnershipViolationKeys
+      ),
       visibilityGaps: bucketFrom(visibilityGapIds),
       zeroDiffOrIneligibleChanges: bucketFrom(ineligibleKeys),
     },
@@ -405,7 +426,7 @@ export const buildGitHubWorkUnitCrosswalk = (
       passed: orderedFailures.length === 0,
     },
     policyExclusions,
-    version: 3,
+    version: 4,
   };
 };
 

--- a/src/lib/github-work-unit-projection-state.ts
+++ b/src/lib/github-work-unit-projection-state.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 
 import { and, eq, sql } from "drizzle-orm";
 
@@ -12,6 +12,16 @@ type DatabaseTransaction = Parameters<
 >[0];
 
 const PROJECTION_LOCK = "github-work-unit-projection-v1";
+// Bump whenever durable evidence maps to different work-unit ownership.
+const PROJECTION_POLICY = "github-work-unit-projection-v2-verified-landings";
+const PIPELINE_POLICY_DIGEST = createHash("sha256")
+  .update(
+    JSON.stringify({
+      projection: PROJECTION_POLICY,
+      summary: GITHUB_WORK_UNIT_SUMMARY_POLICY_DIGEST,
+    })
+  )
+  .digest("hex");
 
 export const acquireGitHubWorkUnitProjectionLock = async (
   transaction: DatabaseTransaction
@@ -40,7 +50,7 @@ export const ensureGitHubWorkUnitProjectionRequest = async () =>
   await getDatabase().transaction(async (transaction) => {
     const [head] = await transaction
       .select({
-        summaryPolicyDigest: githubPublicFeedHead.summaryPolicyDigest,
+        policyDigest: githubPublicFeedHead.summaryPolicyDigest,
         token: githubPublicFeedHead.projectionRequestToken,
       })
       .from(githubPublicFeedHead)
@@ -49,10 +59,7 @@ export const ensureGitHubWorkUnitProjectionRequest = async () =>
     if (head === undefined) {
       throw new Error("The GitHub public feed head is unavailable.");
     }
-    if (
-      head.token !== null ||
-      head.summaryPolicyDigest === GITHUB_WORK_UNIT_SUMMARY_POLICY_DIGEST
-    ) {
+    if (head.token !== null || head.policyDigest === PIPELINE_POLICY_DIGEST) {
       return head.token;
     }
     return await requestGitHubWorkUnitProjection(transaction);
@@ -65,7 +72,7 @@ export const completeGitHubWorkUnitProjectionRequest = async (
     .update(githubPublicFeedHead)
     .set({
       projectionRequestToken: null,
-      summaryPolicyDigest: GITHUB_WORK_UNIT_SUMMARY_POLICY_DIGEST,
+      summaryPolicyDigest: PIPELINE_POLICY_DIGEST,
     })
     .where(
       and(

--- a/src/lib/github-work-unit-store.ts
+++ b/src/lib/github-work-unit-store.ts
@@ -1,9 +1,8 @@
-import { and, asc, eq, inArray, or, sql } from "drizzle-orm";
+import { and, asc, eq, exists, inArray, isNotNull, or, sql } from "drizzle-orm";
 
 import { getDatabase } from "@/db/client";
 import {
   githubAccountRepositoryCatalogs,
-  githubCommitPullRequestAssociations,
   githubCommits,
   githubIssues,
   githubPublicFeedHead,
@@ -491,18 +490,14 @@ const excludedChangesFrom = (
       throw new Error(
         `Effective pull-request member was not projected: ${logicalKey}`
       );
+    } else if (change.verifiedMergeLanding) {
+      reason = "merged_pr_landing";
     } else if (!change.pullRequestCoverageComplete) {
       reason = "pull_request_coverage_incomplete";
     } else if (repository.defaultBranch === null) {
       reason = "canonical_branch_unknown";
     } else if (repository.headGenerationComplete) {
-      const reachableRefs = (
-        ownership.refsByLogicalKey.get(logicalKey) ?? []
-      ).filter((ref) => ref.complete && ref.repositoryId === repository.id);
-      reason =
-        reachableRefs.length === 0 || !change.mergedPullRequestLanding
-          ? "no_current_owner"
-          : "merged_pr_landing";
+      reason = "no_current_owner";
     } else {
       reason = "head_generation_incomplete";
     }
@@ -881,33 +876,17 @@ const loadProjectionSnapshot = async (
       asc(githubRefMemberships.refName),
       asc(githubRefMemberships.position)
     );
-  const associationRows = await transaction
-    .select({
-      baseRepositoryId: githubPullRequests.repositoryId,
-      commitRepositoryId:
-        githubCommitPullRequestAssociations.commitRepositoryId,
-      commitSha: githubCommitPullRequestAssociations.commitSha,
-      state: githubPullRequests.state,
-    })
-    .from(githubCommitPullRequestAssociations)
-    .innerJoin(
-      githubCommits,
+  const verifiedMergeLanding = transaction
+    .select({ one: sql<number>`1` })
+    .from(githubPullRequests)
+    .where(
       and(
-        eq(
-          githubCommits.repositoryId,
-          githubCommitPullRequestAssociations.commitRepositoryId
-        ),
-        eq(githubCommits.sha, githubCommitPullRequestAssociations.commitSha)
+        eq(githubPullRequests.repositoryId, githubCommits.repositoryId),
+        eq(githubPullRequests.state, "merged"),
+        isNotNull(githubPullRequests.mergeShaVerifiedAt),
+        eq(githubPullRequests.mergeSha, githubCommits.sha)
       )
-    )
-    .innerJoin(
-      githubPullRequests,
-      eq(
-        githubPullRequests.nodeId,
-        githubCommitPullRequestAssociations.pullRequestNodeId
-      )
-    )
-    .where(inArray(githubCommits.authorUserId, [...trackedAuthorUserIds]));
+    );
   const commitRows = await transaction
     .select({
       additions: githubCommits.additions,
@@ -925,23 +904,16 @@ const loadProjectionSnapshot = async (
       pullRequestDiscoveryState: githubCommits.pullRequestDiscoveryState,
       repositoryId: githubCommits.repositoryId,
       sha: githubCommits.sha,
+      verifiedMergeLanding: exists(verifiedMergeLanding).mapWith(Boolean),
     })
     .from(githubCommits)
     .where(inArray(githubCommits.authorUserId, [...trackedAuthorUserIds]))
     .orderBy(asc(githubCommits.repositoryId), asc(githubCommits.sha));
-  const mergedPullRequestLandings = new Set(
-    associationRows.flatMap((row) =>
-      row.state === "merged" && row.baseRepositoryId === row.commitRepositoryId
-        ? [logicalKeyFrom(row.commitRepositoryId, row.commitSha)]
-        : []
-    )
-  );
   const changes: GitHubLogicalChange[] = commitRows.map((row) => {
     const fileFacts = checkedCompactFileFacts(row.fileFacts);
     const parentShas = checkedParentShas(row.parentShas);
     const pullRequestCoverageComplete =
       row.pullRequestDiscoveryState === "complete";
-    const logicalKey = logicalKeyFrom(row.repositoryId, row.sha);
     return {
       additions: row.additions ?? -1,
       authorUserId: row.authorUserId,
@@ -950,7 +922,6 @@ const loadProjectionSnapshot = async (
       enrichmentComplete: row.enrichmentState === "complete",
       fileFacts: fileFacts ?? [],
       fileFactsComplete: row.fileFactsComplete && fileFacts !== null,
-      mergedPullRequestLanding: mergedPullRequestLandings.has(logicalKey),
       logicalActivityAt: (row.committerAt ?? row.committedAt).toISOString(),
       logicalRepositoryId: row.repositoryId,
       logicalSha: row.sha,
@@ -962,6 +933,7 @@ const loadProjectionSnapshot = async (
       repositoryId: row.repositoryId,
       sha: row.sha,
       summaryFileFacts: null,
+      verifiedMergeLanding: row.verifiedMergeLanding,
     };
   });
   const commitSummaryEvidenceByLogicalKey = new Map(

--- a/src/lib/github-work-unit-summary-worker.ts
+++ b/src/lib/github-work-unit-summary-worker.ts
@@ -1,0 +1,134 @@
+import { env } from "@/env";
+import {
+  GitHubWorkUnitSummaryInvalidInputError,
+  GitHubWorkUnitSummaryInvalidOutputError,
+  generateGitHubWorkUnitSummary,
+} from "@/lib/github-work-unit-summary-provider";
+import {
+  claimGitHubWorkUnitSummary,
+  completeGitHubWorkUnitSummary,
+  deferGitHubWorkUnitSummary,
+  terminalGitHubWorkUnitSummary,
+} from "@/lib/github-work-unit-summary-store";
+
+const MINIMUM_PROVIDER_BUDGET_MS = 25_000;
+const SETTLEMENT_RESERVE_MS = 3000;
+const RETRY_DELAY_MS = 15 * 60_000;
+
+interface GitHubWorkUnitSummaryWorkerResult {
+  claimed: number;
+  completed: number;
+  deferred: number;
+  failed: number;
+  unavailable: number;
+}
+
+interface GitHubWorkUnitSummaryWorkerDependencies {
+  claim: typeof claimGitHubWorkUnitSummary;
+  complete: typeof completeGitHubWorkUnitSummary;
+  defer: typeof deferGitHubWorkUnitSummary;
+  generate: typeof generateGitHubWorkUnitSummary;
+  now: () => Date;
+  providerConfigured: () => boolean;
+  terminal: typeof terminalGitHubWorkUnitSummary;
+}
+
+const productionDependencies: GitHubWorkUnitSummaryWorkerDependencies = {
+  claim: claimGitHubWorkUnitSummary,
+  complete: completeGitHubWorkUnitSummary,
+  defer: deferGitHubWorkUnitSummary,
+  generate: generateGitHubWorkUnitSummary,
+  now: () => new Date(),
+  providerConfigured: () => (env.OPENAI_API_KEY?.trim().length ?? 0) > 0,
+  terminal: terminalGitHubWorkUnitSummary,
+};
+
+const emptyResult = (): GitHubWorkUnitSummaryWorkerResult => ({
+  claimed: 0,
+  completed: 0,
+  deferred: 0,
+  failed: 0,
+  unavailable: 0,
+});
+
+const checkedNow = (value: Date) => {
+  if (!(value instanceof Date) || Number.isNaN(value.getTime())) {
+    throw new TypeError("The GitHub summary worker clock is invalid.");
+  }
+  return value;
+};
+
+const checkedMaximumDuration = (value: number) => {
+  if (!Number.isSafeInteger(value) || value < 1) {
+    throw new RangeError("The GitHub summary worker duration is invalid.");
+  }
+  return value;
+};
+
+/** Claims and settles at most one provider request in an isolated time budget. */
+export const runGitHubWorkUnitSummaryWorker = async (
+  maximumDurationMs: number,
+  dependencies: GitHubWorkUnitSummaryWorkerDependencies = productionDependencies
+): Promise<GitHubWorkUnitSummaryWorkerResult> => {
+  const durationMs = checkedMaximumDuration(maximumDurationMs);
+  const startedAt = checkedNow(dependencies.now()).getTime();
+  const deadlineAt = startedAt + durationMs - SETTLEMENT_RESERVE_MS;
+  const result = emptyResult();
+  if (
+    !dependencies.providerConfigured() ||
+    deadlineAt - checkedNow(dependencies.now()).getTime() <
+      MINIMUM_PROVIDER_BUDGET_MS
+  ) {
+    return result;
+  }
+
+  const claim = await dependencies.claim({
+    now: checkedNow(dependencies.now()),
+  });
+  if (claim === null) {
+    return result;
+  }
+  result.claimed = 1;
+  try {
+    const generated = await dependencies.generate({
+      deadlineAt,
+      serializedInput: claim.serializedInput,
+    });
+    const completion = await dependencies.complete(
+      claim,
+      generated,
+      checkedNow(dependencies.now())
+    );
+    if (completion.accepted) {
+      result.completed = 1;
+    } else {
+      result.failed = 1;
+    }
+  } catch (error) {
+    if (
+      error instanceof GitHubWorkUnitSummaryInvalidInputError ||
+      error instanceof GitHubWorkUnitSummaryInvalidOutputError
+    ) {
+      if (await dependencies.terminal(claim, checkedNow(dependencies.now()))) {
+        result.unavailable = 1;
+      } else {
+        result.failed = 1;
+      }
+      return result;
+    }
+    const deferredAt = checkedNow(dependencies.now());
+    const disposition = await dependencies.defer(
+      claim,
+      new Date(deferredAt.getTime() + RETRY_DELAY_MS),
+      deferredAt
+    );
+    if (disposition === "deferred") {
+      result.deferred = 1;
+    } else if (disposition === "terminal") {
+      result.unavailable = 1;
+    } else {
+      result.failed = 1;
+    }
+  }
+  return result;
+};

--- a/tests/github-activity-worker.test.mjs
+++ b/tests/github-activity-worker.test.mjs
@@ -9,7 +9,6 @@ import {
   githubActivityRetryAt,
   githubPullRequestSnapshotDisposition,
   githubPrReconciliationCutoff,
-  githubSummaryCanStart,
   GITHUB_PR_RECONCILIATION_MAX_AGE_DAYS,
   nextGitHubPullRequestReconciliationAt,
   workerBatchSizeFrom,
@@ -109,12 +108,6 @@ describe("GitHub activity worker bounds", () => {
   test("uses a deterministic wall-clock deadline", () => {
     expect(workerDeadlineReached(1000, 10_000, 10_999)).toBe(false);
     expect(workerDeadlineReached(1000, 10_000, 11_000)).toBe(true);
-  });
-
-  test("starts summary work only with a complete provider budget", () => {
-    expect(githubSummaryCanStart(26_000, 1000)).toBe(true);
-    expect(githubSummaryCanStart(25_999, 1000)).toBe(false);
-    expect(() => githubSummaryCanStart(Number.NaN, 1000)).toThrow(RangeError);
   });
 
   test("stops terminal PR polling", () => {

--- a/tests/github-backfill.test.mjs
+++ b/tests/github-backfill.test.mjs
@@ -98,7 +98,6 @@ const workerResult = (overrides = {}) => ({
   pullRequestDiscovery: emptyWorkerStage(),
   pullRequestSignals: emptyWorkerStage(),
   refs: emptyWorkerStage(),
-  summaries: emptyWorkerStage(),
   ...overrides,
 });
 

--- a/tests/github-cron-config.test.mjs
+++ b/tests/github-cron-config.test.mjs
@@ -8,6 +8,7 @@ import {
   GITHUB_HEAD_REFS_CRON_JOB,
   GITHUB_REF_REPOSITORY_BATCH_SIZE,
   GITHUB_ROUTINE_MAX_DURATION_SECONDS,
+  GITHUB_SUMMARY_CRON_JOB,
   GITHUB_WORKER_EXECUTION_DURATION_MS,
   GITHUB_WORKER_HTTP_TIMEOUT_MS,
   GITHUB_WORKER_MAX_DURATION_SECONDS,
@@ -44,11 +45,19 @@ describe("GitHub cron configuration", () => {
     const jobs = [
       GITHUB_EVENTS_CRON_JOB,
       GITHUB_WORKER_CRON_JOB,
+      GITHUB_SUMMARY_CRON_JOB,
       GITHUB_HEAD_REFS_CRON_JOB,
     ];
     const allMinutes = jobs.flatMap((job) => minutesFrom(job.schedule));
     expect(new Set(jobs.map((job) => job.name)).size).toBe(jobs.length);
     expect(new Set(allMinutes).size).toBe(allMinutes.length);
+
+    const factualMinutes = new Set(
+      minutesFrom(GITHUB_WORKER_CRON_JOB.schedule)
+    );
+    for (const summaryMinute of minutesFrom(GITHUB_SUMMARY_CRON_JOB.schedule)) {
+      expect(factualMinutes.has((summaryMinute + 59) % 60)).toBe(true);
+    }
   });
 
   test("bounds scheduled repository reconciliation", () => {

--- a/tests/github-pull-request-store.test.mjs
+++ b/tests/github-pull-request-store.test.mjs
@@ -250,6 +250,10 @@ describe.skipIf(!dockerAvailable)("GitHub pull request persistence", () => {
       mergeSnapshot: true,
     });
 
+    await admin`
+      update github_public_feed_head set projection_request_token = null
+      where id
+    `;
     await persistGitHubPullRequestSnapshot("f0rr0", terminalSignal);
     const [verified] = await database
       .select()
@@ -257,6 +261,12 @@ describe.skipIf(!dockerAvailable)("GitHub pull request persistence", () => {
       .where(eq(schema.githubPullRequests.nodeId, "PR_pr_store_8301"));
     expect(verified).toMatchObject({ mergeSha, state: "merged" });
     expect(verified.mergeShaVerifiedAt).not.toBeNull();
+    expect(
+      await admin`
+        select projection_request_token is not null as "projectionRequested"
+        from github_public_feed_head
+      `
+    ).toEqual([{ projectionRequested: true }]);
   });
 
   test("signals an equal-time terminal promotion despite a conflicting head", async () => {

--- a/tests/github-summary-cron-route.test.mjs
+++ b/tests/github-summary-cron-route.test.mjs
@@ -1,0 +1,16 @@
+import { describe, expect, test } from "bun:test";
+
+import { POST } from "../src/app/api/cron/github-summary/route.ts";
+
+describe("GitHub summary cron route", () => {
+  test("rejects an unauthenticated invocation before running summary work", async () => {
+    const response = await POST(
+      new Request("https://f0rr0.dev/api/cron/github-summary", {
+        method: "POST",
+      })
+    );
+
+    expect(response.status).toBe(401);
+    expect(await response.json()).toEqual({ ok: false });
+  });
+});

--- a/tests/github-work-unit-core.test.mjs
+++ b/tests/github-work-unit-core.test.mjs
@@ -45,7 +45,6 @@ const change = (character, overrides = {}) => {
     enrichmentComplete: true,
     fileFacts,
     fileFactsComplete: true,
-    mergedPullRequestLanding: false,
     logicalActivityAt: "2026-08-30T12:00:00.000Z",
     logicalRepositoryId: "1",
     logicalSha: sha(character),
@@ -56,6 +55,7 @@ const change = (character, overrides = {}) => {
     repositoryId: "1",
     sha: sha(character),
     summaryFileFacts: fileFacts,
+    verifiedMergeLanding: false,
     ...overrides,
   };
 };
@@ -289,7 +289,7 @@ describe("deterministic GitHub work ownership", () => {
   });
 
   test("gives a removed PR member to a complete current side ref", () => {
-    const work = change("c", { mergedPullRequestLanding: true });
+    const work = change("c");
     const key = logicalKeyFrom(work);
 
     const units = projection({
@@ -304,8 +304,8 @@ describe("deterministic GitHub work ownership", () => {
     });
   });
 
-  test("gives a removed member with only an unmerged PR association to canonical work", () => {
-    const work = change("c", { mergedPullRequestLanding: false });
+  test("gives a removed PR member to complete current canonical work", () => {
+    const work = change("c");
     const key = logicalKeyFrom(work);
 
     const units = projection({
@@ -320,16 +320,34 @@ describe("deterministic GitHub work ownership", () => {
     });
   });
 
-  test("withholds a same-repository merged-PR landing from canonical work", () => {
-    const work = change("c", { mergedPullRequestLanding: true });
+  test("withholds a verified merge landing from canonical and side refs", () => {
+    const work = change("c", { verifiedMergeLanding: true });
     const key = logicalKeyFrom(work);
 
     expect(
       projection({
         changes: [work],
-        refs: [ref("refs/heads/main", [key])],
+        refs: [
+          ref("refs/heads/main", [key]),
+          ref("refs/heads/topic", [key], {
+            branchLineageId: "22222222-2222-4222-8222-222222222222",
+          }),
+        ],
       })
     ).toEqual([]);
+  });
+
+  test("keeps effective PR membership ahead of merge-landing suppression", () => {
+    const work = change("c", { verifiedMergeLanding: true });
+    const key = logicalKeyFrom(work);
+    const units = projection({
+      changes: [work],
+      pullRequests: [pullRequest("PR_verified_landing", [key])],
+      refs: [ref("refs/heads/main", [key])],
+    });
+
+    expect(units).toHaveLength(1);
+    expect(units[0]).toMatchObject({ kind: "pull_request" });
   });
 
   test("keeps partition-independent PR prose identity and activity anchor across a rewrite", () => {

--- a/tests/github-work-unit-crosswalk.test.mjs
+++ b/tests/github-work-unit-crosswalk.test.mjs
@@ -13,9 +13,9 @@ const change = ({
   character,
   deletions = 0,
   enrichmentComplete = true,
-  mergedPullRequestLanding = false,
   parentCount = 1,
   repositoryId = "1",
+  verifiedMergeLanding = false,
 }) => {
   const fileFacts =
     additions + deletions === 0
@@ -40,7 +40,6 @@ const change = ({
     enrichmentComplete,
     fileFacts,
     fileFactsComplete: true,
-    mergedPullRequestLanding,
     logicalActivityAt: activityAt,
     logicalRepositoryId: repositoryId,
     logicalSha: sha(character),
@@ -51,6 +50,7 @@ const change = ({
     repositoryId,
     sha: sha(character),
     summaryFileFacts: fileFacts,
+    verifiedMergeLanding,
   };
 };
 
@@ -138,8 +138,8 @@ const snapshot = () => {
     change({ character: "6", repositoryId: "1" }),
     change({
       character: "7",
-      mergedPullRequestLanding: true,
       repositoryId: "1",
+      verifiedMergeLanding: true,
     }),
     change({ character: "8", repositoryId: "4" }),
     change({ character: "9", repositoryId: "2" }),
@@ -285,9 +285,14 @@ describe("GitHub work-unit crosswalk", () => {
       "branch:lineage-3",
     ]);
     expect(report.categories.projectedOwnedChanges.count).toBe(4);
-    expect(report.categories.associatedOrRemovedUnreachableChanges.ids).toEqual(
-      [logicalKey("1", "6"), logicalKey("1", "7")]
-    );
+    expect(report.categories.verifiedMergeLandingOwnershipViolations).toEqual({
+      count: 0,
+      ids: [],
+    });
+    expect(report.categories.policyExcludedChanges.ids).toEqual([
+      logicalKey("1", "6"),
+      logicalKey("1", "7"),
+    ]);
     expect(
       report.categories.authoredPullRequestsWithoutOwnedCurrentMember
     ).toEqual({ count: 1, ids: ["PR_2"] });
@@ -327,7 +332,54 @@ describe("GitHub work-unit crosswalk", () => {
       ],
       passed: false,
     });
-    expect(report.version).toBe(3);
+    expect(report.version).toBe(4);
+  });
+
+  test("fails if a verified merge landing is projected as ref-owned work", () => {
+    const evidence = snapshot();
+    const landingKey = logicalKey("1", "7");
+    evidence.units.push(
+      unit({
+        identityKey: "canonical:1:2026-08-03",
+        kind: "canonical_day",
+        members: [landingKey],
+      })
+    );
+
+    const report = buildGitHubWorkUnitCrosswalk(evidence, {
+      since: "2026-08-01",
+      until: "2026-08-08",
+    });
+
+    expect(report.categories.verifiedMergeLandingOwnershipViolations).toEqual({
+      count: 1,
+      ids: [landingKey],
+    });
+    expect(report.invariants).toMatchObject({
+      failures: expect.arrayContaining(["verified_merge_landing_owned"]),
+      passed: false,
+    });
+  });
+
+  test("allows a verified merge landing in its effective PR unit", () => {
+    const evidence = snapshot();
+    evidence.input.changes[0] = {
+      ...evidence.input.changes[0],
+      verifiedMergeLanding: true,
+    };
+
+    const report = buildGitHubWorkUnitCrosswalk(evidence, {
+      since: "2026-08-01",
+      until: "2026-08-08",
+    });
+
+    expect(report.categories.verifiedMergeLandingOwnershipViolations).toEqual({
+      count: 0,
+      ids: [],
+    });
+    expect(report.invariants.failures).not.toContain(
+      "verified_merge_landing_owned"
+    );
   });
 
   test("treats deterministic policy exclusions as complete coverage", () => {

--- a/tests/github-work-unit-store-postgres.test.mjs
+++ b/tests/github-work-unit-store-postgres.test.mjs
@@ -8,12 +8,13 @@ import {
 } from "bun:test";
 import { setTimeout as delay } from "node:timers/promises";
 
-import { and, eq } from "drizzle-orm";
+import { and, eq, inArray } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/postgres-js";
 import { migrate } from "drizzle-orm/postgres-js/migrator";
 import postgres from "postgres";
 
 import { env } from "../src/env.ts";
+import { GITHUB_WORK_UNIT_SUMMARY_POLICY_DIGEST } from "../src/lib/github-work-unit-summary.ts";
 
 setDefaultTimeout(30_000);
 
@@ -73,6 +74,7 @@ describe.skipIf(!dockerAvailable)("GitHub work-unit projection store", () => {
   let completeGitHubWorkUnitProjectionRequest;
   let ensureGitHubWorkUnitProjectionRequest;
   let readPublicGitHubActivityPage;
+  let readGitHubFactualWorkerBacklog;
   let refreshGitHubWorkUnitProjection;
   let requestGitHubWorkUnitProjection;
   let runGitHubActivityWorker;
@@ -147,6 +149,8 @@ describe.skipIf(!dockerAvailable)("GitHub work-unit projection store", () => {
     } = await import("../src/lib/github-work-unit-summary-store.ts"));
     ({ readPublicGitHubActivityPage } =
       await import("../src/lib/github-activity-store.ts"));
+    ({ readGitHubFactualWorkerBacklog } =
+      await import("../src/lib/github-backfill-store.ts"));
     ({ runGitHubActivityWorker } =
       await import("../src/lib/github-activity-worker.ts"));
     ({
@@ -353,6 +357,151 @@ describe.skipIf(!dockerAvailable)("GitHub work-unit projection store", () => {
     }
   });
 
+  test("backfill waits only for incomplete or failed PR evidence", async () => {
+    const backlogRepositoryId = "7093";
+    const nodeId = "PR_backfill_blocker_7093";
+    const versionId = "70930000-0000-4000-8000-000000000001";
+    const baseSha = "c".repeat(40);
+    const headSha = "d".repeat(40);
+    const now = new Date("2026-09-21T12:00:00.000Z");
+    const leaseUntil = new Date("2026-09-21T12:05:00.000Z");
+    const scope = {
+      repositoryId: backlogRepositoryId,
+      sinceAt: new Date("2026-09-01T00:00:00.000Z"),
+      untilAt: new Date("2026-09-30T23:59:59.999Z"),
+    };
+    const readBacklog = async () =>
+      await readGitHubFactualWorkerBacklog({
+        accounts: ["f0rr0"],
+        now,
+        scope,
+      });
+
+    await database.insert(schema.githubRepositories).values({
+      defaultBranch: "main",
+      factsVerifiedAt: now,
+      firstObservedAt: now,
+      fullName: "f0rr0/backfill-blocker-test",
+      id: backlogRepositoryId,
+      lastObservedAt: now,
+      visibility: "public",
+    });
+    await database.insert(schema.githubPullRequests).values({
+      account: "f0rr0",
+      authorUserId: "8574219",
+      baseRepositoryId: backlogRepositoryId,
+      baseSha,
+      changedFiles: 1,
+      commitCount: 1,
+      createdAt: now,
+      headRepositoryId: backlogRepositoryId,
+      headSha,
+      nextReconcileAt: new Date(now.getTime() - 1),
+      nodeId,
+      number: 1,
+      providerUpdatedAt: now,
+      repositoryId: backlogRepositoryId,
+      state: "open",
+      title: "complete evidence",
+      titleSnapshot: "complete evidence",
+      url: "https://github.com/f0rr0/backfill-blocker-test/pull/1",
+    });
+    await database.insert(schema.githubPullRequestVersions).values({
+      baseRepositoryId: backlogRepositoryId,
+      baseSha,
+      commitCount: 1,
+      fileFacts: [fileFact("src/complete.ts")],
+      fileFactsComplete: true,
+      headRepositoryId: backlogRepositoryId,
+      headSha,
+      id: versionId,
+      membershipComplete: true,
+      observedAt: now,
+      providerUpdatedAt: now,
+      pullRequestNodeId: nodeId,
+    });
+    await database.insert(schema.githubPullRequestMemberships).values({
+      commitRepositoryId: backlogRepositoryId,
+      commitSha: headSha,
+      isHead: true,
+      position: 0,
+      versionId,
+    });
+
+    expect((await readBacklog()).pending.pullRequestReconciliation).toBe(0);
+
+    await database
+      .update(schema.githubPullRequests)
+      .set({ nextReconcileAt: leaseUntil, reconcileAttempts: 1 })
+      .where(eq(schema.githubPullRequests.nodeId, nodeId));
+    expect((await readBacklog()).pending.pullRequestReconciliation).toBe(0);
+
+    await database
+      .update(schema.githubPullRequestVersions)
+      .set({ isCurrent: false })
+      .where(eq(schema.githubPullRequestVersions.id, versionId));
+    expect(await readBacklog()).toMatchObject({
+      pending: { pullRequestReconciliation: 1 },
+      retryAt: leaseUntil,
+    });
+
+    await database
+      .update(schema.githubPullRequestVersions)
+      .set({ isCurrent: true, membershipComplete: false })
+      .where(eq(schema.githubPullRequestVersions.id, versionId));
+    expect((await readBacklog()).pending.pullRequestReconciliation).toBe(1);
+
+    await database
+      .update(schema.githubPullRequestVersions)
+      .set({ fileFactsComplete: false, membershipComplete: true })
+      .where(eq(schema.githubPullRequestVersions.id, versionId));
+    expect((await readBacklog()).pending.pullRequestReconciliation).toBe(1);
+
+    await database
+      .update(schema.githubPullRequestVersions)
+      .set({ fileFactsComplete: true })
+      .where(eq(schema.githubPullRequestVersions.id, versionId));
+    await database
+      .update(schema.githubPullRequests)
+      .set({ mergedAt: now, state: "merged", terminalAt: now })
+      .where(eq(schema.githubPullRequests.nodeId, nodeId));
+    expect((await readBacklog()).pending.pullRequestReconciliation).toBe(1);
+
+    await database
+      .update(schema.githubPullRequests)
+      .set({ mergeShaVerifiedAt: now })
+      .where(eq(schema.githubPullRequests.nodeId, nodeId));
+    expect((await readBacklog()).pending.pullRequestReconciliation).toBe(1);
+
+    await database
+      .update(schema.githubPullRequestVersions)
+      .set({ mergeSnapshot: true })
+      .where(eq(schema.githubPullRequestVersions.id, versionId));
+    expect((await readBacklog()).pending.pullRequestReconciliation).toBe(0);
+
+    await database
+      .update(schema.githubPullRequests)
+      .set({ reconcileError: "provider_unavailable" })
+      .where(eq(schema.githubPullRequests.nodeId, nodeId));
+    expect((await readBacklog()).pending.pullRequestReconciliation).toBe(1);
+
+    await database
+      .update(schema.githubPullRequests)
+      .set({ nextReconcileAt: null })
+      .where(eq(schema.githubPullRequests.nodeId, nodeId));
+    expect(await readBacklog()).toMatchObject({
+      pending: { pullRequestReconciliation: 0 },
+      unavailable: 1,
+    });
+
+    await database
+      .delete(schema.githubPullRequests)
+      .where(eq(schema.githubPullRequests.nodeId, nodeId));
+    await database
+      .delete(schema.githubRepositories)
+      .where(eq(schema.githubRepositories.id, backlogRepositoryId));
+  });
+
   test("clears only the projection request token it observed", async () => {
     const first = await requestGitHubWorkUnitProjection(database);
     expect(await ensureGitHubWorkUnitProjectionRequest()).toBe(first);
@@ -369,11 +518,17 @@ describe.skipIf(!dockerAvailable)("GitHub work-unit projection store", () => {
 
     await database
       .update(schema.githubPublicFeedHead)
-      .set({ summaryPolicyDigest: "f".repeat(64) })
+      .set({
+        projectionRequestToken: null,
+        summaryPolicyDigest: GITHUB_WORK_UNIT_SUMMARY_POLICY_DIGEST,
+      })
       .where(eq(schema.githubPublicFeedHead.id, true));
-    expect(await ensureGitHubWorkUnitProjectionRequest()).toMatch(
-      /^[0-9a-f-]{36}$/u
+    const policyUpgrade = await ensureGitHubWorkUnitProjectionRequest();
+    expect(policyUpgrade).toMatch(/^[0-9a-f-]{36}$/u);
+    expect(await completeGitHubWorkUnitProjectionRequest(policyUpgrade)).toBe(
+      true
     );
+    expect(await ensureGitHubWorkUnitProjectionRequest()).toBeNull();
   });
 
   test("atomically swaps public facts, revisions, and summary eligibility", async () => {
@@ -580,7 +735,7 @@ describe.skipIf(!dockerAvailable)("GitHub work-unit projection store", () => {
     await refreshGitHubWorkUnitProjection(new Date("2026-08-30T13:02:00.000Z"));
   });
 
-  test("withholds only a same-repository merged-PR landing until the association clears", async () => {
+  test("does not infer a landing from associations or another repository's verified SHA", async () => {
     const secondObservedAt = new Date("2026-08-30T13:00:00.000Z");
     const foreignBaseRepositoryId = "7009";
     const foreignPullRequestNodeId = "PR_foreign_landing_7001";
@@ -596,11 +751,12 @@ describe.skipIf(!dockerAvailable)("GitHub work-unit projection store", () => {
       account: "f0rr0",
       authorUserId: "9000",
       createdAt: secondObservedAt,
+      mergedAt: secondObservedAt,
       nodeId: pullRequestNodeId,
       number: 71,
       providerUpdatedAt: secondObservedAt,
       repositoryId,
-      state: "closed",
+      state: "merged",
       terminalAt: secondObservedAt,
       title: "associated",
       titleSnapshot: "associated",
@@ -610,6 +766,8 @@ describe.skipIf(!dockerAvailable)("GitHub work-unit projection store", () => {
       account: "f0rr0",
       authorUserId: "9000",
       createdAt: secondObservedAt,
+      mergeSha: secondSha,
+      mergeShaVerifiedAt: secondObservedAt,
       mergedAt: secondObservedAt,
       nodeId: foreignPullRequestNodeId,
       number: 72,
@@ -684,43 +842,77 @@ describe.skipIf(!dockerAvailable)("GitHub work-unit projection store", () => {
       },
     ]);
 
-    const unmerged = await refreshGitHubWorkUnitProjection(secondObservedAt);
-    const [afterUnmergedAssociation] = await database
-      .select()
-      .from(schema.githubWorkUnits);
-    expect(unmerged.exclusionReasonCounts.merged_pr_landing).toBe(0);
-    expect(afterUnmergedAssociation).toMatchObject({ memberCount: 2 });
+    const result = await refreshGitHubWorkUnitProjection(secondObservedAt);
+    const [unit] = await database.select().from(schema.githubWorkUnits);
+    expect(result.exclusionReasonCounts.merged_pr_landing).toBe(0);
+    expect(unit).toMatchObject({ memberCount: 2 });
 
     await database
-      .update(schema.githubPullRequests)
-      .set({ mergedAt: secondObservedAt, state: "merged" })
-      .where(eq(schema.githubPullRequests.nodeId, pullRequestNodeId));
+      .delete(schema.githubPullRequests)
+      .where(
+        inArray(schema.githubPullRequests.nodeId, [
+          pullRequestNodeId,
+          foreignPullRequestNodeId,
+        ])
+      );
+  });
+
+  test("withholds a provider-verified squash landing without a commit association", async () => {
+    const mergedAt = new Date("2026-08-30T13:01:30.000Z");
+    const nodeId = "PR_verified_squash_landing_7001";
+    await database.insert(schema.githubPullRequests).values({
+      account: "f0rr0",
+      authorUserId: "9000",
+      createdAt: mergedAt,
+      mergeSha: secondSha,
+      mergeShaVerifiedAt: mergedAt,
+      mergedAt,
+      nodeId,
+      number: 73,
+      providerUpdatedAt: mergedAt,
+      repositoryId,
+      state: "merged",
+      terminalAt: mergedAt,
+      title: "verified squash landing",
+      titleSnapshot: "verified squash landing",
+      url: "https://github.com/f0rr0/projection-store-test/pull/73",
+    });
+
     const excluded = await refreshGitHubWorkUnitProjection(
-      new Date("2026-08-30T13:00:30.000Z")
+      new Date("2026-08-30T13:01:31.000Z")
     );
-    const [afterMergedAssociation] = await database
+    const [withoutLanding] = await database
       .select()
       .from(schema.githubWorkUnits);
     expect(excluded.exclusionReasonCounts.merged_pr_landing).toBe(1);
-    expect(afterMergedAssociation).toMatchObject({ memberCount: 1 });
+    expect(withoutLanding).toMatchObject({ memberCount: 1 });
 
     await database
-      .delete(schema.githubCommitPullRequestAssociations)
-      .where(
-        and(
-          eq(
-            schema.githubCommitPullRequestAssociations.commitRepositoryId,
-            repositoryId
-          ),
-          eq(schema.githubCommitPullRequestAssociations.commitSha, secondSha)
-        )
-      );
-    const resolved = await refreshGitHubWorkUnitProjection(
-      new Date("2026-08-30T13:01:00.000Z")
+      .update(schema.githubRepositories)
+      .set({ defaultBranch: "trunk" })
+      .where(eq(schema.githubRepositories.id, repositoryId));
+    const sideRefExcluded = await refreshGitHubWorkUnitProjection(
+      new Date("2026-08-30T13:01:31.500Z")
     );
-    const [afterProof] = await database.select().from(schema.githubWorkUnits);
-    expect(resolved.exclusionReasonCounts.merged_pr_landing).toBe(0);
-    expect(afterProof).toMatchObject({ memberCount: 2 });
+    const [withoutSideRefLanding] = await database
+      .select()
+      .from(schema.githubWorkUnits);
+    expect(sideRefExcluded.exclusionReasonCounts.merged_pr_landing).toBe(1);
+    expect(withoutSideRefLanding).toMatchObject({ memberCount: 1 });
+
+    await database
+      .delete(schema.githubPullRequests)
+      .where(eq(schema.githubPullRequests.nodeId, nodeId));
+    await database
+      .update(schema.githubRepositories)
+      .set({ defaultBranch: "main" })
+      .where(eq(schema.githubRepositories.id, repositoryId));
+    const restored = await refreshGitHubWorkUnitProjection(
+      new Date("2026-08-30T13:01:32.000Z")
+    );
+    const [withLanding] = await database.select().from(schema.githubWorkUnits);
+    expect(restored.exclusionReasonCounts.merged_pr_landing).toBe(0);
+    expect(withLanding).toMatchObject({ memberCount: 2 });
   });
 
   test("purges private prose and removes unknown visibility instead of leaking", async () => {
@@ -1307,7 +1499,7 @@ describe.skipIf(!dockerAvailable)("GitHub work-unit projection store", () => {
     expect(unchanged.summaryEvaluatedDigest).toBe(unit.summaryEvaluatedDigest);
   });
 
-  test("an idle worker drains summary evaluation recent-first without clearing a partial request", async () => {
+  test("an idle worker drains a bounded recent-first summary batch without clearing a partial request", async () => {
     const batchRepositoryId = "7092";
     const batchLineageId = "70920000-0000-4000-8000-000000000001";
     const completedAt = new Date("2026-09-10T12:00:00.000Z");

--- a/tests/github-work-unit-summary-worker.test.mjs
+++ b/tests/github-work-unit-summary-worker.test.mjs
@@ -1,0 +1,163 @@
+import { describe, expect, test } from "bun:test";
+
+import { GitHubWorkUnitSummaryInvalidOutputError } from "../src/lib/github-work-unit-summary-provider.ts";
+import { runGitHubWorkUnitSummaryWorker } from "../src/lib/github-work-unit-summary-worker.ts";
+
+const now = new Date("2026-09-01T12:00:00.000Z");
+const claim = Object.freeze({
+  attributionMode: "tracked_authored_pr",
+  leaseToken: "10000000-0000-4000-8000-000000000001",
+  outcomeDigest: "a".repeat(64),
+  revision: 1,
+  serializedInput: '{"evidence":"public"}',
+  startedRequests: 1,
+  summaryInputDigest: "b".repeat(64),
+  workUnitId: "20000000-0000-4000-8000-000000000001",
+});
+const providerResult = Object.freeze({
+  inputTokens: 20,
+  latencyMs: 10,
+  model: "gpt-5.4-nano-2026-03-17",
+  outcome: "Builds the current public outcome.",
+  outputTokens: 8,
+});
+
+const dependenciesFrom = (overrides = {}) => ({
+  claim: async () => claim,
+  complete: async () => ({ accepted: true }),
+  defer: async () => "deferred",
+  generate: async () => providerResult,
+  now: () => new Date(now),
+  providerConfigured: () => true,
+  terminal: async () => true,
+  ...overrides,
+});
+
+describe("GitHub work-unit summary worker", () => {
+  test("claims, generates, and settles one summary in its isolated budget", async () => {
+    let claimed = 0;
+    let completed = 0;
+    let generated = 0;
+    const result = await runGitHubWorkUnitSummaryWorker(
+      58_000,
+      dependenciesFrom({
+        claim: async ({ now: claimedAt }) => {
+          claimed += 1;
+          expect(claimedAt).toEqual(now);
+          return claim;
+        },
+        complete: async (completedClaim, output, completedAt) => {
+          completed += 1;
+          expect(completedClaim).toBe(claim);
+          expect(output).toBe(providerResult);
+          expect(completedAt).toEqual(now);
+          return { accepted: true };
+        },
+        generate: async (request) => {
+          generated += 1;
+          expect(request.serializedInput).toBe(claim.serializedInput);
+          expect(request.deadlineAt).toBeGreaterThan(now.getTime());
+          return providerResult;
+        },
+      })
+    );
+
+    expect({ claimed, completed, generated }).toEqual({
+      claimed: 1,
+      completed: 1,
+      generated: 1,
+    });
+    expect(result).toEqual({
+      claimed: 1,
+      completed: 1,
+      deferred: 0,
+      failed: 0,
+      unavailable: 0,
+    });
+  });
+
+  test("does not claim without a complete provider budget or configuration", async () => {
+    let claims = 0;
+    const dependencies = dependenciesFrom({
+      claim: async () => {
+        claims += 1;
+        return claim;
+      },
+    });
+
+    expect(await runGitHubWorkUnitSummaryWorker(20_000, dependencies)).toEqual({
+      claimed: 0,
+      completed: 0,
+      deferred: 0,
+      failed: 0,
+      unavailable: 0,
+    });
+    expect(
+      await runGitHubWorkUnitSummaryWorker(58_000, {
+        ...dependencies,
+        providerConfigured: () => false,
+      })
+    ).toEqual({
+      claimed: 0,
+      completed: 0,
+      deferred: 0,
+      failed: 0,
+      unavailable: 0,
+    });
+    expect(claims).toBe(0);
+  });
+
+  test("defers one transient provider failure without a second request", async () => {
+    let generated = 0;
+    let deferred = 0;
+    const result = await runGitHubWorkUnitSummaryWorker(
+      58_000,
+      dependenciesFrom({
+        defer: async (deferredClaim, retryAt, deferredAt) => {
+          deferred += 1;
+          expect(deferredClaim).toBe(claim);
+          expect(retryAt.getTime()).toBeGreaterThan(deferredAt.getTime());
+          return "deferred";
+        },
+        generate: async () => {
+          generated += 1;
+          throw new Error("transient provider failure");
+        },
+      })
+    );
+
+    expect({ deferred, generated }).toEqual({ deferred: 1, generated: 1 });
+    expect(result).toMatchObject({
+      claimed: 1,
+      deferred: 1,
+      failed: 0,
+      unavailable: 0,
+    });
+  });
+
+  test("settles invalid provider output as facts-only", async () => {
+    let terminalized = 0;
+    const result = await runGitHubWorkUnitSummaryWorker(
+      58_000,
+      dependenciesFrom({
+        generate: async () => {
+          throw new GitHubWorkUnitSummaryInvalidOutputError("url");
+        },
+        terminal: async (terminalClaim, terminalAt) => {
+          terminalized += 1;
+          expect(terminalClaim).toBe(claim);
+          expect(terminalAt).toEqual(now);
+          return true;
+        },
+      })
+    );
+
+    expect(terminalized).toBe(1);
+    expect(result).toMatchObject({
+      claimed: 1,
+      deferred: 0,
+      failed: 0,
+      unavailable: 1,
+    });
+  });
+});

--- a/tests/production-database-migration.test.mjs
+++ b/tests/production-database-migration.test.mjs
@@ -55,6 +55,7 @@ describe("production Supabase cron URLs", () => {
     expect(supabaseCronUrlsFrom("https://f0rr0.dev")).toEqual({
       events: "https://f0rr0.dev/api/cron/github-sync",
       headRefs: "https://f0rr0.dev/api/cron/github-refs?repositories=8",
+      summary: "https://f0rr0.dev/api/cron/github-summary",
       worker: "https://f0rr0.dev/api/cron/github-worker",
     });
     expect(() => supabaseCronUrlsFrom("http://localhost:3000")).toThrow(


### PR DESCRIPTION
## Summary

- assign commits from authoritative current PR membership and suppress exact verified merge landings from ref-owned work
- make backfill completion depend on factual evidence gaps instead of routine maintenance leases
- separate bounded summary generation from factual projection so recent summaries cannot be starved
- reactivate projection deterministically when ownership or summary policy changes
- extend behavioral and PostgreSQL tests for rewrites, squash merges, repository collisions, backfill, cron topology, and rolling deploys

## Verification

- 280 tests pass
- typecheck, lint, formatting, and production build pass
- August and two weekly production-data crosswalk slices have zero ownership violations, coverage gaps, enrichment backlog, or visibility gaps with the new projector
- current August evidence backlog is empty