### PR TITLE
perf: reuse date formatters and optimize work log avatars

### DIFF
--- a/src/components/github-activity-days.tsx
+++ b/src/components/github-activity-days.tsx
@@ -66,7 +66,6 @@ function RepositoryIdentity({
             height={28}
             sizes="28px"
             src={repository.avatarUrl}
-            unoptimized
             width={28}
           />
         )}

--- a/src/lib/date.ts
+++ b/src/lib/date.ts
@@ -21,14 +21,20 @@ export const dateFormats = {
   dateTime: { dateStyle: "medium", timeStyle: "short", hour12: true },
 } satisfies Record<string, Intl.DateTimeFormatOptions>;
 
+const dateFormatters = new Map<string, Intl.DateTimeFormat>();
+
 export const formatDate = (
   value: Date | string,
   format: keyof typeof dateFormats = "date",
   timeZone = "UTC"
-) =>
-  new Intl.DateTimeFormat("en-US", { ...dateFormats[format], timeZone }).format(
-    new Date(value)
-  );
+) => {
+  const key = `${format}:${timeZone}`;
+  const formatter =
+    dateFormatters.get(key) ??
+    new Intl.DateTimeFormat("en-US", { ...dateFormats[format], timeZone });
+  dateFormatters.set(key, formatter);
+  return formatter.format(new Date(value));
+};
 
 export const dateKey = (value: Date | string, timeZone = "UTC") =>
   new Intl.DateTimeFormat("en-CA", {


### PR DESCRIPTION
Token log creates a new Intl.DateTimeFormat for every heatmap cell on every render, and work-log avatars bypass the existing Next.js image optimizer.

Reuse formatters by format and timezone, and let Next.js resize/cache repository avatars. Existing local-time formatting and accessibility remain intact.

Measured on the deployed homepage before this change:
- Desktop repeat-load LCP: 876 ms; fresh mobile-context LCP with Slow 4G and 4× CPU slowdown: 2,578 ms.
- Reported CLS: 0.00; mobile Token log tab interactions: 336–344 ms. No CrUX field data was available.
- Compressed JavaScript: approximately 283 KB; CSS: 20 KB; fonts: 54 KB.

Validation:
- In an isolated production-mode chart harness using the public series and 4× CPU slowdown, six tab switches measured a median of 647 ms before formatter reuse and 534 ms afterward (~17% lower). These are local click-to-two-animation-frame measurements, not deployed INP or a full-page before/after comparison.
- The production image optimizer returns the existing avatar at 96 px as a 1,908-byte WebP versus the 28,533-byte original JPEG (~93% smaller).
- Seven focused date and work-log tests passed; lint and typecheck passed. The local chart comparison had no browser console errors.

Recheck cold mobile loading and interactions after deployment; this change does not claim a real-user Core Web Vitals pass.
