### PR TITLE
fix(github): retain summaries while refreshing

### DIFF
--- a/docs/github-activity-work-units.md
+++ b/docs/github-activity-work-units.md
@@ -205,24 +205,17 @@ control/bidirectional characters, URLs, HTML, Markdown, and SHAs.
 Summary identity includes the semantic policy, recipe, prompt, normalized
 input, outcome digest, and attribution mode. Transport retries and storage
 configuration do not invalidate prose. A five-minute debounce absorbs active
-rewrites. Up to eight recent-first inputs are deterministically evaluated per
-projection refresh. A separate bounded worker starts at most one provider claim,
-so a historical evaluation backlog cannot consume the provider request's
-runtime window.
+rewrites. Up to eight newest-first inputs are deterministically evaluated per
+projection refresh. A separate bounded worker starts at most one provider claim.
 Valid output remains cacheable if its input becomes stale while the request
 runs; it is displayed only when the current unit's exact
 recipe, outcome, attribution, and summary-input keys match. A force push with
 the same complete PR net outcome can therefore reuse accepted prose.
 
-Claims are recent-first:
+Claims are ordered by newest activity, then newest observed content:
 
-- recent means activity within the last 30 days;
-- only when no recent claim is ready may one historical request start that UTC
-  day;
 - each attempt may start at most twice;
-- at most 30 requests may start per UTC day and 120 per UTC month; and
-- historical claims reserve two monthly requests for every remaining day in
-  the month.
+- at most 30 requests may start per UTC day and 120 per UTC month.
 
 These limits are application configuration; the database only records usage.
 Started requests count even when they fail. A transient failure waits 15
@@ -263,9 +256,9 @@ Supabase Cron invokes:
 
 The worker processes factual queues and current-ref repair before recomputing
 the projection and reconciling the minimal summary status. The separate summary
-worker may claim one provider request, so historical input reevaluation cannot
-consume its provider budget. Webhooks shorten discovery, but they do not render
-a page directly; publication still waits for the bounded factual worker.
+worker may claim one provider request, with newer work staying ahead of older
+backlog. Webhooks shorten discovery, but they do not render a page directly;
+publication still waits for the bounded factual worker.
 Timeline payloads are read from the current projection and are never held in a
 shared response cache.
 
@@ -323,8 +316,8 @@ paginated inventory can require more than one invocation.
 
 The status endpoint returns the feed revision, a monotone head revision, last
 feed publication time, and one boolean: whether the configured summary pipeline
-has a current, recent public evaluation, queued input, retry, or provider lease
-on the initial five-day page. The next worker reconciliation clears an expired
+has a current public evaluation, queued input, retry, or provider lease on the
+initial five-day page. The next worker reconciliation clears an expired
 abandoned lease. The UI renders only:
 
 - `Shaping the latest update` while that boolean is true;
@@ -335,8 +328,8 @@ abandoned lease. The UI renders only:
 Polling runs while the tab is visible, the browser is online, no refresh is
 pending, and the timeline is in view when the browser supports intersection
 observation. A settled page checks every five minutes at most three times.
-While shaping recent summary work, it checks every three minutes, subject to a total cap of 12
-requests. The private, revalidated endpoint supports ETags; polling budgets
+While shaping summary work, it checks every three minutes, subject to a total cap
+of 12 requests. The private, revalidated endpoint supports ETags; polling budgets
 reset after a successful feed refresh. New content is never inserted while the
 reader is moving through the page; the reader chooses `Show latest work` to
 refresh.
@@ -380,7 +373,7 @@ class names:
 | same-day repository rows                                                | one header and a count derived from final groups      |
 | summary budget/retry/expiry                                             | hard caps and facts-only terminal state               |
 | nine pending summary evaluations                                        | eight settle, then one on the next refresh            |
-| recent summary ready during historical policy reevaluation              | separate summary worker may claim it                  |
+| newer summary ready while older work is queued                          | separate summary worker claims newer work first       |
 | paid input A superseded by B then current again                         | count retained and debounce re-armed                  |
 
 Run the complete local gate with:

--- a/docs/github-commits.md
+++ b/docs/github-commits.md
@@ -35,13 +35,13 @@ The worker leases small batches and can safely resume after a deadline. It:
    evidence, and complete PR net file facts;
 4. recomputes the current work-unit projection from durable evidence and swaps
    units, memberships, and public feed revisions atomically; and
-5. evaluates summary inputs in recent-first batches of eight.
+5. evaluates summary inputs in newest-first batches of eight.
 
 A separate bounded summary worker claims at most one eligible summary.
-Historical input reevaluation therefore cannot consume the provider request's
-runtime budget. Valid output can be cached after becoming stale;
-display still requires exact current recipe, outcome, attribution, and input
-digests.
+Claims are ordered by newest activity, then newest observed content. The newest
+accepted same-attribution summary remains visible after becoming stale until an
+exact current summary replaces it; the item is marked as refreshing while that
+replacement is evaluated, queued, retried, or processed.
 
 Multi-parent merge commits and commits with neither file facts nor churn are not
 separate timeline work. A provider-verified same-repository merge SHA is
@@ -75,9 +75,9 @@ the public feed head; replayed deliveries and unknown visibility do not.
 The public reader groups a repository once per UTC day and reads complete days
 against the current ordered-set revision. `github_public_feed_head` contains
 the monotone feed/content/order revisions, last publication time, a durable
-projection-request token, the applied pipeline-policy digest, and
-whether configured recent initial-page summary work is being evaluated, queued,
-retried, or processed. Evidence writers set the token transactionally;
+projection-request token, the applied pipeline-policy digest, and whether
+configured initial-page summary work is being evaluated, queued, retried, or
+processed. Evidence writers set the token transactionally;
 projection clears the observed token only after its bounded summary-evaluation
 backlog reaches zero. The stored pipeline-policy digest covers both projection
 ownership and summary semantics, so a new worker requests the required refresh

--- a/src/components/github-activity-days.tsx
+++ b/src/components/github-activity-days.tsx
@@ -1,4 +1,10 @@
-import { ChevronRight, CircleDot, Code2, LockKeyhole } from "lucide-react";
+import {
+  ChevronRight,
+  CircleDot,
+  Code2,
+  LoaderCircle,
+  LockKeyhole,
+} from "lucide-react";
 import Image from "next/image";
 
 import {
@@ -158,10 +164,23 @@ function WorkUnitDetails({
           {headline}
         </span>
         <DiffCounters facts={item.facts} />
-        <ChevronRight
-          aria-hidden="true"
-          className="mt-[0.3125rem] size-4 text-muted-foreground transition-transform duration-150 group-open:rotate-90 motion-reduce:transition-none"
-        />
+        <span className="mt-[0.3125rem] inline-flex items-center gap-1 text-muted-foreground">
+          {item.summarizing ? (
+            <span
+              className="inline-flex size-4 items-center justify-center text-primary"
+              title="Refreshing summary"
+            >
+              <span aria-hidden="true" className="motion-safe:animate-spin">
+                <LoaderCircle className="size-3.5" />
+              </span>
+              <span className="sr-only">Refreshing summary</span>
+            </span>
+          ) : null}
+          <ChevronRight
+            aria-hidden="true"
+            className="size-4 transition-transform duration-150 group-open:rotate-90 motion-reduce:transition-none"
+          />
+        </span>
       </summary>
       <div className="mt-2 max-w-[50rem] ps-0 text-sm leading-relaxed text-muted-foreground">
         {item.summary === null ? null : (

--- a/src/lib/github-activity-feed-core.ts
+++ b/src/lib/github-activity-feed-core.ts
@@ -19,6 +19,7 @@ export interface PublicGitHubWorkUnitRow extends PublicRepositoryActivityRow {
   facts: PublicGitHubWorkUnitFacts;
   headline: string | null;
   kind: PublicGitHubWorkUnitKind;
+  summarizing: boolean;
   summary: string | null;
 }
 
@@ -138,6 +139,7 @@ export const buildPublicGitHubActivityDays = (
         headline: row.headline,
         id: row.id,
         kind: row.kind,
+        summarizing: row.summarizing,
         summary: row.summary,
       });
     }

--- a/src/lib/github-activity-store.ts
+++ b/src/lib/github-activity-store.ts
@@ -33,6 +33,7 @@ const MAXIMUM_PUBLIC_ROWS_PER_DAY = 1000;
 const SHA = /^[a-f0-9]{40}$/u;
 const REPOSITORY_OWNER = /^(?!-)[A-Za-z0-9-]{1,39}(?<!-)$/u;
 const REPOSITORY_NAME = /^[A-Za-z0-9._-]{1,100}$/u;
+const ACTIVE_SUMMARY_STATES = new Set(["pending", "processing", "retryable"]);
 
 type GitHubActivityDatabase = Parameters<
   Parameters<ReturnType<typeof getDatabase>["transaction"]>[0]
@@ -286,7 +287,8 @@ const readAvailableDays = async (
 
 const readPublicRows = async (
   database: GitHubActivityDatabase,
-  selectedDays: readonly string[]
+  selectedDays: readonly string[],
+  summariesAreRunning: boolean
 ): Promise<{
   issues: readonly PublicGitHubIssueRow[];
   workUnits: readonly PublicGitHubWorkUnitRow[];
@@ -301,6 +303,7 @@ const readPublicRows = async (
         activityAt: githubWorkUnits.activityAt,
         activityDay: githubWorkUnits.activityDay,
         additions: githubWorkUnits.additions,
+        attributionMode: githubWorkUnits.attributionMode,
         deletions: githubWorkUnits.deletions,
         fileCount: githubWorkUnits.fileCount,
         firstActivityAt: githubWorkUnits.firstActivityAt,
@@ -313,9 +316,13 @@ const readPublicRows = async (
         memberCount: githubWorkUnits.memberCount,
         newestCommitRepositoryId: githubWorkUnits.newestCommitRepositoryId,
         newestCommitSha: githubWorkUnits.newestCommitSha,
+        outcomeDigest: githubWorkUnits.outcomeDigest,
         ownerAvatarUrl: githubRepositories.ownerAvatarUrl,
         pullRequestNumber: githubPullRequests.number,
         repositoryId: githubRepositories.id,
+        summaryEvaluatedDigest: githubWorkUnits.summaryEvaluatedDigest,
+        summaryEvaluationDigest: githubWorkUnits.summaryEvaluationDigest,
+        summaryInputDigest: githubWorkUnits.summaryInputDigest,
         visibility: githubRepositories.visibility,
       })
       .from(githubWorkUnits)
@@ -389,59 +396,107 @@ const readPublicRows = async (
   }
 
   const unitIds = unitRows.map(({ id }) => id);
-  const summaryRows =
+  const [currentSummaryRows, fallbackSummaryRows] =
     unitIds.length === 0
-      ? []
-      : await database
-          .select({
-            outcome: githubWorkUnitSummaryAttempts.outcome,
-            revision: githubWorkUnitSummaryAttempts.revision,
-            workUnitId: githubWorkUnitSummaryAttempts.workUnitId,
-          })
-          .from(githubWorkUnitSummaryAttempts)
-          .innerJoin(
-            githubWorkUnits,
-            and(
-              eq(githubWorkUnitSummaryAttempts.workUnitId, githubWorkUnits.id),
-              eq(
-                githubWorkUnitSummaryAttempts.outcomeDigest,
-                githubWorkUnits.outcomeDigest
-              ),
-              eq(
-                githubWorkUnitSummaryAttempts.summaryInputDigest,
-                githubWorkUnits.summaryInputDigest
-              ),
-              eq(
-                githubWorkUnitSummaryAttempts.attributionMode,
-                githubWorkUnits.attributionMode
+      ? [[], []]
+      : await Promise.all([
+          database
+            .select({
+              outcome: githubWorkUnitSummaryAttempts.outcome,
+              state: githubWorkUnitSummaryAttempts.state,
+              workUnitId: githubWorkUnitSummaryAttempts.workUnitId,
+            })
+            .from(githubWorkUnitSummaryAttempts)
+            .innerJoin(
+              githubWorkUnits,
+              and(
+                eq(
+                  githubWorkUnitSummaryAttempts.workUnitId,
+                  githubWorkUnits.id
+                ),
+                eq(
+                  githubWorkUnitSummaryAttempts.outcomeDigest,
+                  githubWorkUnits.outcomeDigest
+                ),
+                eq(
+                  githubWorkUnitSummaryAttempts.summaryInputDigest,
+                  githubWorkUnits.summaryInputDigest
+                ),
+                eq(
+                  githubWorkUnitSummaryAttempts.attributionMode,
+                  githubWorkUnits.attributionMode
+                )
               )
             )
-          )
-          .where(
-            and(
-              inArray(githubWorkUnitSummaryAttempts.workUnitId, unitIds),
-              eq(
-                githubWorkUnitSummaryAttempts.recipe,
-                GITHUB_WORK_UNIT_SUMMARY_RECIPE
-              ),
-              eq(githubWorkUnitSummaryAttempts.state, "accepted"),
-              isNotNull(githubWorkUnitSummaryAttempts.acceptedAt),
-              isNotNull(githubWorkUnitSummaryAttempts.outcome)
+            .where(
+              and(
+                inArray(githubWorkUnitSummaryAttempts.workUnitId, unitIds),
+                eq(
+                  githubWorkUnitSummaryAttempts.recipe,
+                  GITHUB_WORK_UNIT_SUMMARY_RECIPE
+                )
+              )
             )
-          )
-          .orderBy(
-            githubWorkUnitSummaryAttempts.workUnitId,
-            desc(githubWorkUnitSummaryAttempts.revision)
-          );
-  const summaries = new Map<
+            .orderBy(
+              githubWorkUnitSummaryAttempts.workUnitId,
+              desc(githubWorkUnitSummaryAttempts.revision)
+            ),
+          database
+            .selectDistinctOn([githubWorkUnitSummaryAttempts.workUnitId], {
+              outcome: githubWorkUnitSummaryAttempts.outcome,
+              workUnitId: githubWorkUnitSummaryAttempts.workUnitId,
+            })
+            .from(githubWorkUnitSummaryAttempts)
+            .innerJoin(
+              githubWorkUnits,
+              and(
+                eq(
+                  githubWorkUnitSummaryAttempts.workUnitId,
+                  githubWorkUnits.id
+                ),
+                eq(
+                  githubWorkUnitSummaryAttempts.attributionMode,
+                  githubWorkUnits.attributionMode
+                )
+              )
+            )
+            .where(
+              and(
+                inArray(githubWorkUnitSummaryAttempts.workUnitId, unitIds),
+                eq(githubWorkUnitSummaryAttempts.state, "accepted"),
+                isNotNull(githubWorkUnitSummaryAttempts.acceptedAt),
+                isNotNull(githubWorkUnitSummaryAttempts.outcome)
+              )
+            )
+            .orderBy(
+              githubWorkUnitSummaryAttempts.workUnitId,
+              desc(githubWorkUnitSummaryAttempts.revision)
+            ),
+        ]);
+  const currentSummaries = new Map<
     string,
     Readonly<{ headline: string; summary: string | null }>
   >();
-  for (const summary of summaryRows) {
-    if (!summaries.has(summary.workUnitId) && summary.outcome !== null) {
+  const summarizingUnits = new Set<string>();
+  for (const summary of currentSummaryRows) {
+    if (ACTIVE_SUMMARY_STATES.has(summary.state)) {
+      summarizingUnits.add(summary.workUnitId);
+    } else if (summary.outcome !== null) {
       const decoded = decodeGitHubWorkUnitSummary(summary.outcome);
       if (decoded !== null) {
-        summaries.set(summary.workUnitId, decoded);
+        currentSummaries.set(summary.workUnitId, decoded);
+      }
+    }
+  }
+  const fallbackSummaries = new Map<
+    string,
+    Readonly<{ headline: string; summary: string | null }>
+  >();
+  for (const summary of fallbackSummaryRows) {
+    if (summary.outcome !== null) {
+      const decoded = decodeGitHubWorkUnitSummary(summary.outcome);
+      if (decoded !== null) {
+        fallbackSummaries.set(summary.workUnitId, decoded);
       }
     }
   }
@@ -483,7 +538,8 @@ const readPublicRows = async (
     }
     const firstDay = row.firstActivityAt.toISOString().slice(0, 10);
     const lastDay = row.lastActivityAt.toISOString().slice(0, 10);
-    const summary = summaries.get(row.id);
+    const summary =
+      currentSummaries.get(row.id) ?? fallbackSummaries.get(row.id);
     return {
       activityAt: row.activityAt.toISOString(),
       day: row.activityDay,
@@ -501,6 +557,11 @@ const readPublicRows = async (
       headline: summary?.headline ?? null,
       kind,
       repository: repository.projection,
+      summarizing:
+        summarizingUnits.has(row.id) ||
+        (summariesAreRunning &&
+          row.summaryEvaluationDigest !== null &&
+          row.summaryEvaluationDigest !== row.summaryEvaluatedDigest),
       summary: summary?.summary ?? null,
     };
   });
@@ -546,7 +607,11 @@ const readPublicGitHubActivityPageInTransaction = async (
     cursor,
     pageSize
   );
-  const { issues, workUnits } = await readPublicRows(database, selectedDays);
+  const { issues, workUnits } = await readPublicRows(
+    database,
+    selectedDays,
+    head.summarizing
+  );
   const days = buildPublicGitHubActivityDays({
     days: selectedDays,
     issues,

--- a/src/lib/github-activity-types.ts
+++ b/src/lib/github-activity-types.ts
@@ -35,6 +35,7 @@ export interface PublicGitHubWorkUnitActivity {
   id: string;
   kind: PublicGitHubWorkUnitKind;
   headline: string | null;
+  summarizing: boolean;
   summary: string | null;
 }
 

--- a/src/lib/github-cron-config.ts
+++ b/src/lib/github-cron-config.ts
@@ -16,7 +16,6 @@ export const GITHUB_SUMMARY_CRON_JOB = {
 export const GITHUB_SUMMARY_REQUEST_BUDGET = {
   daily: 30,
   monthly: 120,
-  recentReservePerRemainingDay: 2,
 } as const;
 
 export const GITHUB_HEAD_REFS_CRON_JOB = {

--- a/src/lib/github-work-unit-summary-store.ts
+++ b/src/lib/github-work-unit-summary-store.ts
@@ -34,12 +34,9 @@ import type { GitHubWorkUnitSummaryProviderResult } from "@/lib/github-work-unit
 const SUMMARY_CLAIM_LOCK = "github-work-unit-summary-claim-v1";
 const DEFAULT_LEASE_DURATION_MS = 90_000;
 const MAXIMUM_LEASE_DURATION_MS = 15 * 60_000;
-const RECENT_WINDOW_MS = 30 * 24 * 60 * 60_000;
 const MAXIMUM_STARTED_REQUESTS = 2;
 const MAXIMUM_DAILY_STARTED_REQUESTS = GITHUB_SUMMARY_REQUEST_BUDGET.daily;
 const MAXIMUM_MONTHLY_STARTED_REQUESTS = GITHUB_SUMMARY_REQUEST_BUDGET.monthly;
-const RESERVED_RECENT_REQUESTS_PER_FUTURE_DAY =
-  GITHUB_SUMMARY_REQUEST_BUDGET.recentReservePerRemainingDay;
 const DIGEST = /^[a-f0-9]{64}$/u;
 const UUID =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/iu;
@@ -329,9 +326,7 @@ type ClaimCandidate = Awaited<ReturnType<typeof selectClaimCandidate>>;
 
 async function selectClaimCandidate(
   transaction: SummaryTransaction,
-  now: Date,
-  recentSince: Date,
-  lane: "historical" | "recent"
+  now: Date
 ) {
   const [candidate] = await transaction
     .select(claimSelection)
@@ -368,10 +363,7 @@ async function selectClaimCandidate(
         eq(
           githubWorkUnits.attributionMode,
           githubWorkUnitSummaryAttempts.attributionMode
-        ),
-        lane === "recent"
-          ? gte(githubWorkUnits.activityAt, recentSince)
-          : lt(githubWorkUnits.activityAt, recentSince)
+        )
       )
     )
     .orderBy(
@@ -390,7 +382,6 @@ const lockedUnit = async (
 ) => {
   const [unit] = await transaction
     .select({
-      activityAt: githubWorkUnits.activityAt,
       activityDay: githubWorkUnits.activityDay,
       attributionMode: githubWorkUnits.attributionMode,
       outcomeDigest: githubWorkUnits.outcomeDigest,
@@ -436,9 +427,7 @@ const candidateRemainsClaimable = (
   attempt: NonNullable<Awaited<ReturnType<typeof lockedAttempt>>>,
   unit: NonNullable<Awaited<ReturnType<typeof lockedUnit>>>,
   candidate: NonNullable<ClaimCandidate>,
-  now: Date,
-  recentSince: Date,
-  lane: "historical" | "recent"
+  now: Date
 ) =>
   attempt.state === candidate.state &&
   (attempt.state === "pending" || attempt.state === "retryable") &&
@@ -448,27 +437,15 @@ const candidateRemainsClaimable = (
   attempt.startedRequests < MAXIMUM_STARTED_REQUESTS &&
   candidate.debounceUntil.getTime() <= now.getTime() &&
   attempt.recipe === GITHUB_WORK_UNIT_SUMMARY_RECIPE &&
-  currentUnitMatchesAttempt(unit, attempt) &&
-  (lane === "recent"
-    ? unit.activityAt.getTime() >= recentSince.getTime()
-    : unit.activityAt.getTime() < recentSince.getTime());
-
-const utcDayBounds = (now: Date) => {
-  const start = new Date(
-    Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate())
-  );
-  return { end: new Date(start.getTime() + 24 * 60 * 60_000), start };
-};
+  currentUnitMatchesAttempt(unit, attempt);
 
 const utcUsageWindow = (now: Date) => {
   const year = now.getUTCFullYear();
   const month = now.getUTCMonth();
   const monthStart = new Date(Date.UTC(year, month, 1));
   const nextMonthStart = new Date(Date.UTC(year, month + 1, 1));
-  const daysInMonth = new Date(nextMonthStart.getTime() - 1).getUTCDate();
   return {
     day: now.toISOString().slice(0, 10),
-    futureDays: daysInMonth - now.getUTCDate(),
     monthStart: monthStart.toISOString().slice(0, 10),
     nextMonthStart: nextMonthStart.toISOString().slice(0, 10),
   };
@@ -511,13 +488,6 @@ const hasRequestCapacity = (usage: SummaryUsage) =>
   usage.dailyStartedRequests < MAXIMUM_DAILY_STARTED_REQUESTS &&
   usage.monthlyStartedRequests < MAXIMUM_MONTHLY_STARTED_REQUESTS;
 
-const hasHistoricalRequestCapacity = (usage: SummaryUsage) =>
-  hasRequestCapacity(usage) &&
-  usage.monthlyStartedRequests +
-    1 +
-    usage.futureDays * RESERVED_RECENT_REQUESTS_PER_FUTURE_DAY <=
-    MAXIMUM_MONTHLY_STARTED_REQUESTS;
-
 const recordStartedRequest = async (
   transaction: SummaryTransaction,
   usage: SummaryUsage
@@ -539,35 +509,11 @@ const recordStartedRequest = async (
   }
 };
 
-const historicalStartExistsToday = async (
-  transaction: SummaryTransaction,
-  now: Date
-) => {
-  const { end, start } = utcDayBounds(now);
-  const [row] = await transaction
-    .select({ value: sql<number>`count(*)::integer` })
-    .from(githubWorkUnitSummaryAttempts)
-    .innerJoin(
-      githubWorkUnits,
-      eq(githubWorkUnitSummaryAttempts.workUnitId, githubWorkUnits.id)
-    )
-    .where(
-      and(
-        gte(githubWorkUnitSummaryAttempts.lastStartedAt, start),
-        lt(githubWorkUnitSummaryAttempts.lastStartedAt, end),
-        sql`${githubWorkUnits.activityAt} < ${githubWorkUnitSummaryAttempts.lastStartedAt} - interval '30 days'`
-      )
-    );
-  return (row?.value ?? 0) > 0;
-};
-
 const tryClaimCandidate = async (
   transaction: SummaryTransaction,
   candidate: NonNullable<ClaimCandidate>,
   now: Date,
   leaseDurationMs: number,
-  recentSince: Date,
-  lane: "historical" | "recent",
   usage: SummaryUsage
 ): Promise<GitHubWorkUnitSummaryClaim | null> => {
   // The projection store locks units before attempts. Keep the same order.
@@ -582,7 +528,7 @@ const tryClaimCandidate = async (
   );
   if (
     attempt === null ||
-    !candidateRemainsClaimable(attempt, unit, candidate, now, recentSince, lane)
+    !candidateRemainsClaimable(attempt, unit, candidate, now)
   ) {
     return null;
   }
@@ -749,10 +695,6 @@ async function hasCurrentInitialPageSummaryWork(
           "private",
           "internal",
         ]),
-        gte(
-          githubWorkUnits.activityAt,
-          new Date(now.getTime() - RECENT_WINDOW_MS)
-        ),
         inArray(githubWorkUnits.activityDay, [...initialPageDays]),
         or(
           and(
@@ -863,50 +805,21 @@ export const claimGitHubWorkUnitSummary = async (
 ): Promise<GitHubWorkUnitSummaryClaim | null> => {
   const now = checkedDate(options.now ?? new Date(), "claim timestamp");
   const leaseDurationMs = checkedLeaseDuration(options.leaseDurationMs);
-  const recentSince = new Date(now.getTime() - RECENT_WINDOW_MS);
   return await getDatabase().transaction(async (transaction) => {
     await acquireSummaryStateLocks(transaction);
     await recoverExpiredClaims(transaction, now);
     const usage = await readSummaryUsage(transaction, now);
     let claim: GitHubWorkUnitSummaryClaim | null = null;
     if (hasRequestCapacity(usage)) {
-      const recent = await selectClaimCandidate(
-        transaction,
-        now,
-        recentSince,
-        "recent"
-      );
-      if (recent !== null) {
+      const candidate = await selectClaimCandidate(transaction, now);
+      if (candidate !== null) {
         claim = await tryClaimCandidate(
           transaction,
-          recent,
+          candidate,
           now,
           leaseDurationMs,
-          recentSince,
-          "recent",
           usage
         );
-      } else if (
-        hasHistoricalRequestCapacity(usage) &&
-        !(await historicalStartExistsToday(transaction, now))
-      ) {
-        const historical = await selectClaimCandidate(
-          transaction,
-          now,
-          recentSince,
-          "historical"
-        );
-        if (historical !== null) {
-          claim = await tryClaimCandidate(
-            transaction,
-            historical,
-            now,
-            leaseDurationMs,
-            recentSince,
-            "historical",
-            usage
-          );
-        }
       }
     }
     const initialPageDays = await readInitialPageDays(transaction);

--- a/tests/github-activity-feed-core.test.mjs
+++ b/tests/github-activity-feed-core.test.mjs
@@ -1,5 +1,9 @@
 import { describe, expect, test } from "bun:test";
 
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { GitHubActivityDays } from "../src/components/github-activity-days.tsx";
 import { buildPublicGitHubActivityDays } from "../src/lib/github-activity-feed-core.ts";
 
 const repository = (key, label = key) => ({
@@ -30,6 +34,7 @@ const work = (id, activityAt, repositoryIdentity) => ({
   id,
   kind: "pull-request",
   repository: repositoryIdentity,
+  summarizing: false,
   summary: null,
 });
 
@@ -59,6 +64,7 @@ describe("public GitHub activity day projection", () => {
               headline: null,
               id: "newer",
               kind: "pull-request",
+              summarizing: false,
               summary: null,
             },
             {
@@ -70,6 +76,7 @@ describe("public GitHub activity day projection", () => {
               headline: null,
               id: "older",
               kind: "pull-request",
+              summarizing: false,
               summary: null,
             },
           ],
@@ -77,6 +84,34 @@ describe("public GitHub activity day projection", () => {
         },
       ],
     });
+  });
+
+  test("marks a stale summary while its replacement is running", () => {
+    const item = {
+      ...work(
+        "refreshing",
+        "2026-08-28T12:00:00.000Z",
+        repository("42", "example/repository")
+      ),
+      facts: { ...facts, languages: null },
+      headline: "Previous headline",
+      summarizing: true,
+      summary: "Previous summary remains visible.",
+    };
+    const html = renderToStaticMarkup(
+      createElement(GitHubActivityDays, {
+        days: [
+          {
+            day: "2026-08-28",
+            repositories: [{ items: [item], repository: item.repository }],
+          },
+        ],
+      })
+    );
+
+    expect(html).toContain("Previous summary remains visible.");
+    expect(html).toContain('title="Refreshing summary"');
+    expect(html).toContain("motion-safe:animate-spin");
   });
 
   test("rejects rows outside the requested complete-day page", () => {

--- a/tests/github-activity-feed-postgres.test.mjs
+++ b/tests/github-activity-feed-postgres.test.mjs
@@ -207,7 +207,7 @@ describe.skipIf(!dockerAvailable)("GitHub work-unit feed projection", () => {
           '00000000-0000-4000-8000-000000000105',
           'branch:10000000-0000-4000-8000-000000000201', 'branch', null,
           '2026-08-30T09:00:00Z', 4, ${digest("b")}, '201', ${sha("e")},
-          ${digest("c")}, null, '201', 1, null, 'private'
+          ${digest("c")}, null, '201', 1, ${digest("8")}, 'private'
         ),
         (
           '2026-08-31T09:00:00Z', '2026-08-31T09:00:00Z', '2026-08-31',
@@ -269,15 +269,15 @@ describe.skipIf(!dockerAvailable)("GitHub work-unit feed projection", () => {
         (
           '2026-08-30T12:03:00Z', 'tracked_authored_pr',
           '2026-08-30T12:03:00Z', '2026-08-30T12:00:00Z',
-          'Stale outcome must remain hidden.', ${digest("b")},
+          'Earlier summary stays available.', ${digest("b")},
           ${GITHUB_WORK_UNIT_SUMMARY_RECIPE}, 2, 'accepted', ${digest("2")},
           '00000000-0000-4000-8000-000000000101'
         ),
         (
           '2026-08-30T12:04:00Z', 'tracked_authored_pr',
           '2026-08-30T12:04:00Z', '2026-08-30T12:00:00Z',
-          'Stale input must remain hidden.', ${digest("a")},
-          ${GITHUB_WORK_UNIT_SUMMARY_RECIPE}, 3, 'accepted', ${digest("3")},
+          'Previous summary stays visible.', ${digest("a")},
+          'github-work-unit-outcome-v1', 3, 'accepted', ${digest("3")},
           '00000000-0000-4000-8000-000000000101'
         ),
         (
@@ -286,6 +286,17 @@ describe.skipIf(!dockerAvailable)("GitHub work-unit feed projection", () => {
           'Wrong attribution must remain hidden.', ${digest("a")},
           'corrupt-mode-test', 4, 'accepted', ${digest("1")},
           '00000000-0000-4000-8000-000000000101'
+        ),
+        (
+          '2026-08-30T12:06:00Z', 'branch_owned_composite',
+          '2026-08-30T12:06:00Z', '2026-08-30T12:00:00Z',
+          ${encodeGitHubWorkUnitSummary({
+            headline: "Summarizes private work",
+            summary:
+              "The private work summary remains useful without exposing repository identity.",
+          })}, ${digest("c")},
+          ${GITHUB_WORK_UNIT_SUMMARY_RECIPE}, 1, 'accepted', ${digest("9")},
+          '00000000-0000-4000-8000-000000000105'
         )
     `;
     await admin`
@@ -348,6 +359,11 @@ describe.skipIf(!dockerAvailable)("GitHub work-unit feed projection", () => {
         ({ destination }) => destination === null
       )
     ).toBe(true);
+    expect(firstPage.days[0]?.repositories[1]?.items[0]).toMatchObject({
+      headline: "Summarizes private work",
+      summary:
+        "The private work summary remains useful without exposing repository identity.",
+    });
     expect(firstPage.days[1]?.repositories).toHaveLength(1);
     expect(firstPage.days[1]?.repositories[0]?.items).toHaveLength(2);
 
@@ -395,7 +411,39 @@ describe.skipIf(!dockerAvailable)("GitHub work-unit feed projection", () => {
         uniqueFileCount: 4,
       },
       headline: "Explains the pull request outcome",
+      summarizing: false,
       summary: "The expanded summary explains the complete outcome.",
+    });
+  });
+
+  test("reuses a stale summary while the current one is pending", async () => {
+    await admin`
+      update github_work_units set
+        summary_evaluated_digest = ${digest("4")},
+        summary_evaluation_digest = ${digest("4")},
+        summary_input_digest = ${digest("4")}
+      where id = '00000000-0000-4000-8000-000000000101'
+    `;
+    await admin`
+      insert into github_work_unit_summary_attempts (
+        attribution_mode, debounce_until, outcome_digest, recipe,
+        request_payload, revision, state, summary_input_digest, work_unit_id
+      ) values (
+        'tracked_authored_pr', '2026-08-30T12:07:00Z', ${digest("a")},
+        ${GITHUB_WORK_UNIT_SUMMARY_RECIPE}, '{}', 5, 'pending', ${digest("4")},
+        '00000000-0000-4000-8000-000000000101'
+      )
+    `;
+
+    const page = await readPublicGitHubActivityPage(null, 2);
+    const pullRequest = page.days[0]?.repositories[0]?.items.find(
+      ({ kind }) => kind === "pull-request"
+    );
+
+    expect(pullRequest).toMatchObject({
+      headline: "Previous summary stays visible.",
+      summarizing: true,
+      summary: null,
     });
   });
 

--- a/tests/github-work-unit-store-postgres.test.mjs
+++ b/tests/github-work-unit-store-postgres.test.mjs
@@ -1513,7 +1513,7 @@ describe.skipIf(!dockerAvailable)("GitHub work-unit projection store", () => {
     expect(unchanged.summaryEvaluatedDigest).toBe(unit.summaryEvaluatedDigest);
   });
 
-  test("an idle worker drains a bounded recent-first summary batch without clearing a partial request", async () => {
+  test("an idle worker drains a bounded newest-first summary batch without clearing a partial request", async () => {
     const batchRepositoryId = "7092";
     const batchLineageId = "70920000-0000-4000-8000-000000000001";
     const completedAt = new Date("2026-09-10T12:00:00.000Z");

--- a/tests/github-work-unit-summary-store.test.mjs
+++ b/tests/github-work-unit-summary-store.test.mjs
@@ -274,7 +274,7 @@ describe.skipIf(!dockerAvailable)("GitHub work-unit summary store", () => {
     }
   });
 
-  test("claims current recent work newest-first and never claims a stale digest", async () => {
+  test("claims current work by newest activity then newest content", async () => {
     const now = new Date("2026-09-01T12:00:00.000Z");
     const stale = await seedUnit({
       activityAt: new Date("2026-09-01T11:30:00.000Z"),
@@ -287,13 +287,15 @@ describe.skipIf(!dockerAvailable)("GitHub work-unit summary store", () => {
     `;
     const newest = await seedUnit({
       activityAt: new Date("2026-08-31T10:00:00.000Z"),
+      contentObservedAt: new Date("2026-09-01T11:30:00.000Z"),
       debounceUntil: new Date("2026-09-01T11:00:00.000Z"),
     });
     const older = await seedUnit({
-      activityAt: new Date("2026-08-30T10:00:00.000Z"),
+      activityAt: new Date("2026-08-31T10:00:00.000Z"),
+      contentObservedAt: new Date("2026-09-01T10:30:00.000Z"),
       debounceUntil: new Date("2026-09-01T11:00:00.000Z"),
     });
-    await seedUnit({
+    const historical = await seedUnit({
       activityAt: new Date("2026-07-01T10:00:00.000Z"),
       debounceUntil: new Date("2026-09-01T11:00:00.000Z"),
     });
@@ -317,6 +319,10 @@ describe.skipIf(!dockerAvailable)("GitHub work-unit summary store", () => {
       serializedInput: older.payload,
       workUnitId: older.workUnitId,
     });
+    expect(await terminalGitHubWorkUnitSummary(second, now)).toBe(true);
+
+    const third = await claimGitHubWorkUnitSummary({ now });
+    expect(third).toMatchObject({ workUnitId: historical.workUnitId });
     expect(await readAttempt(stale)).toBeUndefined();
   });
 
@@ -485,62 +491,6 @@ describe.skipIf(!dockerAvailable)("GitHub work-unit summary store", () => {
     expect(usage).toEqual({ monthly: 120 });
   });
 
-  test("admits historical work at the exact future-day reserve boundary", async () => {
-    const now = new Date("2026-09-20T12:00:00.000Z");
-    await seedUsage(
-      Array.from({ length: 9 }, (_, index) => ({
-        day: `2026-09-${String(index + 1).padStart(2, "0")}`,
-        startedRequests: 11,
-      }))
-    );
-    const historical = await seedUnit({
-      activityAt: new Date("2026-07-01T12:00:00.000Z"),
-      debounceUntil: new Date("2026-09-20T11:00:00.000Z"),
-    });
-
-    expect(await claimGitHubWorkUnitSummary({ now })).toMatchObject({
-      workUnitId: historical.workUnitId,
-    });
-    const [usage] = await admin`
-      select sum(started_requests)::integer as monthly
-      from github_work_unit_summary_daily_usage
-    `;
-    expect(usage).toEqual({ monthly: 100 });
-    expect(await readHead()).toMatchObject({
-      head_content_revision: "0",
-      summarizing: false,
-    });
-  });
-
-  test("reserves future capacity from historical work without blocking recent work", async () => {
-    const now = new Date("2026-09-20T12:00:00.000Z");
-    await seedUsage([
-      ...Array.from({ length: 9 }, (_, index) => ({
-        day: `2026-09-${String(index + 1).padStart(2, "0")}`,
-        startedRequests: 11,
-      })),
-      { day: "2026-09-10", startedRequests: 1 },
-    ]);
-    await seedUnit({
-      activityAt: new Date("2026-07-01T12:00:00.000Z"),
-      debounceUntil: new Date("2026-09-20T11:00:00.000Z"),
-    });
-
-    expect(await claimGitHubWorkUnitSummary({ now })).toBeNull();
-    const recent = await seedUnit({
-      activityAt: new Date("2026-09-19T12:00:00.000Z"),
-      debounceUntil: new Date("2026-09-20T11:00:00.000Z"),
-    });
-    expect(await claimGitHubWorkUnitSummary({ now })).toMatchObject({
-      workUnitId: recent.workUnitId,
-    });
-    const [usage] = await admin`
-      select sum(started_requests)::integer as monthly
-      from github_work_unit_summary_daily_usage
-    `;
-    expect(usage).toEqual({ monthly: 101 });
-  });
-
   test("recovers expired leases once and settles facts-only at two starts", async () => {
     const now = new Date("2026-09-01T12:00:00.000Z");
     const exhausted = await seedUnit({
@@ -594,46 +544,7 @@ describe.skipIf(!dockerAvailable)("GitHub work-unit summary store", () => {
     expect(await claimGitHubWorkUnitSummary({ now })).toBeNull();
   });
 
-  test("permits one historical start per UTC day without delaying recent work", async () => {
-    const now = new Date("2026-09-01T12:00:00.000Z");
-    const newestHistorical = await seedUnit({
-      activityAt: new Date("2026-07-20T12:00:00.000Z"),
-      debounceUntil: new Date("2026-09-01T11:00:00.000Z"),
-    });
-    await seedUnit({
-      activityAt: new Date("2026-07-10T12:00:00.000Z"),
-      debounceUntil: new Date("2026-09-01T11:00:00.000Z"),
-    });
-
-    const first = await claimGitHubWorkUnitSummary({ now });
-    expect(first).toMatchObject({ workUnitId: newestHistorical.workUnitId });
-    expect(
-      await deferGitHubWorkUnitSummary(
-        first,
-        new Date("2026-09-02T00:00:00.000Z"),
-        now
-      )
-    ).toBe("deferred");
-    expect(await claimGitHubWorkUnitSummary({ now })).toBeNull();
-
-    const recent = await seedUnit({
-      activityAt: new Date("2026-08-31T12:00:00.000Z"),
-      debounceUntil: new Date("2026-09-01T11:00:00.000Z"),
-    });
-    const foreground = await claimGitHubWorkUnitSummary({ now });
-    expect(foreground).toMatchObject({ workUnitId: recent.workUnitId });
-    expect(await terminalGitHubWorkUnitSummary(foreground, now)).toBe(true);
-    expect(await claimGitHubWorkUnitSummary({ now })).toBeNull();
-
-    const nextDay = new Date("2026-09-02T00:01:00.000Z");
-    const retried = await claimGitHubWorkUnitSummary({ now: nextDay });
-    expect(retried).toMatchObject({
-      startedRequests: 2,
-      workUnitId: newestHistorical.workUnitId,
-    });
-  });
-
-  test("presents recent queued work but not historical work as active", async () => {
+  test("presents queued initial-page work regardless of age", async () => {
     const now = new Date("2026-09-06T12:00:00.000Z");
     await seedUnit({
       activityAt: new Date("2026-07-01T10:00:00.000Z"),
@@ -645,16 +556,6 @@ describe.skipIf(!dockerAvailable)("GitHub work-unit summary store", () => {
       state: "processing",
     });
 
-    expect(await reconcileGitHubWorkUnitSummaryStatus(now)).toBe(false);
-    expect(await readHead()).toMatchObject({
-      head_content_revision: "0",
-      summarizing: false,
-    });
-
-    await seedUnit({
-      activityAt: new Date("2026-09-06T10:00:00.000Z"),
-      debounceUntil: new Date("2026-09-06T13:00:00.000Z"),
-    });
     expect(await reconcileGitHubWorkUnitSummaryStatus(now)).toBe(true);
     expect(await readHead()).toMatchObject({
       head_content_revision: "1",
@@ -669,7 +570,7 @@ describe.skipIf(!dockerAvailable)("GitHub work-unit summary store", () => {
     }
   });
 
-  test("presents a recent initial-page reevaluation before its input is built", async () => {
+  test("presents an initial-page reevaluation before its input is built", async () => {
     const now = new Date("2026-09-06T12:00:00.000Z");
     const unit = await seedUnit({
       activityAt: new Date("2026-09-06T10:00:00.000Z"),


### PR DESCRIPTION
## Summary

- keep the newest compatible accepted summary visible while its replacement is generated, with an accessible per-item spinner
- summarize private work through the same pipeline while preserving repository redaction at the public boundary
- prioritize all eligible summaries by newest activity, then newest observed content, without a 30-day historical lane

## Testing

- bun run format:check
- bun run typecheck
- bun run lint
- bun test (282 pass)
- bun run build