### PR TITLE
fix: stabilize work log dates and await parallel homepage data

### DIFF
--- a/src/app/(portfolio)/page.tsx
+++ b/src/app/(portfolio)/page.tsx
@@ -1,6 +1,5 @@
 import { Star, GitFork } from "lucide-react";
 import type { Metadata } from "next";
-import { Suspense } from "react";
 
 import { CodexStats } from "@/components/codex-stats";
 import { GitHubTimeline } from "@/components/github-timeline";
@@ -21,7 +20,9 @@ import {
 import { resumeData } from "@/content/resume";
 import { getBlogPosts } from "@/lib/blog-utils";
 import { getPublicCodexStats } from "@/lib/codex/public-stats";
+import { getInitialGitHubActivity } from "@/lib/github-activity-feed";
 import { getGitHubProfile } from "@/lib/github-profile";
+import type { GitHubProfile } from "@/lib/github-profile";
 import { publicUrl, siteConfig } from "@/lib/site";
 
 const { description } = siteConfig;
@@ -48,43 +49,7 @@ export const metadata: Metadata = {
 
 export const dynamic = "force-dynamic";
 
-function SectionLoading({
-  id,
-  label,
-}: Readonly<{ id: string; label: string }>) {
-  return (
-    <SiteSection className="home-section min-h-64" id={id} title={label}>
-      <p className="py-2.5 text-muted-foreground" role="status">
-        Loading…
-      </p>
-    </SiteSection>
-  );
-}
-
-async function RecentWriting() {
-  const posts = await getBlogPosts();
-  return (
-    <SiteSection id="writing" title="Writing">
-      <WritingList posts={posts.slice(0, 3)} />
-    </SiteSection>
-  );
-}
-
-async function TokenLog() {
-  const codexStats = await getPublicCodexStats();
-  return codexStats === null ? (
-    <SiteSection id="token-log" title="Token log">
-      <p className="py-2.5 text-muted-foreground">
-        Token activity is unavailable right now.
-      </p>
-    </SiteSection>
-  ) : (
-    <CodexStats stats={codexStats} />
-  );
-}
-
-async function OpenSource() {
-  const github = await getGitHubProfile();
+function OpenSource({ github }: Readonly<{ github: GitHubProfile }>) {
   const projects = featuredProjectNames.flatMap((name) => {
     const project = github.projects.find(
       (candidate) => candidate.name === name
@@ -160,29 +125,35 @@ async function OpenSource() {
   );
 }
 
-export default function Home() {
+export default async function Home() {
+  const [codexStats, activity, posts, github] = await Promise.all([
+    getPublicCodexStats(),
+    getInitialGitHubActivity(),
+    getBlogPosts(),
+    getGitHubProfile(),
+  ]);
   return (
     <SiteShell currentPath="/">
       <SiteMain>
         <h1 className="sr-only">{resumeData.person.name}</h1>
         <p>{homeIntroduction}</p>
 
-        <Suspense fallback={<SectionLoading id="writing" label="Writing" />}>
-          <RecentWriting />
-        </Suspense>
+        <SiteSection id="writing" title="Writing">
+          <WritingList posts={posts.slice(0, 3)} />
+        </SiteSection>
 
-        <GitHubTimeline preview />
-        <Suspense
-          fallback={<SectionLoading id="token-log" label="Token log" />}
-        >
-          <TokenLog />
-        </Suspense>
+        <GitHubTimeline initialPage={activity} preview />
+        {codexStats === null ? (
+          <SiteSection id="token-log" title="Token log">
+            <p className="py-2.5 text-muted-foreground">
+              Token activity is unavailable right now.
+            </p>
+          </SiteSection>
+        ) : (
+          <CodexStats stats={codexStats} />
+        )}
 
-        <Suspense
-          fallback={<SectionLoading id="open-source" label="Open source" />}
-        >
-          <OpenSource />
-        </Suspense>
+        <OpenSource github={github} />
       </SiteMain>
     </SiteShell>
   );

--- a/src/app/(portfolio)/work-log/page.tsx
+++ b/src/app/(portfolio)/work-log/page.tsx
@@ -3,6 +3,7 @@ import type { Metadata } from "next";
 import { GitHubTimeline } from "@/components/github-timeline";
 import { SiteMain } from "@/components/site-page";
 import { SiteShell } from "@/components/site-shell";
+import { getInitialGitHubActivity } from "@/lib/github-activity-feed";
 import { publicUrl, siteConfig } from "@/lib/site";
 
 const description =
@@ -29,11 +30,12 @@ export const metadata: Metadata = {
 
 export const dynamic = "force-dynamic";
 
-export default function WorkLogPage() {
+export default async function WorkLogPage() {
+  const initialPage = await getInitialGitHubActivity();
   return (
     <SiteShell activeHref="/work-log">
       <SiteMain>
-        <GitHubTimeline />
+        <GitHubTimeline initialPage={initialPage} />
       </SiteMain>
     </SiteShell>
   );

--- a/src/components/github-activity-days.tsx
+++ b/src/components/github-activity-days.tsx
@@ -4,7 +4,7 @@ import { CircleDot, FolderGit2, LockKeyhole } from "lucide-react";
 import Image from "next/image";
 
 import { LanguageIcon } from "@/components/language-icon";
-import { LocalDateTime, useViewerTimeZone } from "@/components/local-date-time";
+import { LocalDateTime } from "@/components/local-date-time";
 import {
   Collapsible,
   CollapsibleContent,
@@ -16,7 +16,7 @@ import {
   TooltipGroup,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
-import { dateKey, formatDate } from "@/lib/date";
+import { dateKey, formatDate, WORK_LOG_TIME_ZONE } from "@/lib/date";
 import {
   getVisibleGitHubActivityDays,
   localizeGitHubActivityDays,
@@ -289,6 +289,7 @@ function GitHubActivityDay({
           >
             {formatDate(day.day, "weekday")}
           </time>
+          <span title="Days are grouped in India Standard Time">IST</span>
         </h3>
         <dl
           aria-label={`Totals for ${day.day}`}
@@ -335,10 +336,8 @@ export function GitHubActivityDays({
   preview?: boolean;
   now: string;
 }>) {
-  const timeZone = useViewerTimeZone();
-  const localDays =
-    timeZone === "UTC" ? days : localizeGitHubActivityDays(days, timeZone);
-  const today = dateKey(now, timeZone);
+  const localDays = localizeGitHubActivityDays(days, WORK_LOG_TIME_ZONE);
+  const today = dateKey(now, WORK_LOG_TIME_ZONE);
   const activeDays = getVisibleGitHubActivityDays(localDays, today);
   const visibleDays = preview ? activeDays.slice(0, 1) : activeDays;
   return (

--- a/src/components/github-timeline.tsx
+++ b/src/components/github-timeline.tsx
@@ -4,12 +4,12 @@ import {
 } from "@/components/github-activity-status";
 import { GitHubTimelinePager } from "@/components/github-timeline-pager";
 import { SiteSection } from "@/components/site-page";
-import { getInitialGitHubActivity } from "@/lib/github-activity-feed";
+import type { PublicGitHubActivityPage } from "@/lib/github-activity-types";
 
-export async function GitHubTimeline({
+export function GitHubTimeline({
+  initialPage,
   preview = false,
-}: Readonly<{ preview?: boolean }>) {
-  const initialPage = await getInitialGitHubActivity();
+}: Readonly<{ initialPage: PublicGitHubActivityPage; preview?: boolean }>) {
   return (
     <SiteSection
       className={preview ? "home-section" : ""}

--- a/src/components/local-date-time.tsx
+++ b/src/components/local-date-time.tsx
@@ -3,14 +3,14 @@
 import { useSyncExternalStore } from "react";
 import type { ComponentProps } from "react";
 
-import { formatDate } from "@/lib/date";
+import { formatDate, WORK_LOG_TIME_ZONE } from "@/lib/date";
 import type { dateFormats } from "@/lib/date";
 
 const subscribe = () => () => {
   /* Read the browser timezone after hydration; no event subscription is needed. */
 };
 const getTimeZone = () => Intl.DateTimeFormat().resolvedOptions().timeZone;
-const getServerTimeZone = () => "UTC";
+const getServerTimeZone = () => WORK_LOG_TIME_ZONE;
 
 export const useViewerTimeZone = () =>
   useSyncExternalStore(subscribe, getTimeZone, getServerTimeZone);

--- a/src/lib/date.ts
+++ b/src/lib/date.ts
@@ -1,3 +1,5 @@
+export const WORK_LOG_TIME_ZONE = "Asia/Kolkata";
+
 export const dateFormats = {
   date: { dateStyle: "medium" },
   weekday: {

--- a/tests/github-activity-days.test.tsx
+++ b/tests/github-activity-days.test.tsx
@@ -1,0 +1,50 @@
+import { expect, test } from "bun:test";
+
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { GitHubActivityDays } from "../src/components/github-activity-days";
+import { buildPublicGitHubActivityDays } from "../src/lib/github-activity-feed-core";
+
+test("the initial homepage HTML includes all IST work and totals across UTC midnight", () => {
+  const days = buildPublicGitHubActivityDays({
+    days: ["2026-09-07", "2026-09-06"],
+    issues: [],
+    workUnits: [
+      ["site", "2026-09-07T00:23:00.000Z", 3, 4429, 3415],
+      ["oliphaunt", "2026-09-06T23:38:00.000Z", 2, 45, 12],
+      ["yesterday", "2026-09-06T18:29:59.000Z", 1, 100, 100],
+    ].map(([id, activityAt, count, additions, deletions]) => ({
+      id: String(id),
+      activityAt: String(activityAt),
+      day: String(activityAt).slice(0, 10),
+      destination: null,
+      facts: {
+        additions: Number(additions),
+        deletions: Number(deletions),
+        ownedCommitCount: Number(count),
+        uniqueFileCount: 1,
+        languages: [],
+        dateRange: null,
+      },
+      headline: String(id),
+      kind: "pull-request" as const,
+      repository: {
+        key: String(id),
+        label: String(id),
+        url: null,
+        avatarUrl: null,
+      },
+      summarizing: false,
+      summary: null,
+    })),
+  });
+  const html = renderToStaticMarkup(
+    <GitHubActivityDays days={days} preview now="2026-09-07T01:00:00.000Z" />
+  );
+  expect(html).toContain("oliphaunt");
+  expect(html).toContain("5 commits across 2 repos");
+  expect(html).toContain("+4,474");
+  expect(html).toContain("−3,427");
+  expect(html).toContain("IST");
+  expect(html).not.toContain("yesterday");
+});


### PR DESCRIPTION
Hard-refreshing the homepage initially grouped work in UTC, then moved items into the viewer’s local day during hydration. In India, this made Oliphaunt appear later and changed the commit and diff totals.

Group work-log days consistently in IST and label the day headers. Individual timestamps still localize in the browser, with the full local date and timezone in their hover text. Fetch Token log, work log, writing, and GitHub profile concurrently with `Promise.all()` and await them before rendering the homepage, removing the section loading placeholders. The homepage now waits for the slowest of these reads; existing caches remain in place.

Validation:
- 7 focused date and work-log tests passed, including an HTML regression check across UTC midnight.
- Browser hydration check with a simulated America/Los_Angeles timezone: rows and totals stayed unchanged while individual times localized; no console errors.
- Lint and TypeScript checks passed.
