### PR TITLE
fix(github): raise monthly summary limit

### DIFF
--- a/docs/github-activity-work-units.md
+++ b/docs/github-activity-work-units.md
@@ -222,7 +222,7 @@ changing the activity anchor.
 Claims are ordered by newest activity, then newest observed content:
 
 - each attempt may start at most twice;
-- at most 100 requests may start per UTC day and 300 per UTC month.
+- at most 100 requests may start per UTC day and 3,000 per UTC month.
 
 These limits are application configuration; the database only records usage.
 Started requests count even when they fail. A transient failure waits 15
@@ -236,7 +236,7 @@ current again. Expired leases are recovered by the next worker.
 summary claim is started. This is not an OpenAI free-tier design. At the
 [model's documented price](https://developers.openai.com/api/docs/models/gpt-5.4-nano)
 of $0.20/M input tokens and $1.25/M output tokens, the hard monthly maximum is
-`300 * (32,000 * $0.20/M + 160 * $1.25/M) = $1.98`.
+`3,000 * (32,000 * $0.20/M + 160 * $1.25/M) = $19.80`.
 
 ## Intake and cadence
 

--- a/src/lib/github-cron-config.ts
+++ b/src/lib/github-cron-config.ts
@@ -15,7 +15,7 @@ export const GITHUB_SUMMARY_CRON_JOB = {
 
 export const GITHUB_SUMMARY_REQUEST_BUDGET = {
   daily: 100,
-  monthly: 300,
+  monthly: 3000,
 } as const;
 
 export const GITHUB_HEAD_REFS_CRON_JOB = {

--- a/tests/github-cron-config.test.mjs
+++ b/tests/github-cron-config.test.mjs
@@ -75,7 +75,7 @@ describe("GitHub cron configuration", () => {
       GITHUB_WORKER_MAX_DURATION_SECONDS * 1000
     );
     expect(GITHUB_SUMMARY_REQUEST_BUDGET.daily).toBe(100);
-    expect(GITHUB_SUMMARY_REQUEST_BUDGET.monthly).toBe(300);
+    expect(GITHUB_SUMMARY_REQUEST_BUDGET.monthly).toBe(3000);
     expect(githubRefRepositoryLimitFrom(null)).toBe(8);
     expect(githubRefRepositoryLimitFrom("1")).toBe(1);
     expect(githubRefRepositoryLimitFrom("8")).toBe(8);

--- a/tests/github-work-unit-summary-store.test.mjs
+++ b/tests/github-work-unit-summary-store.test.mjs
@@ -464,14 +464,14 @@ describe.skipIf(!dockerAvailable)("GitHub work-unit summary store", () => {
     expect(states).toEqual({ pending: 2, processing: 1 });
   });
 
-  test("stops at the 300-request UTC-month boundary", async () => {
+  test("stops at the 3000-request UTC-month boundary", async () => {
     const now = new Date("2026-09-30T12:00:00.000Z");
     await seedUsage([
-      ...Array.from({ length: 10 }, (_, index) => ({
+      ...Array.from({ length: 29 }, (_, index) => ({
         day: `2026-09-${String(index + 1).padStart(2, "0")}`,
-        startedRequests: 29,
+        startedRequests: 100,
       })),
-      { day: "2026-09-30", startedRequests: 9 },
+      { day: "2026-09-30", startedRequests: 99 },
     ]);
     await seedUnit({
       activityAt: new Date("2026-09-30T11:00:00.000Z"),
@@ -489,7 +489,7 @@ describe.skipIf(!dockerAvailable)("GitHub work-unit summary store", () => {
       from github_work_unit_summary_daily_usage
       where day >= '2026-09-01' and day < '2026-10-01'
     `;
-    expect(usage).toEqual({ monthly: 300 });
+    expect(usage).toEqual({ monthly: 3000 });
   });
 
   test("recovers expired leases once and settles facts-only at two starts", async () => {


### PR DESCRIPTION
## Summary
- raise the monthly GitHub summary request cap from 300 to 3,000
- update the cap-boundary regression test and documented maximum cost

## Tests
- bun test tests/github-cron-config.test.mjs tests/github-work-unit-summary-store.test.mjs
- pre-push formatting, lint, and typecheck