### PR TITLE
feat: add work log

### DIFF
--- a/src/app/(portfolio)/page.tsx
+++ b/src/app/(portfolio)/page.tsx
@@ -14,7 +14,7 @@ import { getGitHubProfile } from "@/lib/github-profile";
 import { publicUrl, siteConfig } from "@/lib/site";
 
 const description =
-  "Sid Jain is an applied AI engineer building useful, durable products and production systems. Explore his open-source work, GitHub activity, and writing.";
+  "Sid Jain is an applied AI engineer building useful, durable products and production systems. Explore his open-source work, Work Log, and writing.";
 
 export const metadata: Metadata = {
   alternates: {
@@ -119,7 +119,7 @@ export default async function Home() {
           </div>
         </section>
 
-        <GitHubTimeline initialPage={activity} />
+        <GitHubTimeline initialPage={activity} preview />
 
         {codexStats === null ? null : <CodexStats stats={codexStats} />}
 

--- a/src/app/(portfolio)/work-log/page.tsx
+++ b/src/app/(portfolio)/work-log/page.tsx
@@ -1,0 +1,42 @@
+import type { Metadata } from "next";
+
+import { GitHubTimeline } from "@/components/github-timeline";
+import { SiteShell } from "@/components/site-shell";
+import { getInitialGitHubActivity } from "@/lib/github-activity-feed";
+import { publicUrl, siteConfig } from "@/lib/site";
+
+const description =
+  "A day-by-day record of what Sid Jain is building, fixing, and shipping.";
+
+export const metadata: Metadata = {
+  alternates: { canonical: "/work-log" },
+  description,
+  openGraph: {
+    description,
+    locale: siteConfig.locale,
+    siteName: siteConfig.name,
+    title: "Sid Jain Work Log",
+    type: "website",
+    url: publicUrl("/work-log"),
+  },
+  title: "Work Log",
+  twitter: {
+    card: "summary",
+    description,
+    title: "Sid Jain Work Log",
+  },
+};
+
+export const dynamic = "force-dynamic";
+
+export default async function WorkLogPage() {
+  const activity = await getInitialGitHubActivity();
+
+  return (
+    <SiteShell currentPath="/work-log" includeFooter>
+      <main className="site-container pb-20 pt-8 sm:pb-24 sm:pt-12">
+        <GitHubTimeline initialPage={activity} />
+      </main>
+    </SiteShell>
+  );
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -30,6 +30,11 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       url: publicUrl("/resume"),
     },
     {
+      changeFrequency: "daily",
+      priority: 0.9,
+      url: publicUrl("/work-log"),
+    },
+    {
       changeFrequency: "weekly",
       lastModified: resumeUpdatedAt,
       priority: 0.8,

--- a/src/components/codex-stats.tsx
+++ b/src/components/codex-stats.tsx
@@ -220,7 +220,7 @@ export function CodexStats({ stats }: { stats: PublicCodexStats }) {
         className="font-serif text-2xl font-bold tracking-tight text-foreground sm:text-3xl"
         id="codex-stats-title"
       >
-        AI, in numbers
+        Token Log
       </h2>
 
       <dl className="mt-8 grid grid-cols-2 gap-x-6 gap-y-6 sm:grid-cols-4">

--- a/src/components/github-activity-days.tsx
+++ b/src/components/github-activity-days.tsx
@@ -2,6 +2,11 @@ import { ChevronRight, CircleDot, Code2, LockKeyhole } from "lucide-react";
 import Image from "next/image";
 
 import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible";
+import {
   Tooltip,
   TooltipContent,
   TooltipProvider,
@@ -69,7 +74,7 @@ function RepositoryIdentity({
 }: Readonly<{ repository: PublicGitHubActivityRepository }>) {
   if (repository.label === null || repository.url === null) {
     return (
-      <span className="inline-flex min-w-0 items-center gap-2.5 font-mono text-xs text-muted-foreground">
+      <span className="inline-flex min-h-[1.375rem] min-w-0 items-center gap-2.5 font-mono text-xs text-muted-foreground">
         {repository.avatarUrl === null ? (
           <LockKeyhole aria-hidden="true" className="size-3" />
         ) : (
@@ -101,7 +106,7 @@ function RepositoryIdentity({
   }
   return (
     <a
-      className="inline-flex min-w-0 items-center gap-2.5 rounded-sm font-mono text-xs text-muted-foreground transition-colors duration-150 hover:text-brand-hover focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-ring motion-reduce:transition-none"
+      className="inline-flex min-h-[1.375rem] min-w-0 items-center gap-2.5 font-mono text-xs text-muted-foreground transition-colors duration-150 hover:text-brand-hover focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-ring motion-reduce:transition-none"
       href={repository.url}
       rel="noopener noreferrer"
       target="_blank"
@@ -109,16 +114,16 @@ function RepositoryIdentity({
       {repository.avatarUrl === null ? null : (
         <span
           aria-hidden="true"
-          className="size-5 flex-none overflow-hidden rounded-full bg-muted"
+          className="size-[1.375rem] flex-none overflow-hidden rounded-full bg-muted"
         >
           <Image
             alt=""
             className="size-full object-cover"
-            height={20}
-            sizes="20px"
+            height={22}
+            sizes="22px"
             src={repository.avatarUrl}
             unoptimized
-            width={20}
+            width={22}
           />
         </span>
       )}
@@ -152,70 +157,74 @@ function WorkUnitDetails({
   const commits = `${countFormatter.format(item.facts.ownedCommitCount)} ${item.facts.ownedCommitCount === 1 ? "commit" : "commits"}`;
   const files = `${countFormatter.format(item.facts.uniqueFileCount)} ${item.facts.uniqueFileCount === 1 ? "file" : "files"}`;
   return (
-    <details className="group min-w-0">
-      <summary className="grid min-h-6 cursor-pointer list-none grid-cols-[minmax(0,1fr)_auto_auto] items-start gap-3 text-foreground focus-visible:rounded-sm focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring [&::-webkit-details-marker]:hidden">
-        <span className="truncate text-base leading-relaxed group-open:overflow-visible group-open:wrap-anywhere group-open:text-clip group-open:whitespace-normal">
+    <Collapsible className="min-w-0">
+      <CollapsibleTrigger className="group/details grid min-h-6 w-full cursor-pointer grid-cols-[minmax(0,1fr)_auto_auto] items-start gap-3 text-start text-foreground focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring">
+        <span className="truncate text-base leading-relaxed group-data-panel-open/details:overflow-visible group-data-panel-open/details:wrap-anywhere group-data-panel-open/details:text-clip group-data-panel-open/details:whitespace-normal">
           {headline}
         </span>
         <DiffCounters facts={item.facts} />
         <span className="mt-[0.3125rem] inline-flex items-center gap-1 text-muted-foreground">
           <ChevronRight
             aria-hidden="true"
-            className="size-4 transition-transform duration-150 group-open:rotate-90 motion-reduce:transition-none"
+            className="size-4 transition-transform duration-150 group-data-panel-open/details:rotate-90 motion-reduce:transition-none"
           />
         </span>
-      </summary>
-      <div className="mt-2 max-w-[50rem] ps-0 text-sm leading-relaxed text-muted-foreground">
-        {item.summary === null ? null : (
-          <p className="wrap-anywhere">{item.summary}</p>
-        )}
-        <p className={item.summary === null ? undefined : "mt-2"}>
-          {commits} touching {files}
-          {item.facts.languages === null ||
-          item.facts.languages.length === 0 ? null : (
-            <TooltipProvider>
-              <span
-                aria-label="Languages"
-                className="relative -top-[0.5px] ms-1.5 inline-flex items-center gap-0.5 align-middle"
-                role="group"
-              >
-                {item.facts.languages.map((language) => {
-                  const slug = languageIconSlugs[language];
-                  return (
-                    <Tooltip key={language}>
-                      <TooltipTrigger
-                        render={
-                          <button
-                            aria-label={language}
-                            className="inline-flex size-5 cursor-help items-center justify-center rounded-sm focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-ring"
-                            type="button"
-                          />
-                        }
-                      >
-                        {slug === undefined ? (
-                          <Code2 aria-hidden="true" className="size-3.5" />
-                        ) : (
-                          <Image
-                            alt=""
-                            className="opacity-[0.82] dark:invert"
-                            height={14}
-                            sizes="14px"
-                            src={`https://cdn.jsdelivr.net/npm/simple-icons@16.12.0/icons/${slug}.svg`}
-                            unoptimized
-                            width={14}
-                          />
-                        )}
-                      </TooltipTrigger>
-                      <TooltipContent side="bottom">{language}</TooltipContent>
-                    </Tooltip>
-                  );
-                })}
-              </span>
-            </TooltipProvider>
+      </CollapsibleTrigger>
+      <CollapsibleContent hiddenUntilFound>
+        <div className="max-w-[50rem] pt-2 ps-0 text-sm leading-relaxed text-muted-foreground">
+          {item.summary === null ? null : (
+            <p className="wrap-anywhere">{item.summary}</p>
           )}
-        </p>
-      </div>
-    </details>
+          <p className={item.summary === null ? undefined : "mt-2"}>
+            {commits} touching {files}
+            {item.facts.languages === null ||
+            item.facts.languages.length === 0 ? null : (
+              <TooltipProvider>
+                <span
+                  aria-label="Languages"
+                  className="relative -top-[0.5px] ms-1.5 inline-flex items-center gap-0.5 align-middle"
+                  role="group"
+                >
+                  {item.facts.languages.map((language) => {
+                    const slug = languageIconSlugs[language];
+                    return (
+                      <Tooltip key={language}>
+                        <TooltipTrigger
+                          render={
+                            <button
+                              aria-label={language}
+                              className="inline-flex size-6 cursor-help items-center justify-center focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-ring"
+                              type="button"
+                            />
+                          }
+                        >
+                          {slug === undefined ? (
+                            <Code2 aria-hidden="true" className="size-3.5" />
+                          ) : (
+                            <Image
+                              alt=""
+                              className="size-3.5 opacity-[0.82] dark:invert"
+                              height={14}
+                              sizes="14px"
+                              src={`https://cdn.jsdelivr.net/npm/simple-icons@16.12.0/icons/${slug}.svg`}
+                              unoptimized
+                              width={14}
+                            />
+                          )}
+                        </TooltipTrigger>
+                        <TooltipContent side="bottom">
+                          {language}
+                        </TooltipContent>
+                      </Tooltip>
+                    );
+                  })}
+                </span>
+              </TooltipProvider>
+            )}
+          </p>
+        </div>
+      </CollapsibleContent>
+    </Collapsible>
   );
 }
 
@@ -223,7 +232,7 @@ function WorkUnitRow({
   item,
 }: Readonly<{ item: PublicGitHubWorkUnitActivity }>) {
   return (
-    <li className="py-3">
+    <li className="py-1.5">
       <article>
         <WorkUnitDetails item={item} />
       </article>
@@ -237,7 +246,7 @@ function IssueRow({
   item: Extract<PublicGitHubActivityItem, { kind: "issue-opened" }>;
 }>) {
   return (
-    <li className="py-3">
+    <li className="py-1.5">
       <article className="grid grid-cols-[minmax(0,1fr)_auto] items-start gap-4">
         <p className="max-w-[50rem] wrap-anywhere text-base leading-relaxed text-foreground">
           {item.title}
@@ -245,7 +254,7 @@ function IssueRow({
         {item.destination === null ? null : (
           <a
             aria-label={`Issue opened: ${item.destination.label}`}
-            className="mt-0.5 inline-flex size-6 items-center justify-center rounded-sm text-muted-foreground transition-colors duration-150 hover:text-brand-hover focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring motion-reduce:transition-none"
+            className="mt-0.5 inline-flex size-6 items-center justify-center text-muted-foreground transition-colors duration-150 hover:text-brand-hover focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring motion-reduce:transition-none"
             href={item.destination.url}
             rel="noopener noreferrer"
             target="_blank"
@@ -268,18 +277,48 @@ function ActivityItem({ item }: Readonly<{ item: PublicGitHubActivityItem }>) {
 
 function RepositoryGroup({
   group,
-}: Readonly<{ group: PublicGitHubActivityRepositoryGroup }>) {
+  itemLimit,
+}: Readonly<{
+  group: PublicGitHubActivityRepositoryGroup;
+  itemLimit?: number;
+}>) {
+  const visibleItems =
+    itemLimit === undefined ? group.items : group.items.slice(0, itemLimit);
+  const hiddenItems = group.items.slice(visibleItems.length);
   return (
-    <li className="border-b border-border py-5 [contain-intrinsic-size:auto_10rem] [content-visibility:auto]">
+    <li className="pt-4 pb-1.5 first:pt-0 last:pb-0">
       <article aria-label={`${group.repository.label ?? "Private"} activity`}>
-        <header>
+        <header className="flex">
           <RepositoryIdentity repository={group.repository} />
         </header>
-        <ol className="mt-1 divide-y divide-border/60">
-          {group.items.map((item) => (
+        <ol className="pt-2.5">
+          {visibleItems.map((item) => (
             <ActivityItem item={item} key={item.id} />
           ))}
         </ol>
+        {hiddenItems.length === 0 ? null : (
+          <Collapsible>
+            <CollapsibleContent>
+              <ol>
+                {hiddenItems.map((item) => (
+                  <ActivityItem item={item} key={item.id} />
+                ))}
+              </ol>
+            </CollapsibleContent>
+            <CollapsibleTrigger className="group/more inline-flex min-h-8 items-center gap-1.5 font-ui text-[0.8125rem] text-muted-foreground transition-colors duration-150 hover:text-brand-hover focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring motion-reduce:transition-none">
+              <ChevronRight
+                aria-hidden="true"
+                className="-ms-1.5 size-4 transition-transform duration-150 group-data-panel-open/more:rotate-90 motion-reduce:transition-none"
+              />
+              <span className="group-data-panel-open/more:hidden">
+                Show {countFormatter.format(hiddenItems.length)} more
+              </span>
+              <span className="hidden group-data-panel-open/more:inline">
+                Show less
+              </span>
+            </CollapsibleTrigger>
+          </Collapsible>
+        )}
       </article>
     </li>
   );
@@ -287,7 +326,8 @@ function RepositoryGroup({
 
 function GitHubActivityDay({
   day,
-}: Readonly<{ day: PublicGitHubActivityDay }>) {
+  itemLimit,
+}: Readonly<{ day: PublicGitHubActivityDay; itemLimit?: number }>) {
   const repositoryCount = day.repositories.length;
   const workUnits = day.repositories
     .flatMap(({ items }) => items)
@@ -305,11 +345,8 @@ function GitHubActivityDay({
     0
   );
   return (
-    <section
-      aria-labelledby={`activity-day-${day.day}`}
-      className="[contain-intrinsic-size:auto_28rem] [content-visibility:auto]"
-    >
-      <header className="flex flex-wrap items-baseline justify-between gap-x-4 gap-y-2">
+    <section aria-labelledby={`activity-day-${day.day}`}>
+      <header className="flex flex-wrap items-baseline justify-between gap-x-4 gap-y-2 border-y border-border py-3">
         <h3 className="font-mono text-[0.6875rem] font-medium tracking-[0.11em] text-muted-foreground uppercase">
           <time dateTime={day.day} id={`activity-day-${day.day}`}>
             {dayFormatter.format(new Date(`${day.day}T00:00:00.000Z`))}
@@ -343,9 +380,13 @@ function GitHubActivityDay({
           </div>
         </dl>
       </header>
-      <ol aria-label={`Activity for ${day.day}`} className="mt-2">
+      <ol aria-label={`Activity for ${day.day}`} className="mt-7">
         {day.repositories.map((group) => (
-          <RepositoryGroup group={group} key={group.repository.key} />
+          <RepositoryGroup
+            group={group}
+            itemLimit={itemLimit}
+            key={group.repository.key}
+          />
         ))}
       </ol>
     </section>
@@ -354,6 +395,12 @@ function GitHubActivityDay({
 
 export function GitHubActivityDays({
   days,
-}: Readonly<{ days: readonly PublicGitHubActivityDay[] }>) {
-  return days.map((day) => <GitHubActivityDay day={day} key={day.day} />);
+  itemLimit,
+}: Readonly<{
+  days: readonly PublicGitHubActivityDay[];
+  itemLimit?: number;
+}>) {
+  return days.map((day) => (
+    <GitHubActivityDay day={day} itemLimit={itemLimit} key={day.day} />
+  ));
 }

--- a/src/components/github-activity-status.tsx
+++ b/src/components/github-activity-status.tsx
@@ -274,7 +274,7 @@ export function GitHubActivityStatus({
     >
       {latestAvailable ? (
         <button
-          className="mt-4 inline-flex min-h-6 items-center gap-1.5 rounded-sm font-mono text-[0.6875rem] text-primary transition-colors duration-150 hover:text-brand-hover focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring motion-reduce:transition-none"
+          className="mt-4 inline-flex min-h-6 items-center gap-1.5 font-mono text-[0.6875rem] text-primary transition-colors duration-150 hover:text-brand-hover focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring motion-reduce:transition-none"
           disabled={isRefreshing}
           onClick={refreshLatest}
           type="button"

--- a/src/components/github-timeline.tsx
+++ b/src/components/github-timeline.tsx
@@ -1,3 +1,5 @@
+import Link from "next/link";
+
 import { GitHubActivityDays } from "@/components/github-activity-days";
 import {
   GitHubActivityLiveProvider,
@@ -8,33 +10,59 @@ import type { PublicGitHubActivityPage } from "@/lib/github-activity-types";
 
 export function GitHubTimeline({
   initialPage,
-}: Readonly<{ initialPage: PublicGitHubActivityPage }>) {
+  preview = false,
+}: Readonly<{ initialPage: PublicGitHubActivityPage; preview?: boolean }>) {
+  const Heading = preview ? "h2" : "h1";
+  const days = preview ? initialPage.days.slice(0, 3) : initialPage.days;
   return (
     <section
       aria-labelledby="timeline-title"
-      className="home-section"
+      className={preview ? "home-section" : undefined}
       id="timeline"
     >
-      <h2
-        className="font-serif text-2xl font-bold tracking-tight text-foreground sm:text-3xl"
-        id="timeline-title"
-      >
-        GitHub activity
-      </h2>
+      <div className="flex items-baseline justify-between gap-4">
+        <Heading
+          className={
+            preview
+              ? "font-serif text-2xl font-bold tracking-tight text-foreground sm:text-3xl"
+              : "font-serif text-3xl font-bold tracking-tight text-foreground sm:text-4xl"
+          }
+          id="timeline-title"
+        >
+          Work Log
+        </Heading>
+        {preview ? (
+          <Link
+            className="shrink-0 font-ui text-sm text-muted-foreground transition-colors hover:text-brand-hover focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-ring"
+            href="/work-log"
+            prefetch={false}
+          >
+            All work
+          </Link>
+        ) : null}
+      </div>
+      {preview ? null : (
+        <p className="mt-3 max-w-2xl text-base leading-relaxed text-muted-foreground sm:text-lg">
+          A day-by-day record of what I’m building, fixing, and shipping.
+        </p>
+      )}
 
       <GitHubActivityLiveProvider
         feedRevision={initialPage.head.feedRevision}
         orderingRevision={initialPage.orderingRevision}
       >
         <GitHubActivityStatus initialHead={initialPage.head} />
-        {initialPage.days.length === 0 ? (
+        {days.length === 0 ? (
           <p className="mt-6 border-y border-border py-5 text-sm leading-relaxed text-muted-foreground">
             No work is currently visible.
           </p>
         ) : (
-          <div className="mt-6 grid gap-[clamp(2.75rem,6vw,4.5rem)]">
-            <GitHubActivityDays days={initialPage.days} />
-            {initialPage.nextCursor === null ? null : (
+          <div className="mt-4 grid gap-4">
+            <GitHubActivityDays
+              days={days}
+              itemLimit={preview ? 2 : undefined}
+            />
+            {preview || initialPage.nextCursor === null ? null : (
               <GitHubTimelinePager
                 initialCursor={initialPage.nextCursor}
                 key={`${initialPage.head.feedRevision}:${initialPage.orderingRevision}`}

--- a/src/components/site-header.tsx
+++ b/src/components/site-header.tsx
@@ -8,7 +8,7 @@ import { SiteMobileMenu } from "./site-mobile-menu";
 
 interface SiteHeaderProps {
   activeHref?: "/blog" | "/resume";
-  currentPath?: "/" | "/blog" | "/resume";
+  currentPath?: "/" | "/blog" | "/resume" | "/work-log";
 }
 
 export function SiteHeader({

--- a/src/components/site-mobile-menu.tsx
+++ b/src/components/site-mobile-menu.tsx
@@ -9,7 +9,7 @@ export function SiteMobileMenu({
   navItems,
 }: Readonly<{
   activeHref?: "/blog" | "/resume";
-  currentPath: "/" | "/blog" | "/resume";
+  currentPath: "/" | "/blog" | "/resume" | "/work-log";
   navItems: readonly ResumeNavItem[];
 }>) {
   return (

--- a/src/components/site-shell.tsx
+++ b/src/components/site-shell.tsx
@@ -6,7 +6,7 @@ import { SiteHeader } from "@/components/site-header";
 interface SiteShellProps {
   activeHref?: "/blog" | "/resume";
   children: ReactNode;
-  currentPath?: "/" | "/blog" | "/resume";
+  currentPath?: "/" | "/blog" | "/resume" | "/work-log";
   includeFooter?: boolean;
 }
 

--- a/src/components/ui/collapsible.tsx
+++ b/src/components/ui/collapsible.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import { Collapsible as CollapsiblePrimitive } from "@base-ui/react/collapsible";
+
+import { cn } from "@/lib/utils";
+
+function Collapsible({ ...props }: CollapsiblePrimitive.Root.Props) {
+  return <CollapsiblePrimitive.Root data-slot="collapsible" {...props} />;
+}
+
+function CollapsibleTrigger({ ...props }: CollapsiblePrimitive.Trigger.Props) {
+  return (
+    <CollapsiblePrimitive.Trigger data-slot="collapsible-trigger" {...props} />
+  );
+}
+
+function CollapsibleContent({
+  className,
+  ...props
+}: CollapsiblePrimitive.Panel.Props) {
+  return (
+    <CollapsiblePrimitive.Panel
+      className={cn(
+        "h-[var(--collapsible-panel-height)] overflow-hidden data-ending-style:h-0 data-starting-style:h-0 motion-safe:transition-[height] motion-safe:duration-150 motion-safe:ease-out [&[hidden]:not([hidden='until-found'])]:hidden",
+        className
+      )}
+      data-slot="collapsible-content"
+      {...props}
+    />
+  );
+}
+
+export { Collapsible, CollapsibleTrigger, CollapsibleContent };


### PR DESCRIPTION
## Summary

- rename GitHub activity to Work Log and AI, in numbers to Token Log
- add a dedicated /work-log page and a three-day homepage preview
- add animated disclosure for work details and per-repository overflow
- refine spacing, alignment, and hierarchy across the activity feed

## Testing

- bun run lint
- bun run typecheck
- bun test (285 tests)