### PR TITLE
fix: smooth journey, accordion, and overlay animations

### DIFF
--- a/scripts/check-site-motion.mjs
+++ b/scripts/check-site-motion.mjs
@@ -1,0 +1,165 @@
+// Run against a local dev server: bun scripts/check-site-motion.mjs http://localhost:3000
+// Uses an existing Playwright installation (or PLAYWRIGHT_MODULE) and optional CHROMIUM_EXECUTABLE.
+import assert from "node:assert/strict";
+
+const { chromium } = await import(
+  process.env.PLAYWRIGHT_MODULE ?? "playwright"
+);
+const browser = await chromium.launch({
+  executablePath: process.env.CHROMIUM_EXECUTABLE,
+  headless: true,
+});
+const errors = [];
+
+try {
+  for (const width of [1280, 390, 320]) {
+    const page = await browser.newPage({ viewport: { width, height: 844 } });
+    page.on("pageerror", (error) => errors.push(error.message));
+    await page.goto(new URL("/journey", process.argv[2]).href);
+    const toggle = page.getByRole("button", { name: "Details", exact: true });
+    await toggle.waitFor();
+    await page.evaluate(async () => {
+      await document.fonts.ready;
+    });
+    // Let hydration attach the interaction and Motion's layout measurements.
+    await page.waitForTimeout(300);
+
+    const titleCount = await page.locator(".journey-role-title").count();
+    const { heights, pointSamples } = await toggle.evaluate(async (button) => {
+      const content = document.querySelector(
+        `#${CSS.escape(button.getAttribute("aria-controls"))}`
+      );
+      const viewport = content.parentElement;
+      const samples = [viewport.getBoundingClientRect().height];
+      const pointSamples = [];
+      button.click();
+      const start = performance.now();
+      while (performance.now() - start < 700) {
+        // Frame sampling needs the browser's callback-based animation clock.
+        // oxlint-disable-next-line promise/avoid-new
+        await new Promise((resolve) => {
+          requestAnimationFrame(() => {
+            resolve();
+          });
+        });
+        samples.push(viewport.getBoundingClientRect().height);
+        const first = content.querySelector(".journey-role-detail li");
+        const last = content.querySelector(
+          ".journey-role-detail li:last-child"
+        );
+        if (first !== null && last !== null) {
+          pointSamples.push([
+            Number(getComputedStyle(first).opacity),
+            Number(getComputedStyle(last).opacity),
+          ]);
+        }
+      }
+      return { heights: samples, pointSamples };
+    });
+    const travel = heights.at(-1) - heights[0];
+    assert.ok(travel > 100, "Journey should expand");
+    assert.ok(
+      pointSamples.some(([first, last]) => first > last + 0.1),
+      "Supporting points should reveal in reading order"
+    );
+    assert.deepEqual(
+      pointSamples.at(-1),
+      [1, 1],
+      "The cascade must finish without leaving content faded"
+    );
+    assert.ok(
+      heights
+        .slice(1)
+        .every(
+          (height, index) => Math.abs(height - heights[index]) < travel * 0.5
+        ),
+      "Journey's document height should animate instead of snapping"
+    );
+    assert.ok((await page.locator(".journey-role-detail").count()) > 0);
+    assert.ok(
+      await page.evaluate(
+        () => document.documentElement.scrollWidth <= innerWidth
+      )
+    );
+
+    // Interrupt both opening and closing; the final click must always win.
+    for (let i = 0; i < 4; i += 1) {
+      await toggle.evaluate((button) => button.click());
+      await page.waitForTimeout(40);
+    }
+    await page.waitForTimeout(700);
+    assert.equal(await toggle.getAttribute("aria-expanded"), "true");
+    assert.ok(
+      await page
+        .locator(".journey-role-detail li")
+        .evaluateAll((points) =>
+          points.every((point) => getComputedStyle(point).opacity === "1")
+        ),
+      "Reversing a reveal must not strand partially faded points"
+    );
+    await toggle.click();
+    await page.waitForTimeout(400);
+    assert.equal(await toggle.getAttribute("aria-expanded"), "false");
+    assert.equal(await page.locator(".journey-role-detail").count(), 0);
+    assert.equal(await page.locator(".journey-role-title").count(), titleCount);
+
+    // Keyboard activation and reduced motion must retain the same content.
+    await page.emulateMedia({ reducedMotion: "reduce" });
+    await page.reload();
+    await toggle.waitFor();
+    await page.waitForTimeout(300);
+    await toggle.focus();
+    await page.keyboard.press("Enter");
+    await page.waitForTimeout(100);
+    assert.equal(await toggle.getAttribute("aria-expanded"), "true");
+    assert.ok((await page.locator(".journey-role-detail").count()) > 0);
+    assert.ok(
+      await toggle.evaluate((button) => {
+        const content = document.querySelector(
+          `#${CSS.escape(button.getAttribute("aria-controls"))}`
+        );
+        return (
+          Math.abs(
+            content.offsetHeight -
+              content.parentElement.getBoundingClientRect().height
+          ) < 1
+        );
+      }),
+      "Reduced motion should update the document height immediately"
+    );
+    assert.equal(
+      await page
+        .locator(".disclosure-chevron")
+        .first()
+        .evaluate((icon) => getComputedStyle(icon).transitionDuration),
+      "0s"
+    );
+    assert.ok(
+      await page
+        .locator(".journey-role-detail li")
+        .first()
+        .evaluate((point) => getComputedStyle(point).opacity === "1"),
+      "Reduced motion should reveal the points immediately"
+    );
+    const company = page.locator(".journey-company-trigger").first();
+    await company.hover();
+    assert.equal(
+      await page
+        .locator(".journey-logo > div")
+        .first()
+        .evaluate((logo) => getComputedStyle(logo).scale),
+      "none"
+    );
+    await toggle.focus();
+    await page.keyboard.press("Space");
+    await page.waitForTimeout(100);
+    assert.equal(await page.locator(".journey-role-detail").count(), 0);
+    await page.close();
+  }
+  assert.deepEqual(errors, []);
+  console.log(
+    "Journey motion: desktop, mobile, interruption, keyboard and reduced motion passed."
+  );
+} finally {
+  await browser.close();
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -70,7 +70,14 @@
     padding-inline: 1rem;
   }
 
+  .journey {
+    overflow-anchor: none;
+  }
+
   .journey-entry {
+    position: relative;
+    border-bottom: 1px solid transparent;
+    transition: border-color 100ms ease-out;
     display: grid;
     grid-template-columns: 2.5rem minmax(0, 1fr);
     align-items: start;
@@ -91,6 +98,21 @@
     grid-column: 2;
     grid-row: 1;
   }
+  .journey-company-trigger {
+    text-decoration: underline;
+    text-decoration-color: transparent;
+    text-underline-offset: 0.2em;
+    transition: text-decoration-color 150ms ease-out;
+  }
+
+  .journey-company-trigger:is(:hover, :focus-visible) {
+    text-decoration-color: currentColor;
+  }
+
+  .journey-toggle {
+    transition: color 150ms ease-out;
+  }
+
   .journey-tagline {
     grid-column: 2;
     margin-top: 0.5rem;
@@ -108,7 +130,8 @@
     margin-top: 0.5rem;
   }
   .journey[data-expanded="false"] .journey-entry:not(:last-child) {
-    border-bottom: 1px solid var(--border);
+    border-bottom-color: var(--border);
+    transition: border-color 140ms ease-out 200ms;
   }
   .journey[data-expanded="false"]
     :is(.journey-role-title, .journey-role-dates) {
@@ -130,15 +153,6 @@
   .journey-role-detail {
     flex-basis: 100%;
     min-width: 0;
-  }
-  .journey [hidden] {
-    display: none;
-  }
-
-  @media (prefers-reduced-motion: reduce) {
-    .journey * {
-      transform: none !important;
-    }
   }
 
   @media (min-width: 40rem) {
@@ -195,11 +209,11 @@
 
   .disclosure-chevron {
     --chevron-inset: 5px;
-    @apply size-4 shrink-0 motion-safe:transition-transform motion-safe:duration-150;
+    @apply size-4 shrink-0;
+    transition: rotate 220ms var(--ease-settle);
   }
 
   [aria-expanded="true"] .disclosure-chevron {
-    --chevron-inset: 3px;
     rotate: 90deg;
   }
 
@@ -212,24 +226,132 @@
     margin-inline-start: calc(-1 * var(--chevron-inset));
   }
 
+  .disclosure-panel {
+    height: var(--collapsible-panel-height);
+    overflow: clip;
+    transition: height 280ms var(--ease-settle);
+  }
+
+  .disclosure-panel-body {
+    display: flow-root;
+    opacity: 1;
+    translate: 0 0;
+    transition:
+      opacity 180ms ease-out 35ms,
+      translate 240ms var(--ease-settle) 35ms;
+  }
+
+  .disclosure-panel:is([data-starting-style], [data-ending-style]) {
+    height: 0;
+  }
+
+  .disclosure-panel[data-ending-style] {
+    transition-duration: 200ms;
+  }
+
+  .disclosure-panel:is([data-starting-style], [data-ending-style])
+    > .disclosure-panel-body {
+    opacity: 0;
+    translate: 0 -4px;
+    transition-duration: 100ms;
+    transition-delay: 0ms;
+  }
+
   .site-menu-panel {
-    @apply rounded-lg bg-popover p-2 text-popover-foreground shadow-site-floating ring-1 ring-border outline-none data-ending-style:opacity-0 data-starting-style:opacity-0 motion-safe:transition-opacity motion-safe:duration-150;
+    @apply rounded-lg bg-popover p-2 text-popover-foreground shadow-site-floating ring-1 ring-border outline-none;
   }
 
   .site-preview {
-    @apply w-80 max-w-[calc(100vw-2rem)] rounded-xl border bg-popover text-sm text-popover-foreground shadow-site-floating data-ending-style:opacity-0 data-starting-style:opacity-0 motion-safe:transition-opacity motion-safe:duration-150;
+    @apply w-80 max-w-[calc(100vw-2rem)] rounded-xl border bg-popover text-sm text-popover-foreground shadow-site-floating;
+    height: var(--popup-height, auto);
+  }
+
+  .site-tooltip {
+    @apply z-50 inline-flex w-fit max-w-xs items-center gap-1.5 rounded-md bg-foreground px-3 py-1.5 text-xs text-background;
+  }
+
+  .site-menu-panel,
+  .site-preview,
+  .site-tooltip {
+    --popup-enter-x: 0px;
+    --popup-enter-y: -4px;
+    transform-origin: var(--transform-origin);
+    transition:
+      opacity 160ms ease-out,
+      transform 220ms var(--ease-settle),
+      height 240ms var(--ease-settle);
+  }
+
+  :is(.site-menu-panel, .site-preview, .site-tooltip)[data-side="top"] {
+    --popup-enter-y: 4px;
+  }
+
+  :is(.site-menu-panel, .site-preview, .site-tooltip)[data-side="left"] {
+    --popup-enter-x: 4px;
+    --popup-enter-y: 0px;
+  }
+
+  :is(.site-menu-panel, .site-preview, .site-tooltip)[data-side="right"] {
+    --popup-enter-x: -4px;
+    --popup-enter-y: 0px;
+  }
+
+  :is(.site-menu-panel, .site-preview, .site-tooltip):is(
+    [data-starting-style],
+    [data-ending-style]
+  ) {
+    opacity: 0;
+    transform: translate(var(--popup-enter-x), var(--popup-enter-y))
+      scale(0.985);
+  }
+
+  :is(.site-menu-panel, .site-preview, .site-tooltip)[data-ending-style] {
+    transition-duration: 100ms;
+  }
+
+  .site-tooltip {
+    transition-duration: 125ms;
+  }
+
+  .site-tooltip[data-instant] {
+    transition-duration: 0ms;
+  }
+
+  .site-preview-positioner {
+    transition-property: top, left, right, bottom, transform;
+    transition-duration: 240ms;
+    transition-timing-function: var(--ease-settle);
   }
 
   .preview-viewport {
     @apply relative size-full overflow-clip;
+    --preview-enter-y: 4px;
+  }
+
+  .preview-viewport[data-activation-direction="up"] {
+    --preview-enter-y: -4px;
   }
 
   .preview-viewport > :is([data-current], [data-previous]) {
-    @apply w-full motion-safe:transition-opacity motion-safe:duration-100;
+    width: 100%;
+    transition:
+      opacity 140ms ease-out,
+      translate 200ms var(--ease-settle);
   }
 
-  .preview-viewport > :is([data-starting-style], [data-ending-style]) {
+  .preview-viewport[data-transitioning] > [data-current] {
+    transition-delay: 45ms, 0ms;
+  }
+
+  .preview-viewport > [data-starting-style] {
     opacity: 0;
+    translate: 0 var(--preview-enter-y);
+  }
+
+  .preview-viewport > [data-ending-style] {
+    opacity: 0;
+    translate: 0 calc(-1 * var(--preview-enter-y));
+    transition-duration: 80ms;
   }
 
   .site-list {
@@ -244,8 +366,15 @@
     @apply min-w-0 truncate font-light;
   }
 
+  .site-row[aria-expanded] .site-row-title {
+    interpolate-size: allow-keywords;
+    block-size: 1lh;
+    transition: block-size 240ms var(--ease-settle);
+  }
+
   .site-row[aria-expanded="true"] .site-row-title {
     @apply wrap-anywhere whitespace-normal;
+    block-size: auto;
   }
 
   .site-row-meta {
@@ -254,6 +383,24 @@
 
   .work-log-date {
     @apply font-mono font-normal uppercase tracking-wider;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .journey-entry,
+    .journey[data-expanded="false"] .journey-entry:not(:last-child),
+    .journey-company-trigger,
+    .journey-toggle,
+    .site-row[aria-expanded] .site-row-title,
+    .disclosure-chevron,
+    .disclosure-panel,
+    .disclosure-panel-body,
+    .site-menu-panel,
+    .site-preview,
+    .site-tooltip,
+    .site-preview-positioner,
+    .preview-viewport > :is([data-current], [data-previous]) {
+      transition: none;
+    }
   }
 
   @media (min-width: 40rem) {
@@ -1301,6 +1448,7 @@ h6 {
 }
 
 :root {
+  --ease-settle: cubic-bezier(0.23, 1, 0.32, 1);
   --radius: 0.625rem;
   --background: #fafafa;
   --foreground: #171717;

--- a/src/components/journey.tsx
+++ b/src/components/journey.tsx
@@ -1,7 +1,16 @@
 "use client";
 
-import { motion, MotionConfig, LayoutGroup } from "motion/react";
-import { useId, useRef, useState } from "react";
+import {
+  animate,
+  AnimatePresence,
+  motion,
+  MotionConfig,
+  LayoutGroup,
+  useReducedMotion,
+  useMotionValue,
+} from "motion/react";
+import { useId, useLayoutEffect, useRef, useState } from "react";
+import type { ReactNode } from "react";
 
 import { Badge } from "@/components/ui/badge";
 import { DisclosureChevron } from "@/components/ui/collapsible";
@@ -15,6 +24,69 @@ import {
   resumeRoleMarkerLabels,
 } from "@/content/resume";
 import type { LogoAsset, ResumeExperience, ResumeRole } from "@/content/resume";
+
+const layoutTransition = {
+  type: "spring",
+  visualDuration: 0.24,
+  bounce: 0,
+} as const;
+const revealEase = [0.23, 1, 0.32, 1] as const;
+
+// Exit in place while the persistent labels move to their new positions.
+function JourneyReveal({
+  expanded,
+  children,
+  className,
+  delay = 0.18,
+  inline = false,
+}: Readonly<{
+  expanded: boolean;
+  children: ReactNode;
+  className?: string;
+  delay?: number;
+  inline?: boolean;
+}>) {
+  const reducedMotion = useReducedMotion() === true;
+  const Element = inline ? motion.span : motion.div;
+  return (
+    <AnimatePresence initial={false} mode="popLayout">
+      {expanded ? (
+        <Element
+          key="detail"
+          className={className}
+          initial="hidden"
+          animate="visible"
+          exit="exit"
+          variants={{
+            hidden: {
+              opacity: 0,
+              transform: reducedMotion || inline ? "none" : "translateY(6px)",
+            },
+            visible: {
+              opacity: 1,
+              transform: reducedMotion || inline ? "none" : "translateY(0px)",
+            },
+            exit: {
+              opacity: 0,
+              transform: reducedMotion || inline ? "none" : "translateY(3px)",
+              transition: {
+                duration: reducedMotion ? 0 : 0.1,
+                ease: revealEase,
+              },
+            },
+          }}
+          transition={{
+            duration: reducedMotion ? 0 : inline ? 0.14 : 0.18,
+            delay: reducedMotion ? 0 : delay,
+            ease: revealEase,
+          }}
+        >
+          {children}
+        </Element>
+      ) : null}
+    </AnimatePresence>
+  );
+}
 
 function CompanyLogo({
   logo,
@@ -78,68 +150,107 @@ function RoleBlock({
   role,
   expanded,
 }: Readonly<{ role: ResumeRole; expanded: boolean }>) {
+  const reducedMotion = useReducedMotion() === true;
+  const pointVariants = {
+    hidden: {
+      opacity: reducedMotion ? 1 : 0,
+      transform: reducedMotion ? "none" : "translateY(4px)",
+    },
+    visible: (index: number) => ({
+      opacity: 1,
+      transform: reducedMotion ? "none" : "translateY(0px)",
+      transition: {
+        duration: reducedMotion ? 0 : 0.16,
+        delay: reducedMotion ? 0 : 0.16 + Math.min(index, 3) * 0.03,
+        ease: revealEase,
+      },
+    }),
+  };
   return (
     <div className="journey-role">
       <motion.div
         layout="position"
-        className="journey-role-title flex min-w-0 flex-wrap items-center gap-2"
+        className="journey-role-title relative flex min-w-0 flex-wrap items-center gap-2"
       >
-        <span className="font-medium text-foreground">{role.title}</span>
-        <span className="flex flex-wrap gap-2" hidden={!expanded}>
+        <motion.span layout="position" className="font-medium text-foreground">
+          {role.title}
+        </motion.span>
+        <JourneyReveal
+          expanded={expanded}
+          inline
+          className="flex flex-wrap gap-2"
+          delay={0.12}
+        >
           <RoleMarkers role={role} />
-        </span>
+        </JourneyReveal>
       </motion.div>
       <motion.p
         layout="position"
-        className="journey-role-dates text-xs text-muted-foreground"
+        className="journey-role-dates relative text-xs text-muted-foreground"
       >
-        <span hidden={!expanded}>{role.location} · </span>
-        {role.dates}
+        <JourneyReveal
+          expanded={expanded}
+          inline
+          className="inline-block"
+          delay={0.22}
+        >
+          {role.location} ·&nbsp;
+        </JourneyReveal>
+        <motion.span layout="position" className="inline-block">
+          {role.dates}
+        </motion.span>
       </motion.p>
-      <motion.div
+      <JourneyReveal
+        expanded={expanded}
         className="journey-role-detail"
-        hidden={!expanded}
-        initial={false}
-        animate={{ opacity: expanded ? 1 : 0 }}
+        delay={0.12}
       >
         {role.summary === undefined ? null : (
           <p className="mt-2 text-muted-foreground">{role.summary}</p>
         )}
         {role.bullets !== undefined && role.bullets.length > 0 ? (
           <ul className="mt-2 space-y-2 text-muted-foreground">
-            {role.bullets.map((bullet) => {
+            {role.bullets.map((bullet, index) => {
               const isTextBullet = typeof bullet === "string";
               const text = isTextBullet ? bullet : bullet.text;
               const label = isTextBullet ? undefined : bullet.label;
               const logo = isTextBullet ? undefined : bullet.logo;
 
-              return logo === undefined ? (
-                <li
+              return (
+                <motion.li
                   key={text}
-                  className="relative pl-4 before:absolute before:left-0 before:text-primary before:content-['·']"
+                  custom={index}
+                  variants={pointVariants}
+                  className={
+                    logo === undefined
+                      ? "relative pl-4 before:absolute before:left-0 before:text-primary before:content-['·']"
+                      : "flex gap-2.5"
+                  }
                 >
-                  {text}
-                </li>
-              ) : (
-                <li className="flex gap-2.5" key={text}>
-                  <BulletLogo logo={logo} />
-                  <span>
-                    {label === undefined ? null : (
-                      <>
-                        <span className="font-medium text-foreground">
-                          {label}
-                        </span>
-                        {": "}
-                      </>
-                    )}
-                    {text}
-                  </span>
-                </li>
+                  {logo === undefined ? (
+                    text
+                  ) : (
+                    <>
+                      <BulletLogo logo={logo} />
+                      <span>
+                        {label === undefined ? null : (
+                          <>
+                            <span className="font-medium text-foreground">
+                              {label}
+                            </span>
+                            {": "}
+                          </>
+                        )}
+                        {text}
+                      </span>
+                    </>
+                  )}
+                </motion.li>
               );
             })}
           </ul>
         ) : null}
-      </motion.div>
+      </JourneyReveal>
     </div>
   );
 }
@@ -167,7 +278,7 @@ function ExperienceItem({
         <CompanyLogo logo={item.logo} />
       </motion.div>
       <motion.div layout="position" className="journey-company min-w-0">
-        <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
+        <div className="relative flex flex-wrap items-center gap-x-2 gap-y-1">
           <h3 className="font-semibold text-foreground">
             <TooltipTrigger
               payload={
@@ -194,7 +305,7 @@ function ExperienceItem({
                   })}
                 </TooltipContent>
               }
-              className="min-h-6 cursor-pointer text-start hover:underline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-ring"
+              className="journey-company-trigger relative block min-h-6 cursor-pointer text-start focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-ring"
               onClick={onToggle}
               aria-expanded={expanded}
               aria-label={`${company}: ${expanded ? "hide details" : "show details"}`}
@@ -203,29 +314,50 @@ function ExperienceItem({
                 company
               ) : (
                 <>
-                  <span hidden={expanded}>{compactName}</span>
-                  <span hidden={!expanded}>{fullName}</span>
+                  <JourneyReveal
+                    expanded={!expanded}
+                    inline
+                    delay={0}
+                    className="block"
+                  >
+                    {compactName}
+                  </JourneyReveal>
+                  <JourneyReveal
+                    expanded={expanded}
+                    inline
+                    delay={0}
+                    className="block"
+                  >
+                    {fullName}
+                  </JourneyReveal>
                 </>
               )}
             </TooltipTrigger>
           </h3>
           {companyStage === undefined ? null : (
-            <Badge
-              hidden={!expanded}
-              variant="outline"
-              title={`Company stage during this role: ${companyStage}`}
+            <JourneyReveal
+              expanded={expanded}
+              inline
+              className="inline-flex"
+              delay={0.12}
             >
-              {companyStage}
-            </Badge>
+              <Badge
+                variant="outline"
+                title={`Company stage during this role: ${companyStage}`}
+              >
+                {companyStage}
+              </Badge>
+            </JourneyReveal>
           )}
         </div>
       </motion.div>
-      <p
-        hidden={!expanded}
+      <JourneyReveal
+        expanded={expanded}
         className="journey-tagline text-xs text-muted-foreground"
+        delay={0.08}
       >
-        {item.tagline}
-      </p>
+        <p>{item.tagline}</p>
+      </JourneyReveal>
       <div className="journey-roles">
         {item.roles.map((role) => (
           <RoleBlock key={role.title} role={role} expanded={expanded} />
@@ -248,13 +380,38 @@ export function Journey({
 }>) {
   const [expanded, setExpanded] = useState(false);
   const contentId = useId();
+  const contentRef = useRef<HTMLDivElement>(null);
+  const height = useMotionValue<number | string>("auto");
+  const reducedMotion = useReducedMotion() === true;
+
+  // Keep the footer and the document's scroll limit in step with the entries.
+  useLayoutEffect(() => {
+    const observer = new ResizeObserver(([entry]) => {
+      const nextHeight = entry.borderBoxSize[0].blockSize;
+      if (reducedMotion || height.get() === "auto") {
+        height.stop();
+        height.set(nextHeight);
+      } else {
+        animate(height, nextHeight, layoutTransition);
+      }
+    });
+    const content = contentRef.current;
+    if (content !== null) {
+      observer.observe(content);
+    }
+    return () => {
+      observer.disconnect();
+      height.stop();
+    };
+  }, [height, reducedMotion]);
+
   const toggle = () => {
     setExpanded((value) => !value);
   };
   return (
     <MotionConfig
       reducedMotion="user"
-      transition={{ duration: 0.2, ease: [0.2, 0, 0, 1] }}
+      transition={{ layout: layoutTransition }}
     >
       <LayoutGroup>
         <TooltipGroup>
@@ -267,7 +424,7 @@ export function Journey({
             <div className="flex min-h-11 items-center justify-between gap-4">
               <button
                 type="button"
-                className="site-text-link"
+                className="journey-toggle site-text-link"
                 aria-expanded={expanded}
                 aria-controls={contentId}
                 onClick={toggle}
@@ -277,30 +434,27 @@ export function Journey({
               </button>
               {action}
             </div>
-            <div id={contentId}>
-              <div hidden={!expanded} className="mt-6">
-                <h2 className="section-title">Skills</h2>
-                <p className="mt-2 text-muted-foreground">
-                  {skills.join(" · ")}
-                </p>
-              </div>
-              <motion.h2 layout="position" className="section-title mt-8">
-                Experience
-              </motion.h2>
-              <ol className="mt-4">
-                {experience.map((item) => (
-                  <ExperienceItem
-                    key={item.company}
-                    item={item}
-                    expanded={expanded}
-                    onToggle={toggle}
-                  />
-                ))}
-              </ol>
-              <motion.div layout="position" className="mt-8">
-                <h2 className="section-title">Education</h2>
+            <motion.div style={{ height }}>
+              <div
+                ref={contentRef}
+                id={contentId}
+                className="relative flow-root"
+              >
+                <JourneyReveal
+                  expanded={expanded}
+                  className="mt-6"
+                  delay={0.04}
+                >
+                  <h2 className="section-title">Skills</h2>
+                  <p className="mt-2 text-muted-foreground">
+                    {skills.join(" · ")}
+                  </p>
+                </JourneyReveal>
+                <motion.h2 layout="position" className="section-title mt-8">
+                  Experience
+                </motion.h2>
                 <ol className="mt-4">
-                  {education.map((item) => (
+                  {experience.map((item) => (
                     <ExperienceItem
                       key={item.company}
                       item={item}
@@ -309,8 +463,21 @@ export function Journey({
                     />
                   ))}
                 </ol>
-              </motion.div>
-            </div>
+                <motion.div layout="position" className="mt-8">
+                  <h2 className="section-title">Education</h2>
+                  <ol className="mt-4">
+                    {education.map((item) => (
+                      <ExperienceItem
+                        key={item.company}
+                        item={item}
+                        expanded={expanded}
+                        onToggle={toggle}
+                      />
+                    ))}
+                  </ol>
+                </motion.div>
+              </div>
+            </motion.div>
           </section>
         </TooltipGroup>
       </LayoutGroup>

--- a/src/components/ui/collapsible.tsx
+++ b/src/components/ui/collapsible.tsx
@@ -17,22 +17,31 @@ function CollapsibleTrigger({ ...props }: CollapsiblePrimitive.Trigger.Props) {
 
 function CollapsibleContent({
   className,
+  children,
   ...props
 }: CollapsiblePrimitive.Panel.Props) {
   return (
     <CollapsiblePrimitive.Panel
       className={cn(
-        "h-[var(--collapsible-panel-height)] overflow-hidden data-ending-style:h-0 data-starting-style:h-0 motion-safe:transition-[height] motion-safe:duration-150 motion-safe:ease-out [&[hidden]:not([hidden='until-found'])]:hidden",
+        "disclosure-panel [&[hidden]:not([hidden='until-found'])]:hidden",
         className
       )}
       data-slot="collapsible-content"
       {...props}
-    />
+    >
+      <div className="disclosure-panel-body">{children}</div>
+    </CollapsiblePrimitive.Panel>
   );
 }
 
 function DisclosureChevron() {
-  return <ChevronRight aria-hidden="true" className="disclosure-chevron" />;
+  return (
+    <ChevronRight
+      aria-hidden="true"
+      className="disclosure-chevron"
+      strokeWidth={1.5}
+    />
+  );
 }
 
 export {

--- a/src/components/ui/hover-card.tsx
+++ b/src/components/ui/hover-card.tsx
@@ -68,7 +68,7 @@ function HoverCardContent({
     <HoverCardPrimitive.Portal>
       <HoverCardPrimitive.Positioner
         align="start"
-        className="z-50 motion-safe:transition-[top,left,right,bottom,transform] motion-safe:duration-100 motion-safe:ease-out"
+        className="site-preview-positioner z-50"
         side={side}
         sideOffset={24}
         collisionPadding={16}
@@ -79,10 +79,7 @@ function HoverCardContent({
         }}
       >
         <HoverCardPrimitive.Popup
-          className={cn(
-            "site-preview h-[var(--popup-height,auto)] origin-(--transform-origin) overflow-hidden outline-none motion-safe:transition-[height,opacity] motion-safe:duration-100",
-            className
-          )}
+          className={cn("site-preview overflow-hidden outline-none", className)}
           data-slot="hover-card-content"
           {...props}
         >

--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -57,7 +57,7 @@ function TooltipContent({
         anchor={anchor}
         align={align}
         alignOffset={alignOffset}
-        className="isolate z-50 motion-safe:transition-[top,left,right,bottom,transform] motion-safe:duration-100 motion-safe:ease-out"
+        className="site-preview-positioner isolate z-50"
         side={side}
         sideOffset={sideOffset}
         collisionPadding={preview ? 16 : undefined}
@@ -70,8 +70,8 @@ function TooltipContent({
         <TooltipPrimitive.Popup
           className={cn(
             preview
-              ? "site-preview block h-[var(--popup-height,auto)] overflow-hidden motion-safe:transition-[height,opacity] motion-safe:duration-100"
-              : "z-50 inline-flex w-fit max-w-xs origin-(--transform-origin) items-center gap-1.5 rounded-md bg-foreground px-3 py-1.5 text-xs text-background has-data-[slot=kbd]:pr-1.5 data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 **:data-[slot=kbd]:relative **:data-[slot=kbd]:isolate **:data-[slot=kbd]:z-50 **:data-[slot=kbd]:rounded-sm data-[state=delayed-open]:animate-in data-[state=delayed-open]:fade-in-0 data-[state=delayed-open]:zoom-in-95 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95 duration-150 motion-reduce:animate-none",
+              ? "site-preview block overflow-hidden"
+              : "site-tooltip has-data-[slot=kbd]:pr-1.5 **:data-[slot=kbd]:relative **:data-[slot=kbd]:isolate **:data-[slot=kbd]:z-50 **:data-[slot=kbd]:rounded-sm",
             preview ? undefined : className
           )}
           data-slot="tooltip-content"


### PR DESCRIPTION
Journey expansion and shared disclosures could jump as content entered or left. Animate Journey's document height alongside its layout, coordinate supporting content reveals, and tune accordion height, body, and chevron transitions for smoother opening and faster closing.

Also refine shared menu/popover, tooltip, and hover-preview entrances, exits, resizing, and content handoffs across the site. Respect reduced motion and keep interrupted transitions responsive.

Validation: lint and typecheck pass; the existing test suite passed (291 tests). A browser regression script covers Journey at desktop and mobile widths, rapid reversals, keyboard activation, and reduced motion. Shared disclosures and overlays were also checked in the browser.
