### PR TITLE
fix(github): raise summary limits and remove spinner

### DIFF
--- a/docs/github-activity-work-units.md
+++ b/docs/github-activity-work-units.md
@@ -215,7 +215,7 @@ the same complete PR net outcome can therefore reuse accepted prose.
 Claims are ordered by newest activity, then newest observed content:
 
 - each attempt may start at most twice;
-- at most 30 requests may start per UTC day and 120 per UTC month.
+- at most 100 requests may start per UTC day and 300 per UTC month.
 
 These limits are application configuration; the database only records usage.
 Started requests count even when they fail. A transient failure waits 15
@@ -229,7 +229,7 @@ current again. Expired leases are recovered by the next worker.
 summary claim is started. This is not an OpenAI free-tier design. At the
 [model's documented price](https://developers.openai.com/api/docs/models/gpt-5.4-nano)
 of $0.20/M input tokens and $1.25/M output tokens, the hard monthly maximum is
-`120 * (32,000 * $0.20/M + 160 * $1.25/M) = $0.792`.
+`300 * (32,000 * $0.20/M + 160 * $1.25/M) = $1.98`.
 
 ## Intake and cadence
 

--- a/src/components/github-activity-days.tsx
+++ b/src/components/github-activity-days.tsx
@@ -1,10 +1,4 @@
-import {
-  ChevronRight,
-  CircleDot,
-  Code2,
-  LoaderCircle,
-  LockKeyhole,
-} from "lucide-react";
+import { ChevronRight, CircleDot, Code2, LockKeyhole } from "lucide-react";
 import Image from "next/image";
 
 import {
@@ -165,17 +159,6 @@ function WorkUnitDetails({
         </span>
         <DiffCounters facts={item.facts} />
         <span className="mt-[0.3125rem] inline-flex items-center gap-1 text-muted-foreground">
-          {item.summarizing ? (
-            <span
-              className="inline-flex size-4 items-center justify-center text-primary"
-              title="Refreshing summary"
-            >
-              <span aria-hidden="true" className="motion-safe:animate-spin">
-                <LoaderCircle className="size-3.5" />
-              </span>
-              <span className="sr-only">Refreshing summary</span>
-            </span>
-          ) : null}
           <ChevronRight
             aria-hidden="true"
             className="size-4 transition-transform duration-150 group-open:rotate-90 motion-reduce:transition-none"

--- a/src/lib/github-cron-config.ts
+++ b/src/lib/github-cron-config.ts
@@ -14,8 +14,8 @@ export const GITHUB_SUMMARY_CRON_JOB = {
 } as const;
 
 export const GITHUB_SUMMARY_REQUEST_BUDGET = {
-  daily: 30,
-  monthly: 120,
+  daily: 100,
+  monthly: 300,
 } as const;
 
 export const GITHUB_HEAD_REFS_CRON_JOB = {

--- a/tests/github-activity-feed-core.test.mjs
+++ b/tests/github-activity-feed-core.test.mjs
@@ -86,7 +86,7 @@ describe("public GitHub activity day projection", () => {
     });
   });
 
-  test("marks a stale summary while its replacement is running", () => {
+  test("keeps a stale summary visible without a processing indicator", () => {
     const item = {
       ...work(
         "refreshing",
@@ -110,8 +110,8 @@ describe("public GitHub activity day projection", () => {
     );
 
     expect(html).toContain("Previous summary remains visible.");
-    expect(html).toContain('title="Refreshing summary"');
-    expect(html).toContain("motion-safe:animate-spin");
+    expect(html).not.toContain("Refreshing summary");
+    expect(html).not.toContain("animate-spin");
   });
 
   test("rejects rows outside the requested complete-day page", () => {

--- a/tests/github-cron-config.test.mjs
+++ b/tests/github-cron-config.test.mjs
@@ -74,7 +74,8 @@ describe("GitHub cron configuration", () => {
     expect(GITHUB_WORKER_HTTP_TIMEOUT_MS).toBe(
       GITHUB_WORKER_MAX_DURATION_SECONDS * 1000
     );
-    expect(GITHUB_SUMMARY_REQUEST_BUDGET.daily).toBe(30);
+    expect(GITHUB_SUMMARY_REQUEST_BUDGET.daily).toBe(100);
+    expect(GITHUB_SUMMARY_REQUEST_BUDGET.monthly).toBe(300);
     expect(githubRefRepositoryLimitFrom(null)).toBe(8);
     expect(githubRefRepositoryLimitFrom("1")).toBe(1);
     expect(githubRefRepositoryLimitFrom("8")).toBe(8);

--- a/tests/github-work-unit-summary-store.test.mjs
+++ b/tests/github-work-unit-summary-store.test.mjs
@@ -435,7 +435,7 @@ describe.skipIf(!dockerAvailable)("GitHub work-unit summary store", () => {
 
   test("serializes concurrent claims at the configured UTC-day cap", async () => {
     const now = new Date("2026-09-01T12:00:00.000Z");
-    await seedUsage([{ day: "2026-09-01", startedRequests: 29 }]);
+    await seedUsage([{ day: "2026-09-01", startedRequests: 99 }]);
     for (const hour of [11, 10, 9]) {
       await seedUnit({
         activityAt: new Date(
@@ -452,7 +452,7 @@ describe.skipIf(!dockerAvailable)("GitHub work-unit summary store", () => {
     ]);
     expect(claims.filter((claim) => claim !== null)).toHaveLength(1);
     expect(await readUsage()).toEqual([
-      { day: "2026-09-01", started_requests: 30 },
+      { day: "2026-09-01", started_requests: 100 },
     ]);
     const [states] = await admin`
       select
@@ -463,12 +463,12 @@ describe.skipIf(!dockerAvailable)("GitHub work-unit summary store", () => {
     expect(states).toEqual({ pending: 2, processing: 1 });
   });
 
-  test("stops at the 120-request UTC-month boundary", async () => {
+  test("stops at the 300-request UTC-month boundary", async () => {
     const now = new Date("2026-09-30T12:00:00.000Z");
     await seedUsage([
       ...Array.from({ length: 10 }, (_, index) => ({
         day: `2026-09-${String(index + 1).padStart(2, "0")}`,
-        startedRequests: 11,
+        startedRequests: 29,
       })),
       { day: "2026-09-30", startedRequests: 9 },
     ]);
@@ -488,7 +488,7 @@ describe.skipIf(!dockerAvailable)("GitHub work-unit summary store", () => {
       from github_work_unit_summary_daily_usage
       where day >= '2026-09-01' and day < '2026-10-01'
     `;
-    expect(usage).toEqual({ monthly: 120 });
+    expect(usage).toEqual({ monthly: 300 });
   });
 
   test("recovers expired leases once and settles facts-only at two starts", async () => {


### PR DESCRIPTION
## Summary

- raise GitHub summary limits to 100 requests per UTC day and 300 per UTC month
- remove the per-work-unit refreshing-summary spinner
- update budget documentation and boundary coverage

## Checks

- bun test tests/github-cron-config.test.mjs tests/github-activity-feed-core.test.mjs tests/github-work-unit-summary-store.test.mjs
- bun run typecheck
- bun run lint
- git diff --check