### PR TITLE
ci: remove production build from validation

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -28,6 +28,3 @@ jobs:
 
       - name: Test
         run: bun test
-
-      - name: Production build
-        run: bun run build


### PR DESCRIPTION
## Summary

- remove the production build step from pull-request validation
- keep lint, Typst formatting, type checking, and tests unchanged

## Testing

- bun run format:check