### PR TITLE
fix: reuse work summaries and preserve request budgets

### DIFF
--- a/docs/github-activity-work-units.md
+++ b/docs/github-activity-work-units.md
@@ -256,6 +256,8 @@ Each future start is recorded on the existing attempt (at most two timestamps),
 so daily usage can be reconciled even when a retry crosses UTC midnight. The
 migration preserves the known last-start time and marks an unrecoverable earlier
 legacy start as null; it does not invent past timestamps.
+The database records each counter increment, including claims from the previous
+worker version while the new build is rolling out.
 
 `OPENAI_API_KEY` is optional; without it the factual pipeline continues and no
 summary claim is started. This is not an OpenAI free-tier design. At the

--- a/docs/github-activity-work-units.md
+++ b/docs/github-activity-work-units.md
@@ -265,7 +265,7 @@ Supabase Cron invokes:
 | -------------------------- | ------------------------------------- | -------------------------------------------------------------------- |
 | `/api/cron/github-sync`    | every 5 minutes                       | 15-second request                                                    |
 | `/api/cron/github-worker`  | every 5 minutes, offset by 2 minutes  | 60-second request; default eight items per factual queue and one ref |
-| `/api/cron/github-summary` | every 5 minutes, offset by 3 minutes  | 60-second request; at most one provider claim                        |
+| `/api/cron/github-summary` | every minute                          | 60-second request; at most one provider claim                        |
 | `/api/cron/github-refs`    | every 15 minutes, offset by 4 minutes | 15-second request; eight ref pages/repositories per account          |
 
 The worker processes factual queues and current-ref repair before recomputing

--- a/docs/github-activity-work-units.md
+++ b/docs/github-activity-work-units.md
@@ -265,7 +265,7 @@ Supabase Cron invokes:
 | -------------------------- | ------------------------------------- | -------------------------------------------------------------------- |
 | `/api/cron/github-sync`    | every 5 minutes                       | 15-second request                                                    |
 | `/api/cron/github-worker`  | every 5 minutes, offset by 2 minutes  | 60-second request; default eight items per factual queue and one ref |
-| `/api/cron/github-summary` | every minute                          | 60-second request; at most one provider claim                        |
+| `/api/cron/github-summary` | every 3 minutes                       | 60-second request; at most one provider claim                        |
 | `/api/cron/github-refs`    | every 15 minutes, offset by 4 minutes | 15-second request; eight ref pages/repositories per account          |
 
 The worker processes factual queues and current-ref repair before recomputing

--- a/docs/github-activity-work-units.md
+++ b/docs/github-activity-work-units.md
@@ -170,8 +170,8 @@ revision. An ordering change returns `409`, prompting a fresh first page.
 
 The exact accepted summary is preferred. The newest accepted same-attribution
 summary remains a visible fallback while an identity is refreshed. Accepted
-output is also copied to durable storage without a work-unit foreign key, so a
-projection deletion cannot erase it; an exact same-repository outcome may reuse
+output and paid attempt history live without a work-unit foreign key, so a
+projection deletion cannot erase them; an exact same-repository outcome may reuse
 that prose after branch-lineage identity replacement.
 
 ## Outcome summaries
@@ -213,9 +213,13 @@ headline of at most 16 words and a standalone expanded summary of at most three
 sentences and 80 words. Validation rejects invalid Unicode,
 control/bidirectional characters, URLs, HTML, Markdown, and SHAs.
 
-Summary identity includes the semantic policy, recipe, prompt, normalized
-input, outcome digest, and attribution mode. Transport retries and storage
-configuration do not invalidate prose. A five-minute debounce absorbs active
+Summary input identity records the policy, recipe, prompt, normalized input,
+outcome digest, and attribution mode. Before any paid claim, the worker reuses a
+valid accepted summary for the same repository, outcome, attribution, and recipe
+(same identity, or equivalent branch lineage). Prompt, policy, and repository-context
+changes therefore do not spend another request on unchanged work. A recipe change
+explicitly requires a new summary. Cache reuse also runs when the paid budget is
+exhausted. A five-minute debounce absorbs active
 rewrites. Up to eight newest-first inputs are deterministically evaluated per
 projection refresh. A separate bounded worker starts at most one provider claim.
 Valid output remains cacheable if its input becomes stale while the request
@@ -225,25 +229,39 @@ branch outcome after lineage replacement. A force push with the same complete
 outcome can therefore reuse accepted prose without inventing ownership or
 changing the activity anchor.
 
-Claims are ordered by newest activity, then newest observed content:
+Missing summaries take priority over refreshing existing prose. Within each
+group, claims are ordered by newest activity, then newest observed content:
 
 - each attempt may start at most twice;
 - at most 100 requests may start per UTC day and 3,000 per UTC month.
 
-These limits are application configuration; the database only records usage.
+These limits are application configuration; the database records usage. Work older
+than 24 hours can consume only the elapsed share of the daily budget: at noon,
+that is 50 requests. Recent work can use any remaining capacity immediately.
+This lets historical work progress without taking the whole day’s allowance
+before new work arrives. Cache reuse consumes no request.
+
 Started requests count even when they fail. A transient failure waits 15
 minutes before its one possible retry. Output-format rejection uses that same
 bounded retry; invalid persisted input and exhausted attempts become facts-only.
 The last failure code is retained on the attempt. Superseded attempts that never started are removed;
 a paid retryable attempt becomes a payload-free tombstone that retains its
 request count. Its input is rebuilt and debounced only if the exact input becomes
-current again. Expired leases are recovered by the next worker.
+current again. Paid attempts retain their stable identity, repository, counters,
+per-request start timestamps, and failure code even after projection deletion or a recipe
+change. Recreating an identity reuses its prior work-unit ID and attempt budget.
+An in-flight result can still be cached after its projected row disappears.
+Expired leases, including orphaned attempts, are recovered by the next worker.
+Each future start is recorded on the existing attempt (at most two timestamps),
+so daily usage can be reconciled even when a retry crosses UTC midnight. The
+migration preserves the known last-start time and marks an unrecoverable earlier
+legacy start as null; it does not invent past timestamps.
 
 `OPENAI_API_KEY` is optional; without it the factual pipeline continues and no
 summary claim is started. This is not an OpenAI free-tier design. At the
 [model's documented price](https://developers.openai.com/api/docs/models/gpt-5.4-nano)
 of $0.20/M input tokens and $1.25/M output tokens, the hard monthly maximum is
-`3,000 * (32,000 * $0.20/M + 160 * $1.25/M) = $19.80`.
+`3,000 * (32,000 * $0.20/M + 256 * $1.25/M) = $20.16`.
 
 ## Intake and cadence
 
@@ -331,8 +349,10 @@ paginated inventory can require more than one invocation.
 The status endpoint returns the feed revision, a monotone head revision, last
 feed publication time, and one boolean: whether the configured summary pipeline
 has a current public evaluation, queued input, retry, or provider lease on the
-initial five-day page. The next worker reconciliation clears an expired
-abandoned lease. The UI renders only:
+initial five-day page. Queued work does not report active summarization when the
+paid budget is exhausted; an already-started request remains active until it
+settles. The next worker reconciliation clears an expired abandoned lease.
+The UI renders only:
 
 - `Shaping the latest update` while that boolean is true;
 - `Updated … ago` (or `Activity is up to date`) otherwise; or

--- a/drizzle/0021_windy_midnight.sql
+++ b/drizzle/0021_windy_midnight.sql
@@ -18,3 +18,23 @@ ALTER TABLE github_work_unit_summary_attempts ALTER COLUMN identity_key SET NOT 
 ALTER TABLE github_work_unit_summary_attempts ALTER COLUMN repository_id SET NOT NULL;
 --> statement-breakpoint
 ALTER TABLE "github_work_unit_summary_attempts" ADD CONSTRAINT "gh_work_unit_summary_request_times" CHECK (cardinality("github_work_unit_summary_attempts"."request_started_at") = "github_work_unit_summary_attempts"."started_requests");
+--> statement-breakpoint
+-- Migrations precede application rollout. Old workers omit the new identity
+-- columns; recording starts here keeps both worker versions auditable.
+CREATE FUNCTION record_github_summary_attempt() RETURNS trigger
+LANGUAGE plpgsql SET search_path = public AS $$
+BEGIN
+  IF TG_OP = 'INSERT' AND (NEW.identity_key IS NULL OR NEW.repository_id IS NULL) THEN
+    SELECT identity_key, repository_id INTO NEW.identity_key, NEW.repository_id
+    FROM github_work_units WHERE id = NEW.work_unit_id;
+  END IF;
+  IF TG_OP = 'UPDATE' AND NEW.started_requests = OLD.started_requests + 1 THEN
+    NEW.request_started_at := array_append(OLD.request_started_at, NEW.last_started_at);
+  END IF;
+  RETURN NEW;
+END;
+$$;
+--> statement-breakpoint
+CREATE TRIGGER record_github_summary_attempt
+BEFORE INSERT OR UPDATE ON github_work_unit_summary_attempts
+FOR EACH ROW EXECUTE FUNCTION record_github_summary_attempt();

--- a/drizzle/0021_windy_midnight.sql
+++ b/drizzle/0021_windy_midnight.sql
@@ -1,0 +1,20 @@
+ALTER TABLE "github_work_unit_summary_attempts" DROP CONSTRAINT "gh_work_unit_summary_attempts_unit_fk";
+--> statement-breakpoint
+ALTER TABLE "github_work_unit_summary_attempts" ADD COLUMN "identity_key" varchar(180);--> statement-breakpoint
+ALTER TABLE "github_work_unit_summary_attempts" ADD COLUMN "repository_id" varchar(32);--> statement-breakpoint
+ALTER TABLE "github_work_unit_summary_attempts" ADD COLUMN "request_started_at" timestamp with time zone[] DEFAULT ARRAY[]::timestamptz[] NOT NULL;--> statement-breakpoint
+CREATE INDEX "gh_work_unit_summary_attempts_identity_idx" ON "github_work_unit_summary_attempts" USING btree ("identity_key");--> statement-breakpoint
+UPDATE github_work_unit_summary_attempts a
+SET identity_key = w.identity_key, repository_id = w.repository_id,
+    request_started_at = CASE a.started_requests
+      WHEN 0 THEN ARRAY[]::timestamptz[]
+      WHEN 1 THEN ARRAY[a.last_started_at]
+      ELSE ARRAY[NULL::timestamptz, a.last_started_at]
+    END
+FROM github_work_units w WHERE w.id = a.work_unit_id;
+--> statement-breakpoint
+ALTER TABLE github_work_unit_summary_attempts ALTER COLUMN identity_key SET NOT NULL;
+--> statement-breakpoint
+ALTER TABLE github_work_unit_summary_attempts ALTER COLUMN repository_id SET NOT NULL;
+--> statement-breakpoint
+ALTER TABLE "github_work_unit_summary_attempts" ADD CONSTRAINT "gh_work_unit_summary_request_times" CHECK (cardinality("github_work_unit_summary_attempts"."request_started_at") = "github_work_unit_summary_attempts"."started_requests");

--- a/drizzle/meta/0021_snapshot.json
+++ b/drizzle/meta/0021_snapshot.json
@@ -1,0 +1,3871 @@
+{
+  "id": "6070194c-d84b-488f-9507-6aa51ce8bb1f",
+  "prevId": "23bd606f-2dac-4f52-9b27-6bc555d3a11d",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.codex_accounts": {
+      "name": "codex_accounts",
+      "schema": "",
+      "columns": {
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "snapshot": {
+          "name": "snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "snapshot_at": {
+          "name": "snapshot_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "codex_accounts_id_shape": {
+          "name": "codex_accounts_id_shape",
+          "value": "\"codex_accounts\".\"id\" ~ '^[a-z0-9][a-z0-9_-]{0,63}$'"
+        },
+        "codex_accounts_snapshot_pair": {
+          "name": "codex_accounts_snapshot_pair",
+          "value": "(\"codex_accounts\".\"snapshot\" IS NULL) = (\"codex_accounts\".\"snapshot_at\" IS NULL)"
+        },
+        "codex_accounts_snapshot_object": {
+          "name": "codex_accounts_snapshot_object",
+          "value": "\"codex_accounts\".\"snapshot\" IS NULL OR jsonb_typeof(\"codex_accounts\".\"snapshot\") = 'object'"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.github_account_checkpoints": {
+      "name": "github_account_checkpoints",
+      "schema": "",
+      "columns": {
+        "account": {
+          "name": "account",
+          "type": "varchar(39)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "events_etag": {
+          "name": "events_etag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "events_last_attempted_at": {
+          "name": "events_last_attempted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "events_last_succeeded_at": {
+          "name": "events_last_succeeded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "events_next_poll_at": {
+          "name": "events_next_poll_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gap_detected_at": {
+          "name": "gap_detected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gap_expected_event_id": {
+          "name": "gap_expected_event_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gap_oldest_available_event_id": {
+          "name": "gap_oldest_available_event_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gap_state": {
+          "name": "gap_state",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'clear'"
+        },
+        "latest_event_id": {
+          "name": "latest_event_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "paused": {
+          "name": "paused",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "pull_request_backfill_digest": {
+          "name": "pull_request_backfill_digest",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "head_ref_cursor_repository_id": {
+          "name": "head_ref_cursor_repository_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "head_ref_cycle_started_at": {
+          "name": "head_ref_cycle_started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "head_ref_last_attempted_at": {
+          "name": "head_ref_last_attempted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "head_ref_last_succeeded_at": {
+          "name": "head_ref_last_succeeded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "head_ref_lease_token": {
+          "name": "head_ref_lease_token",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "head_ref_lease_until": {
+          "name": "head_ref_lease_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "head_ref_next_page": {
+          "name": "head_ref_next_page",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "head_ref_scan_started_at": {
+          "name": "head_ref_scan_started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ref_backfill_since_at": {
+          "name": "ref_backfill_since_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "tag_ref_cursor_repository_id": {
+          "name": "tag_ref_cursor_repository_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tag_ref_cycle_started_at": {
+          "name": "tag_ref_cycle_started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tag_ref_last_attempted_at": {
+          "name": "tag_ref_last_attempted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tag_ref_last_succeeded_at": {
+          "name": "tag_ref_last_succeeded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tag_ref_lease_token": {
+          "name": "tag_ref_lease_token",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tag_ref_lease_until": {
+          "name": "tag_ref_lease_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tag_ref_next_page": {
+          "name": "tag_ref_next_page",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tag_ref_scan_started_at": {
+          "name": "tag_ref_scan_started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "github_account_checkpoints_tracked_account": {
+          "name": "github_account_checkpoints_tracked_account",
+          "value": "\"github_account_checkpoints\".\"account\" IN ('f0rr0', 'yuppiestechdev')"
+        },
+        "github_account_checkpoints_event_id_shape": {
+          "name": "github_account_checkpoints_event_id_shape",
+          "value": "(\"github_account_checkpoints\".\"latest_event_id\" IS NULL OR \"github_account_checkpoints\".\"latest_event_id\" ~ '^[0-9]{1,64}$') AND (\"github_account_checkpoints\".\"gap_expected_event_id\" IS NULL OR \"github_account_checkpoints\".\"gap_expected_event_id\" ~ '^[0-9]{1,64}$') AND (\"github_account_checkpoints\".\"gap_oldest_available_event_id\" IS NULL OR \"github_account_checkpoints\".\"gap_oldest_available_event_id\" ~ '^[0-9]{1,64}$')"
+        },
+        "github_account_checkpoints_gap_state": {
+          "name": "github_account_checkpoints_gap_state",
+          "value": "\"github_account_checkpoints\".\"gap_state\" IN ('clear', 'detected')"
+        },
+        "github_account_checkpoints_gap_details": {
+          "name": "github_account_checkpoints_gap_details",
+          "value": "(\"github_account_checkpoints\".\"gap_state\" = 'detected' AND \"github_account_checkpoints\".\"gap_detected_at\" IS NOT NULL) OR (\"github_account_checkpoints\".\"gap_state\" = 'clear' AND \"github_account_checkpoints\".\"gap_detected_at\" IS NULL AND \"github_account_checkpoints\".\"gap_expected_event_id\" IS NULL AND \"github_account_checkpoints\".\"gap_oldest_available_event_id\" IS NULL)"
+        },
+        "github_account_checkpoints_ref_cursor_shape": {
+          "name": "github_account_checkpoints_ref_cursor_shape",
+          "value": "(\"github_account_checkpoints\".\"head_ref_cursor_repository_id\" IS NULL OR \"github_account_checkpoints\".\"head_ref_cursor_repository_id\" ~ '^[0-9]{1,32}$') AND (\"github_account_checkpoints\".\"tag_ref_cursor_repository_id\" IS NULL OR \"github_account_checkpoints\".\"tag_ref_cursor_repository_id\" ~ '^[0-9]{1,32}$')"
+        },
+        "github_account_checkpoints_ref_leases": {
+          "name": "github_account_checkpoints_ref_leases",
+          "value": "(\"github_account_checkpoints\".\"head_ref_lease_token\" IS NULL) = (\"github_account_checkpoints\".\"head_ref_lease_until\" IS NULL) AND (\"github_account_checkpoints\".\"tag_ref_lease_token\" IS NULL) = (\"github_account_checkpoints\".\"tag_ref_lease_until\" IS NULL)"
+        },
+        "github_account_checkpoints_ref_scans": {
+          "name": "github_account_checkpoints_ref_scans",
+          "value": "(\"github_account_checkpoints\".\"head_ref_next_page\" IS NULL AND \"github_account_checkpoints\".\"head_ref_scan_started_at\" IS NULL OR \"github_account_checkpoints\".\"head_ref_next_page\" >= 2 AND \"github_account_checkpoints\".\"head_ref_scan_started_at\" IS NOT NULL) AND (\"github_account_checkpoints\".\"tag_ref_next_page\" IS NULL AND \"github_account_checkpoints\".\"tag_ref_scan_started_at\" IS NULL OR \"github_account_checkpoints\".\"tag_ref_next_page\" >= 2 AND \"github_account_checkpoints\".\"tag_ref_scan_started_at\" IS NOT NULL)"
+        },
+        "github_account_checkpoints_pr_backfill_digest": {
+          "name": "github_account_checkpoints_pr_backfill_digest",
+          "value": "\"github_account_checkpoints\".\"pull_request_backfill_digest\" IS NULL OR \"github_account_checkpoints\".\"pull_request_backfill_digest\" ~ '^[a-f0-9]{64}$'"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.github_account_repository_catalogs": {
+      "name": "github_account_repository_catalogs",
+      "schema": "",
+      "columns": {
+        "account_user_id": {
+          "name": "account_user_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active_access": {
+          "name": "active_access",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "inventory_generation": {
+          "name": "inventory_generation",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "observed_at": {
+          "name": "observed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "gh_account_repo_catalogs_current_idx": {
+          "name": "gh_account_repo_catalogs_current_idx",
+          "columns": [
+            {
+              "expression": "account_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "inventory_generation",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "active_access",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gh_account_repo_catalogs_account_fk": {
+          "name": "gh_account_repo_catalogs_account_fk",
+          "tableFrom": "github_account_repository_catalogs",
+          "tableTo": "github_repository_inventory_heads",
+          "columnsFrom": ["account_user_id"],
+          "columnsTo": ["account_user_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gh_account_repo_catalogs_repository_fk": {
+          "name": "gh_account_repo_catalogs_repository_fk",
+          "tableFrom": "github_account_repository_catalogs",
+          "tableTo": "github_repositories",
+          "columnsFrom": ["repository_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "gh_account_repo_catalogs_pk": {
+          "name": "gh_account_repo_catalogs_pk",
+          "columns": ["account_user_id", "repository_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "gh_account_repo_catalogs_generation": {
+          "name": "gh_account_repo_catalogs_generation",
+          "value": "\"github_account_repository_catalogs\".\"inventory_generation\" > 0"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.github_commit_pull_request_associations": {
+      "name": "github_commit_pull_request_associations",
+      "schema": "",
+      "columns": {
+        "commit_repository_id": {
+          "name": "commit_repository_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "commit_sha": {
+          "name": "commit_sha",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pull_request_node_id": {
+          "name": "pull_request_node_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "gh_commit_pr_associations_commit_fk": {
+          "name": "gh_commit_pr_associations_commit_fk",
+          "tableFrom": "github_commit_pull_request_associations",
+          "tableTo": "github_commits",
+          "columnsFrom": ["commit_repository_id", "commit_sha"],
+          "columnsTo": ["repository_id", "sha"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gh_commit_pr_associations_pr_fk": {
+          "name": "gh_commit_pr_associations_pr_fk",
+          "tableFrom": "github_commit_pull_request_associations",
+          "tableTo": "github_pull_requests",
+          "columnsFrom": ["pull_request_node_id"],
+          "columnsTo": ["node_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "gh_commit_pr_associations_pk": {
+          "name": "gh_commit_pr_associations_pk",
+          "columns": [
+            "commit_repository_id",
+            "commit_sha",
+            "pull_request_node_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "gh_commit_pr_associations_sha_shape": {
+          "name": "gh_commit_pr_associations_sha_shape",
+          "value": "\"github_commit_pull_request_associations\".\"commit_sha\" ~ '^[a-f0-9]{40}$'"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.github_commits": {
+      "name": "github_commits",
+      "schema": "",
+      "columns": {
+        "additions": {
+          "name": "additions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_login": {
+          "name": "author_login",
+          "type": "varchar(39)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "authored_at": {
+          "name": "authored_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_user_id": {
+          "name": "author_user_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "changed_files": {
+          "name": "changed_files",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "committed_at": {
+          "name": "committed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "committer_at": {
+          "name": "committer_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "committer_user_id": {
+          "name": "committer_user_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deletions": {
+          "name": "deletions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enrichment_error": {
+          "name": "enrichment_error",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enrichment_attempts": {
+          "name": "enrichment_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "enrichment_lease_token": {
+          "name": "enrichment_lease_token",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enrichment_lease_until": {
+          "name": "enrichment_lease_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enrichment_state": {
+          "name": "enrichment_state",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "file_facts": {
+          "name": "file_facts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_facts_digest": {
+          "name": "file_facts_digest",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "CASE WHEN \"file_facts\" IS NULL THEN NULL ELSE encode(sha256(jsonb_send(\"file_facts\")), 'hex') END",
+            "type": "stored"
+          }
+        },
+        "file_facts_complete": {
+          "name": "file_facts_complete",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "first_observed_at": {
+          "name": "first_observed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_shas": {
+          "name": "parent_shas",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_file_cap_reached": {
+          "name": "provider_file_cap_reached",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "pr_discovery_error": {
+          "name": "pr_discovery_error",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_discovery_attempts": {
+          "name": "pr_discovery_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "pr_discovery_lease_token": {
+          "name": "pr_discovery_lease_token",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_discovery_lease_until": {
+          "name": "pr_discovery_lease_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_discovery_state": {
+          "name": "pr_discovery_state",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sha": {
+          "name": "sha",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "github_commits_committed_at_idx": {
+          "name": "github_commits_committed_at_idx",
+          "columns": [
+            {
+              "expression": "committed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_commits_enrichment_pending_idx": {
+          "name": "github_commits_enrichment_pending_idx",
+          "columns": [
+            {
+              "expression": "enrichment_state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "enrichment_lease_until",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "committed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_commits_pr_discovery_pending_idx": {
+          "name": "github_commits_pr_discovery_pending_idx",
+          "columns": [
+            {
+              "expression": "pr_discovery_state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pr_discovery_lease_until",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "first_observed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_commits_repository_fk": {
+          "name": "github_commits_repository_fk",
+          "tableFrom": "github_commits",
+          "tableTo": "github_repositories",
+          "columnsFrom": ["repository_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "github_commits_repository_id_sha_pk": {
+          "name": "github_commits_repository_id_sha_pk",
+          "columns": ["repository_id", "sha"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "github_commits_sha_shape": {
+          "name": "github_commits_sha_shape",
+          "value": "\"github_commits\".\"sha\" ~ '^[a-f0-9]{40}$'"
+        },
+        "github_commits_parent_shas_array": {
+          "name": "github_commits_parent_shas_array",
+          "value": "\"github_commits\".\"parent_shas\" IS NULL OR jsonb_typeof(\"github_commits\".\"parent_shas\") = 'array'"
+        },
+        "github_commits_file_facts_array": {
+          "name": "github_commits_file_facts_array",
+          "value": "\"github_commits\".\"file_facts\" IS NULL OR jsonb_typeof(\"github_commits\".\"file_facts\") = 'array'"
+        },
+        "github_commits_file_facts_completeness": {
+          "name": "github_commits_file_facts_completeness",
+          "value": "NOT \"github_commits\".\"file_facts_complete\" OR (\"github_commits\".\"file_facts\" IS NOT NULL AND NOT \"github_commits\".\"provider_file_cap_reached\")"
+        },
+        "github_commits_enrichment_state": {
+          "name": "github_commits_enrichment_state",
+          "value": "\"github_commits\".\"enrichment_state\" IN ('pending', 'processing', 'complete', 'unavailable')"
+        },
+        "github_commits_enrichment_lease": {
+          "name": "github_commits_enrichment_lease",
+          "value": "(\"github_commits\".\"enrichment_state\" = 'processing') = (\"github_commits\".\"enrichment_lease_token\" IS NOT NULL) AND (\"github_commits\".\"enrichment_state\" <> 'processing' OR \"github_commits\".\"enrichment_lease_until\" IS NOT NULL) AND (\"github_commits\".\"enrichment_state\" NOT IN ('complete', 'unavailable') OR \"github_commits\".\"enrichment_lease_until\" IS NULL)"
+        },
+        "github_commits_pr_discovery_state": {
+          "name": "github_commits_pr_discovery_state",
+          "value": "\"github_commits\".\"pr_discovery_state\" IN ('pending', 'processing', 'complete', 'unavailable')"
+        },
+        "github_commits_pr_discovery_lease": {
+          "name": "github_commits_pr_discovery_lease",
+          "value": "(\"github_commits\".\"pr_discovery_state\" = 'processing') = (\"github_commits\".\"pr_discovery_lease_token\" IS NOT NULL) AND (\"github_commits\".\"pr_discovery_state\" <> 'processing' OR \"github_commits\".\"pr_discovery_lease_until\" IS NOT NULL) AND (\"github_commits\".\"pr_discovery_state\" NOT IN ('complete', 'unavailable') OR \"github_commits\".\"pr_discovery_lease_until\" IS NULL)"
+        },
+        "github_commits_tracked_author": {
+          "name": "github_commits_tracked_author",
+          "value": "\"github_commits\".\"author_login\" IN ('f0rr0', 'yuppiestechdev')"
+        },
+        "github_commits_nonnegative_activity_counts": {
+          "name": "github_commits_nonnegative_activity_counts",
+          "value": "(\"github_commits\".\"changed_files\" IS NULL OR \"github_commits\".\"changed_files\" >= 0) AND (\"github_commits\".\"additions\" IS NULL OR \"github_commits\".\"additions\" >= 0) AND (\"github_commits\".\"deletions\" IS NULL OR \"github_commits\".\"deletions\" >= 0)"
+        },
+        "github_commits_nonnegative_attempts": {
+          "name": "github_commits_nonnegative_attempts",
+          "value": "\"github_commits\".\"enrichment_attempts\" >= 0 AND \"github_commits\".\"pr_discovery_attempts\" >= 0"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.github_issues": {
+      "name": "github_issues",
+      "schema": "",
+      "columns": {
+        "account": {
+          "name": "account",
+          "type": "varchar(39)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_login": {
+          "name": "author_login",
+          "type": "varchar(39)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_user_id": {
+          "name": "author_user_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_observed_at": {
+          "name": "first_observed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "varchar(128)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "number": {
+          "name": "number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title_snapshot": {
+          "name": "title_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url_snapshot": {
+          "name": "url_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "github_issues_repository_number_unique": {
+          "name": "github_issues_repository_number_unique",
+          "columns": [
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_issues_author_idx": {
+          "name": "github_issues_author_idx",
+          "columns": [
+            {
+              "expression": "author_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_issues_repository_id_github_repositories_id_fk": {
+          "name": "github_issues_repository_id_github_repositories_id_fk",
+          "tableFrom": "github_issues",
+          "tableTo": "github_repositories",
+          "columnsFrom": ["repository_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "github_issues_tracked_account": {
+          "name": "github_issues_tracked_account",
+          "value": "\"github_issues\".\"account\" IN ('f0rr0', 'yuppiestechdev')"
+        },
+        "github_issues_positive_number": {
+          "name": "github_issues_positive_number",
+          "value": "\"github_issues\".\"number\" > 0"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.github_public_feed_head": {
+      "name": "github_public_feed_head",
+      "schema": "",
+      "columns": {
+        "feed_revision": {
+          "name": "feed_revision",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "head_content_revision": {
+          "name": "head_content_revision",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "id": {
+          "name": "id",
+          "type": "boolean",
+          "primaryKey": true,
+          "notNull": true,
+          "default": true
+        },
+        "last_published_at": {
+          "name": "last_published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ordering_revision": {
+          "name": "ordering_revision",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "projection_request_token": {
+          "name": "projection_request_token",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary_policy_digest": {
+          "name": "summary_policy_digest",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summarizing": {
+          "name": "summarizing",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "gh_public_feed_head_singleton": {
+          "name": "gh_public_feed_head_singleton",
+          "value": "\"github_public_feed_head\".\"id\""
+        },
+        "gh_public_feed_head_revisions": {
+          "name": "gh_public_feed_head_revisions",
+          "value": "\"github_public_feed_head\".\"feed_revision\" >= 0 AND \"github_public_feed_head\".\"head_content_revision\" >= 0 AND \"github_public_feed_head\".\"ordering_revision\" >= 0"
+        },
+        "gh_public_feed_head_summary_policy_digest": {
+          "name": "gh_public_feed_head_summary_policy_digest",
+          "value": "\"github_public_feed_head\".\"summary_policy_digest\" IS NULL OR \"github_public_feed_head\".\"summary_policy_digest\" ~ '^[a-f0-9]{64}$'"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.github_pull_request_memberships": {
+      "name": "github_pull_request_memberships",
+      "schema": "",
+      "columns": {
+        "commit_repository_id": {
+          "name": "commit_repository_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "commit_sha": {
+          "name": "commit_sha",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_head": {
+          "name": "is_head",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version_id": {
+          "name": "version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "github_pull_request_memberships_position_unique": {
+          "name": "github_pull_request_memberships_position_unique",
+          "columns": [
+            {
+              "expression": "version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_pull_request_memberships_commit_lookup_idx": {
+          "name": "github_pull_request_memberships_commit_lookup_idx",
+          "columns": [
+            {
+              "expression": "commit_repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "commit_sha",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gh_pr_memberships_version_fk": {
+          "name": "gh_pr_memberships_version_fk",
+          "tableFrom": "github_pull_request_memberships",
+          "tableTo": "github_pull_request_versions",
+          "columnsFrom": ["version_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "gh_pr_memberships_pk": {
+          "name": "gh_pr_memberships_pk",
+          "columns": ["version_id", "commit_repository_id", "commit_sha"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "github_pull_request_memberships_sha_shape": {
+          "name": "github_pull_request_memberships_sha_shape",
+          "value": "\"github_pull_request_memberships\".\"commit_sha\" ~ '^[a-f0-9]{40}$'"
+        },
+        "github_pull_request_memberships_nonnegative_position": {
+          "name": "github_pull_request_memberships_nonnegative_position",
+          "value": "\"github_pull_request_memberships\".\"position\" >= 0"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.github_pull_request_signals": {
+      "name": "github_pull_request_signals",
+      "schema": "",
+      "columns": {
+        "account": {
+          "name": "account",
+          "type": "varchar(39)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "lease_token": {
+          "name": "lease_token",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lease_until": {
+          "name": "lease_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "number": {
+          "name": "number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "observed_at": {
+          "name": "observed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository_name_snapshot": {
+          "name": "repository_name_snapshot",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        }
+      },
+      "indexes": {
+        "github_pull_request_signals_event_unique": {
+          "name": "github_pull_request_signals_event_unique",
+          "columns": [
+            {
+              "expression": "account",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_pull_request_signals_pending_idx": {
+          "name": "github_pull_request_signals_pending_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lease_until",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "observed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "github_pull_request_signals_account": {
+          "name": "github_pull_request_signals_account",
+          "value": "\"github_pull_request_signals\".\"account\" IN ('f0rr0', 'yuppiestechdev')"
+        },
+        "github_pull_request_signals_event_id": {
+          "name": "github_pull_request_signals_event_id",
+          "value": "\"github_pull_request_signals\".\"event_id\" ~ '^[0-9]{1,64}$'"
+        },
+        "github_pull_request_signals_repository_id": {
+          "name": "github_pull_request_signals_repository_id",
+          "value": "\"github_pull_request_signals\".\"repository_id\" ~ '^[0-9]{1,32}$'"
+        },
+        "github_pull_request_signals_state": {
+          "name": "github_pull_request_signals_state",
+          "value": "\"github_pull_request_signals\".\"state\" IN ('pending', 'processing', 'complete', 'unavailable')"
+        },
+        "github_pull_request_signals_lease": {
+          "name": "github_pull_request_signals_lease",
+          "value": "(\"github_pull_request_signals\".\"state\" = 'processing') = (\"github_pull_request_signals\".\"lease_token\" IS NOT NULL) AND (\"github_pull_request_signals\".\"state\" <> 'processing' OR \"github_pull_request_signals\".\"lease_until\" IS NOT NULL)"
+        },
+        "github_pull_request_signals_values": {
+          "name": "github_pull_request_signals_values",
+          "value": "\"github_pull_request_signals\".\"number\" > 0 AND \"github_pull_request_signals\".\"attempt_count\" >= 0"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.github_pull_request_versions": {
+      "name": "github_pull_request_versions",
+      "schema": "",
+      "columns": {
+        "base_ref_name": {
+          "name": "base_ref_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_repository_id": {
+          "name": "base_repository_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_sha": {
+          "name": "base_sha",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "commit_count": {
+          "name": "commit_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_facts": {
+          "name": "file_facts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_facts_digest": {
+          "name": "file_facts_digest",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "CASE WHEN \"file_facts\" IS NULL THEN NULL ELSE encode(sha256(jsonb_send(\"file_facts\")), 'hex') END",
+            "type": "stored"
+          }
+        },
+        "file_facts_complete": {
+          "name": "file_facts_complete",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "head_ref_name": {
+          "name": "head_ref_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "head_repository_id": {
+          "name": "head_repository_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "head_sha": {
+          "name": "head_sha",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "is_current": {
+          "name": "is_current",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "membership_complete": {
+          "name": "membership_complete",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "merge_snapshot": {
+          "name": "merge_snapshot",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "observed_at": {
+          "name": "observed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "provider_updated_at": {
+          "name": "provider_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pull_request_node_id": {
+          "name": "pull_request_node_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "github_pull_request_versions_head_unique": {
+          "name": "github_pull_request_versions_head_unique",
+          "columns": [
+            {
+              "expression": "pull_request_node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "head_sha",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_pull_request_versions_current_unique": {
+          "name": "github_pull_request_versions_current_unique",
+          "columns": [
+            {
+              "expression": "pull_request_node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"github_pull_request_versions\".\"is_current\"",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gh_pr_versions_pull_request_fk": {
+          "name": "gh_pr_versions_pull_request_fk",
+          "tableFrom": "github_pull_request_versions",
+          "tableTo": "github_pull_requests",
+          "columnsFrom": ["pull_request_node_id"],
+          "columnsTo": ["node_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "github_pull_request_versions_sha_shapes": {
+          "name": "github_pull_request_versions_sha_shapes",
+          "value": "\"github_pull_request_versions\".\"base_sha\" ~ '^[a-f0-9]{40}$' AND \"github_pull_request_versions\".\"head_sha\" ~ '^[a-f0-9]{40}$'"
+        },
+        "github_pull_request_versions_nonnegative_count": {
+          "name": "github_pull_request_versions_nonnegative_count",
+          "value": "\"github_pull_request_versions\".\"commit_count\" IS NULL OR \"github_pull_request_versions\".\"commit_count\" >= 0"
+        },
+        "github_pull_request_versions_file_facts_array": {
+          "name": "github_pull_request_versions_file_facts_array",
+          "value": "\"github_pull_request_versions\".\"file_facts\" IS NULL OR jsonb_typeof(\"github_pull_request_versions\".\"file_facts\") = 'array'"
+        },
+        "github_pull_request_versions_file_facts_complete": {
+          "name": "github_pull_request_versions_file_facts_complete",
+          "value": "NOT \"github_pull_request_versions\".\"file_facts_complete\" OR \"github_pull_request_versions\".\"file_facts\" IS NOT NULL"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.github_pull_requests": {
+      "name": "github_pull_requests",
+      "schema": "",
+      "columns": {
+        "account": {
+          "name": "account",
+          "type": "varchar(39)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "additions": {
+          "name": "additions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_login": {
+          "name": "author_login",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_user_id": {
+          "name": "author_user_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "base_ref_name": {
+          "name": "base_ref_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_repository_id": {
+          "name": "base_repository_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_sha": {
+          "name": "base_sha",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body_snapshot": {
+          "name": "body_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "changed_files": {
+          "name": "changed_files",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commit_count": {
+          "name": "commit_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deletions": {
+          "name": "deletions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "draft": {
+          "name": "draft",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "first_observed_at": {
+          "name": "first_observed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "head_ref_name": {
+          "name": "head_ref_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "head_repository_id": {
+          "name": "head_repository_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "head_sha": {
+          "name": "head_sha",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_reconciled_at": {
+          "name": "last_reconciled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "merged_at": {
+          "name": "merged_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "merge_sha": {
+          "name": "merge_sha",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "merge_sha_verified_at": {
+          "name": "merge_sha_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_reconcile_at": {
+          "name": "next_reconcile_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "varchar(128)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "number": {
+          "name": "number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_updated_at": {
+          "name": "provider_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reconcile_attempts": {
+          "name": "reconcile_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reconcile_error": {
+          "name": "reconcile_error",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "terminal_at": {
+          "name": "terminal_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title_snapshot": {
+          "name": "title_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "github_pull_requests_repository_number_unique": {
+          "name": "github_pull_requests_repository_number_unique",
+          "columns": [
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_pull_requests_reconciliation_idx": {
+          "name": "github_pull_requests_reconciliation_idx",
+          "columns": [
+            {
+              "expression": "account",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_reconcile_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_pull_requests_author_idx": {
+          "name": "github_pull_requests_author_idx",
+          "columns": [
+            {
+              "expression": "author_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_pull_requests_repository_id_github_repositories_id_fk": {
+          "name": "github_pull_requests_repository_id_github_repositories_id_fk",
+          "tableFrom": "github_pull_requests",
+          "tableTo": "github_repositories",
+          "columnsFrom": ["repository_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "github_pull_requests_tracked_account": {
+          "name": "github_pull_requests_tracked_account",
+          "value": "\"github_pull_requests\".\"account\" IN ('f0rr0', 'yuppiestechdev')"
+        },
+        "github_pull_requests_state": {
+          "name": "github_pull_requests_state",
+          "value": "\"github_pull_requests\".\"state\" IN ('open', 'closed', 'merged')"
+        },
+        "github_pull_requests_terminal_state": {
+          "name": "github_pull_requests_terminal_state",
+          "value": "(\"github_pull_requests\".\"state\" = 'open' AND \"github_pull_requests\".\"terminal_at\" IS NULL) OR (\"github_pull_requests\".\"state\" IN ('closed', 'merged') AND \"github_pull_requests\".\"terminal_at\" IS NOT NULL)"
+        },
+        "github_pull_requests_merged_state": {
+          "name": "github_pull_requests_merged_state",
+          "value": "(\"github_pull_requests\".\"state\" = 'merged') = (\"github_pull_requests\".\"merged_at\" IS NOT NULL)"
+        },
+        "github_pull_requests_sha_shapes": {
+          "name": "github_pull_requests_sha_shapes",
+          "value": "(\"github_pull_requests\".\"base_sha\" IS NULL OR \"github_pull_requests\".\"base_sha\" ~ '^[a-f0-9]{40}$') AND (\"github_pull_requests\".\"head_sha\" IS NULL OR \"github_pull_requests\".\"head_sha\" ~ '^[a-f0-9]{40}$') AND (\"github_pull_requests\".\"merge_sha\" IS NULL OR \"github_pull_requests\".\"merge_sha\" ~ '^[a-f0-9]{40}$')"
+        },
+        "github_pull_requests_verified_merge_sha": {
+          "name": "github_pull_requests_verified_merge_sha",
+          "value": "(\"github_pull_requests\".\"merge_sha\" IS NULL AND \"github_pull_requests\".\"merge_sha_verified_at\" IS NULL) OR (\"github_pull_requests\".\"state\" = 'merged' AND \"github_pull_requests\".\"merge_sha_verified_at\" IS NOT NULL)"
+        },
+        "github_pull_requests_positive_number": {
+          "name": "github_pull_requests_positive_number",
+          "value": "\"github_pull_requests\".\"number\" > 0"
+        },
+        "github_pull_requests_nonnegative_counts": {
+          "name": "github_pull_requests_nonnegative_counts",
+          "value": "(\"github_pull_requests\".\"changed_files\" IS NULL OR \"github_pull_requests\".\"changed_files\" >= 0) AND (\"github_pull_requests\".\"additions\" IS NULL OR \"github_pull_requests\".\"additions\" >= 0) AND (\"github_pull_requests\".\"deletions\" IS NULL OR \"github_pull_requests\".\"deletions\" >= 0) AND (\"github_pull_requests\".\"commit_count\" IS NULL OR \"github_pull_requests\".\"commit_count\" >= 0)"
+        },
+        "github_pull_requests_nonnegative_attempts": {
+          "name": "github_pull_requests_nonnegative_attempts",
+          "value": "\"github_pull_requests\".\"reconcile_attempts\" >= 0"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.github_push_observation_commits": {
+      "name": "github_push_observation_commits",
+      "schema": "",
+      "columns": {
+        "observation_id": {
+          "name": "observation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sha": {
+          "name": "sha",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "github_push_observation_commits_position_unique": {
+          "name": "github_push_observation_commits_position_unique",
+          "columns": [
+            {
+              "expression": "observation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gh_push_observation_commits_observation_fk": {
+          "name": "gh_push_observation_commits_observation_fk",
+          "tableFrom": "github_push_observation_commits",
+          "tableTo": "github_push_observations",
+          "columnsFrom": ["observation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "gh_push_observation_commits_pk": {
+          "name": "gh_push_observation_commits_pk",
+          "columns": ["observation_id", "repository_id", "sha"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "github_push_observation_commits_sha_shape": {
+          "name": "github_push_observation_commits_sha_shape",
+          "value": "\"github_push_observation_commits\".\"sha\" ~ '^[a-f0-9]{40}$'"
+        },
+        "github_push_observation_commits_nonnegative_position": {
+          "name": "github_push_observation_commits_nonnegative_position",
+          "value": "\"github_push_observation_commits\".\"position\" >= 0"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.github_push_observations": {
+      "name": "github_push_observations",
+      "schema": "",
+      "columns": {
+        "account": {
+          "name": "account",
+          "type": "varchar(39)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "after_sha": {
+          "name": "after_sha",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "before_sha": {
+          "name": "before_sha",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expected_commit_count": {
+          "name": "expected_commit_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "history_since_at": {
+          "name": "history_since_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "history_until_at": {
+          "name": "history_until_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "lease_token": {
+          "name": "lease_token",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lease_until": {
+          "name": "lease_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "observed_at": {
+          "name": "observed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "provider_created_at": {
+          "name": "provider_created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ref_name": {
+          "name": "ref_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository_name_snapshot": {
+          "name": "repository_name_snapshot",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        }
+      },
+      "indexes": {
+        "github_push_observations_source_unique": {
+          "name": "github_push_observations_source_unique",
+          "columns": [
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_push_observations_push_unique": {
+          "name": "github_push_observations_push_unique",
+          "columns": [
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ref_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "before_sha",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "after_sha",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"github_push_observations\".\"source\" <> 'backfill'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_push_observations_pending_idx": {
+          "name": "github_push_observations_pending_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lease_until",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "observed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_push_observations_account_idx": {
+          "name": "github_push_observations_account_idx",
+          "columns": [
+            {
+              "expression": "account",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "observed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gh_push_observations_repository_fk": {
+          "name": "gh_push_observations_repository_fk",
+          "tableFrom": "github_push_observations",
+          "tableTo": "github_repositories",
+          "columnsFrom": ["repository_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "github_push_observations_tracked_account": {
+          "name": "github_push_observations_tracked_account",
+          "value": "\"github_push_observations\".\"account\" IN ('f0rr0', 'yuppiestechdev')"
+        },
+        "github_push_observations_source": {
+          "name": "github_push_observations_source",
+          "value": "\"github_push_observations\".\"source\" IN ('webhook', 'events', 'refs', 'backfill')"
+        },
+        "github_push_observations_sha_shape": {
+          "name": "github_push_observations_sha_shape",
+          "value": "\"github_push_observations\".\"before_sha\" ~ '^[a-f0-9]{40}$' AND \"github_push_observations\".\"after_sha\" ~ '^[a-f0-9]{40}$'"
+        },
+        "github_push_observations_nonnegative_count": {
+          "name": "github_push_observations_nonnegative_count",
+          "value": "\"github_push_observations\".\"attempt_count\" >= 0 AND (\"github_push_observations\".\"expected_commit_count\" IS NULL OR \"github_push_observations\".\"expected_commit_count\" >= 0)"
+        },
+        "github_push_observations_history_bounds": {
+          "name": "github_push_observations_history_bounds",
+          "value": "(\"github_push_observations\".\"source\" <> 'backfill' AND \"github_push_observations\".\"history_since_at\" IS NULL AND \"github_push_observations\".\"history_until_at\" IS NULL) OR (\"github_push_observations\".\"source\" = 'backfill' AND \"github_push_observations\".\"history_since_at\" IS NOT NULL AND \"github_push_observations\".\"history_until_at\" IS NOT NULL AND \"github_push_observations\".\"history_since_at\" <= \"github_push_observations\".\"history_until_at\" AND \"github_push_observations\".\"expected_commit_count\" IS NULL AND \"github_push_observations\".\"before_sha\" = repeat('0', 40))"
+        },
+        "github_push_observations_state": {
+          "name": "github_push_observations_state",
+          "value": "\"github_push_observations\".\"state\" IN ('pending', 'processing', 'complete', 'deferred', 'unavailable')"
+        },
+        "github_push_observations_lease": {
+          "name": "github_push_observations_lease",
+          "value": "(\"github_push_observations\".\"state\" = 'processing') = (\"github_push_observations\".\"lease_token\" IS NOT NULL) AND (\"github_push_observations\".\"state\" <> 'processing' OR \"github_push_observations\".\"lease_until\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.github_ref_generations": {
+      "name": "github_ref_generations",
+      "schema": "",
+      "columns": {
+        "branch_lineage_id": {
+          "name": "branch_lineage_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "coverage_since_at": {
+          "name": "coverage_since_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generation": {
+          "name": "generation",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "head_sha": {
+          "name": "head_sha",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ref_name": {
+          "name": "ref_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "gh_ref_generations_lineage_idx": {
+          "name": "gh_ref_generations_lineage_idx",
+          "columns": [
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "branch_lineage_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gh_ref_generations_repository_fk": {
+          "name": "gh_ref_generations_repository_fk",
+          "tableFrom": "github_ref_generations",
+          "tableTo": "github_repositories",
+          "columnsFrom": ["repository_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "gh_ref_generations_pk": {
+          "name": "gh_ref_generations_pk",
+          "columns": ["repository_id", "ref_name"]
+        }
+      },
+      "uniqueConstraints": {
+        "gh_ref_generations_version_unique": {
+          "name": "gh_ref_generations_version_unique",
+          "nullsNotDistinct": false,
+          "columns": ["repository_id", "ref_name", "generation"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "gh_ref_generations_head_name": {
+          "name": "gh_ref_generations_head_name",
+          "value": "\"github_ref_generations\".\"ref_name\" LIKE 'refs/heads/%'"
+        },
+        "gh_ref_generations_sha_shape": {
+          "name": "gh_ref_generations_sha_shape",
+          "value": "\"github_ref_generations\".\"head_sha\" ~ '^[a-f0-9]{40}$'"
+        },
+        "gh_ref_generations_positive": {
+          "name": "gh_ref_generations_positive",
+          "value": "\"github_ref_generations\".\"generation\" > 0"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.github_ref_memberships": {
+      "name": "github_ref_memberships",
+      "schema": "",
+      "columns": {
+        "commit_repository_id": {
+          "name": "commit_repository_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "commit_sha": {
+          "name": "commit_sha",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generation": {
+          "name": "generation",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ref_name": {
+          "name": "ref_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "gh_ref_memberships_position_unique": {
+          "name": "gh_ref_memberships_position_unique",
+          "columns": [
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ref_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "gh_ref_memberships_commit_idx": {
+          "name": "gh_ref_memberships_commit_idx",
+          "columns": [
+            {
+              "expression": "commit_repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "commit_sha",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gh_ref_memberships_generation_fk": {
+          "name": "gh_ref_memberships_generation_fk",
+          "tableFrom": "github_ref_memberships",
+          "tableTo": "github_ref_generations",
+          "columnsFrom": ["repository_id", "ref_name", "generation"],
+          "columnsTo": ["repository_id", "ref_name", "generation"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gh_ref_memberships_commit_fk": {
+          "name": "gh_ref_memberships_commit_fk",
+          "tableFrom": "github_ref_memberships",
+          "tableTo": "github_commits",
+          "columnsFrom": ["commit_repository_id", "commit_sha"],
+          "columnsTo": ["repository_id", "sha"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "gh_ref_memberships_pk": {
+          "name": "gh_ref_memberships_pk",
+          "columns": [
+            "repository_id",
+            "ref_name",
+            "commit_repository_id",
+            "commit_sha"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "gh_ref_memberships_values": {
+          "name": "gh_ref_memberships_values",
+          "value": "\"github_ref_memberships\".\"generation\" > 0 AND \"github_ref_memberships\".\"position\" >= 0 AND \"github_ref_memberships\".\"commit_sha\" ~ '^[a-f0-9]{40}$'"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.github_repositories": {
+      "name": "github_repositories",
+      "schema": "",
+      "columns": {
+        "default_branch": {
+          "name": "default_branch",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_observed_at": {
+          "name": "first_observed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "facts_verified_at": {
+          "name": "facts_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "inventory_verified_at": {
+          "name": "inventory_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "homepage_url": {
+          "name": "homepage_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "heads_last_reconciled_at": {
+          "name": "heads_last_reconciled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "html_url": {
+          "name": "html_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar(32)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "last_observed_at": {
+          "name": "last_observed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "owner_avatar_url": {
+          "name": "owner_avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_login": {
+          "name": "owner_login",
+          "type": "varchar(39)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_type": {
+          "name": "owner_type",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pushed_at": {
+          "name": "pushed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "topics": {
+          "name": "topics",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags_last_reconciled_at": {
+          "name": "tags_last_reconciled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "github_repositories_full_name_idx": {
+          "name": "github_repositories_full_name_idx",
+          "columns": [
+            {
+              "expression": "full_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "github_repositories_full_name": {
+          "name": "github_repositories_full_name",
+          "value": "length(btrim(\"github_repositories\".\"full_name\")) > 0"
+        },
+        "github_repositories_owner_type": {
+          "name": "github_repositories_owner_type",
+          "value": "\"github_repositories\".\"owner_type\" IS NULL OR \"github_repositories\".\"owner_type\" IN ('Organization', 'User')"
+        },
+        "github_repositories_visibility": {
+          "name": "github_repositories_visibility",
+          "value": "\"github_repositories\".\"visibility\" IS NULL OR \"github_repositories\".\"visibility\" IN ('public', 'private', 'internal')"
+        },
+        "github_repositories_topics_array": {
+          "name": "github_repositories_topics_array",
+          "value": "\"github_repositories\".\"topics\" IS NULL OR jsonb_typeof(\"github_repositories\".\"topics\") = 'array'"
+        },
+        "github_repositories_observation_order": {
+          "name": "github_repositories_observation_order",
+          "value": "\"github_repositories\".\"last_observed_at\" >= \"github_repositories\".\"first_observed_at\""
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.github_repository_inventory_heads": {
+      "name": "github_repository_inventory_heads",
+      "schema": "",
+      "columns": {
+        "account_login": {
+          "name": "account_login",
+          "type": "varchar(39)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_user_id": {
+          "name": "account_user_id",
+          "type": "varchar(32)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "generation": {
+          "name": "generation",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "gh_repo_inventory_head_account_id": {
+          "name": "gh_repo_inventory_head_account_id",
+          "value": "\"github_repository_inventory_heads\".\"account_user_id\" ~ '^[0-9]{1,32}$'"
+        },
+        "gh_repo_inventory_head_generation": {
+          "name": "gh_repo_inventory_head_generation",
+          "value": "(\"github_repository_inventory_heads\".\"generation\" = 0 AND \"github_repository_inventory_heads\".\"completed_at\" IS NULL) OR (\"github_repository_inventory_heads\".\"generation\" > 0 AND \"github_repository_inventory_heads\".\"completed_at\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.github_repository_refs": {
+      "name": "github_repository_refs",
+      "schema": "",
+      "columns": {
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "branch_lineage_id": {
+          "name": "branch_lineage_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_observed_at": {
+          "name": "first_observed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "head_sha": {
+          "name": "head_sha",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_observed_at": {
+          "name": "last_observed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "projection_relevant": {
+          "name": "projection_relevant",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "ref_name": {
+          "name": "ref_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repair_attempts": {
+          "name": "repair_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "repair_error": {
+          "name": "repair_error",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repair_lease_token": {
+          "name": "repair_lease_token",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repair_lease_until": {
+          "name": "repair_lease_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "github_repository_refs_active_idx": {
+          "name": "github_repository_refs_active_idx",
+          "columns": [
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "github_repository_refs_projection_idx": {
+          "name": "github_repository_refs_projection_idx",
+          "columns": [
+            {
+              "expression": "projection_relevant",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_observed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_repository_refs_repository_fk": {
+          "name": "github_repository_refs_repository_fk",
+          "tableFrom": "github_repository_refs",
+          "tableTo": "github_repositories",
+          "columnsFrom": ["repository_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "github_repository_refs_repository_id_ref_name_pk": {
+          "name": "github_repository_refs_repository_id_ref_name_pk",
+          "columns": ["repository_id", "ref_name"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "github_repository_refs_kind": {
+          "name": "github_repository_refs_kind",
+          "value": "\"github_repository_refs\".\"kind\" IN ('head', 'tag')"
+        },
+        "github_repository_refs_name": {
+          "name": "github_repository_refs_name",
+          "value": "(\"github_repository_refs\".\"kind\" = 'head' AND \"github_repository_refs\".\"ref_name\" LIKE 'refs/heads/%') OR (\"github_repository_refs\".\"kind\" = 'tag' AND \"github_repository_refs\".\"ref_name\" LIKE 'refs/tags/%')"
+        },
+        "github_repository_refs_lineage": {
+          "name": "github_repository_refs_lineage",
+          "value": "(\"github_repository_refs\".\"kind\" = 'head') = (\"github_repository_refs\".\"branch_lineage_id\" IS NOT NULL)"
+        },
+        "github_repository_refs_projection_relevance": {
+          "name": "github_repository_refs_projection_relevance",
+          "value": "NOT \"github_repository_refs\".\"projection_relevant\" OR \"github_repository_refs\".\"kind\" = 'head'"
+        },
+        "github_repository_refs_sha_shape": {
+          "name": "github_repository_refs_sha_shape",
+          "value": "\"github_repository_refs\".\"head_sha\" ~ '^[a-f0-9]{40}$'"
+        },
+        "github_repository_refs_observation_order": {
+          "name": "github_repository_refs_observation_order",
+          "value": "\"github_repository_refs\".\"last_observed_at\" >= \"github_repository_refs\".\"first_observed_at\""
+        },
+        "github_repository_refs_repair_lease": {
+          "name": "github_repository_refs_repair_lease",
+          "value": "(\"github_repository_refs\".\"repair_lease_token\" IS NULL) = (\"github_repository_refs\".\"repair_lease_until\" IS NULL) AND (\"github_repository_refs\".\"repair_lease_token\" IS NULL OR \"github_repository_refs\".\"kind\" = 'head')"
+        },
+        "github_repository_refs_repair_attempts": {
+          "name": "github_repository_refs_repair_attempts",
+          "value": "\"github_repository_refs\".\"repair_attempts\" >= 0"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.github_webhook_deliveries": {
+      "name": "github_webhook_deliveries",
+      "schema": "",
+      "columns": {
+        "accepted": {
+          "name": "accepted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account": {
+          "name": "account",
+          "type": "varchar(39)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_id": {
+          "name": "delivery_id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event": {
+          "name": "event",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "observed_at": {
+          "name": "observed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "github_webhook_deliveries_audit_idx": {
+          "name": "github_webhook_deliveries_audit_idx",
+          "columns": [
+            {
+              "expression": "event",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "observed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "github_webhook_deliveries_id_shape": {
+          "name": "github_webhook_deliveries_id_shape",
+          "value": "\"github_webhook_deliveries\".\"delivery_id\" ~ '^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$'"
+        },
+        "github_webhook_deliveries_event_shape": {
+          "name": "github_webhook_deliveries_event_shape",
+          "value": "\"github_webhook_deliveries\".\"event\" ~ '^[a-z][a-z0-9_]{0,39}$'"
+        },
+        "github_webhook_deliveries_action_shape": {
+          "name": "github_webhook_deliveries_action_shape",
+          "value": "\"github_webhook_deliveries\".\"action\" IS NULL OR \"github_webhook_deliveries\".\"action\" ~ '^[a-z][a-z0-9_]{0,39}$'"
+        },
+        "github_webhook_deliveries_repository_id_shape": {
+          "name": "github_webhook_deliveries_repository_id_shape",
+          "value": "\"github_webhook_deliveries\".\"repository_id\" IS NULL OR \"github_webhook_deliveries\".\"repository_id\" ~ '^[0-9]{1,32}$'"
+        },
+        "github_webhook_deliveries_tracked_account": {
+          "name": "github_webhook_deliveries_tracked_account",
+          "value": "\"github_webhook_deliveries\".\"account\" IS NULL OR \"github_webhook_deliveries\".\"account\" IN ('f0rr0', 'yuppiestechdev')"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.github_work_unit_accepted_summaries": {
+      "name": "github_work_unit_accepted_summaries",
+      "schema": "",
+      "columns": {
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attribution_mode": {
+          "name": "attribution_mode",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "identity_key": {
+          "name": "identity_key",
+          "type": "varchar(180)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "outcome_digest": {
+          "name": "outcome_digest",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipe": {
+          "name": "recipe",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary_input_digest": {
+          "name": "summary_input_digest",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "gh_work_unit_accepted_summaries_identity_idx": {
+          "name": "gh_work_unit_accepted_summaries_identity_idx",
+          "columns": [
+            {
+              "expression": "identity_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "attribution_mode",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "recipe",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "accepted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "gh_work_unit_accepted_summaries_outcome_idx": {
+          "name": "gh_work_unit_accepted_summaries_outcome_idx",
+          "columns": [
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "outcome_digest",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "attribution_mode",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "recipe",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "accepted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "gh_work_unit_accepted_summaries_pk": {
+          "name": "gh_work_unit_accepted_summaries_pk",
+          "columns": ["identity_key", "summary_input_digest", "recipe"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "gh_work_unit_accepted_summaries_digests": {
+          "name": "gh_work_unit_accepted_summaries_digests",
+          "value": "\"github_work_unit_accepted_summaries\".\"outcome_digest\" ~ '^[a-f0-9]{64}$' AND \"github_work_unit_accepted_summaries\".\"summary_input_digest\" ~ '^[a-f0-9]{64}$'"
+        },
+        "gh_work_unit_accepted_summaries_attribution": {
+          "name": "gh_work_unit_accepted_summaries_attribution",
+          "value": "\"github_work_unit_accepted_summaries\".\"attribution_mode\" IN ('tracked_authored_pr', 'foreign_pr_contribution', 'canonical_owned_composite', 'branch_owned_composite')"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.github_work_unit_memberships": {
+      "name": "github_work_unit_memberships",
+      "schema": "",
+      "columns": {
+        "logical_repository_id": {
+          "name": "logical_repository_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logical_sha": {
+          "name": "logical_sha",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "work_unit_id": {
+          "name": "work_unit_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "gh_work_unit_memberships_position_unique": {
+          "name": "gh_work_unit_memberships_position_unique",
+          "columns": [
+            {
+              "expression": "work_unit_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "gh_work_unit_memberships_commit_unique": {
+          "name": "gh_work_unit_memberships_commit_unique",
+          "columns": [
+            {
+              "expression": "logical_repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "logical_sha",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gh_work_unit_memberships_unit_fk": {
+          "name": "gh_work_unit_memberships_unit_fk",
+          "tableFrom": "github_work_unit_memberships",
+          "tableTo": "github_work_units",
+          "columnsFrom": ["work_unit_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gh_work_unit_memberships_commit_fk": {
+          "name": "gh_work_unit_memberships_commit_fk",
+          "tableFrom": "github_work_unit_memberships",
+          "tableTo": "github_commits",
+          "columnsFrom": ["logical_repository_id", "logical_sha"],
+          "columnsTo": ["repository_id", "sha"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "gh_work_unit_memberships_pk": {
+          "name": "gh_work_unit_memberships_pk",
+          "columns": ["work_unit_id", "logical_repository_id", "logical_sha"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "gh_work_unit_memberships_values": {
+          "name": "gh_work_unit_memberships_values",
+          "value": "\"github_work_unit_memberships\".\"position\" >= 0 AND \"github_work_unit_memberships\".\"logical_sha\" ~ '^[a-f0-9]{40}$'"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.github_work_unit_summary_attempts": {
+      "name": "github_work_unit_summary_attempts",
+      "schema": "",
+      "columns": {
+        "identity_key": {
+          "name": "identity_key",
+          "type": "varchar(180)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attribution_mode": {
+          "name": "attribution_mode",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "debounce_until": {
+          "name": "debounce_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_started_at": {
+          "name": "request_started_at",
+          "type": "timestamp with time zone[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY[]::timestamptz[]"
+        },
+        "last_started_at": {
+          "name": "last_started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latency_ms": {
+          "name": "latency_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lease_token": {
+          "name": "lease_token",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lease_until": {
+          "name": "lease_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "outcome_digest": {
+          "name": "outcome_digest",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recipe": {
+          "name": "recipe",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_payload": {
+          "name": "request_payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revision": {
+          "name": "revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_requests": {
+          "name": "started_requests",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "state": {
+          "name": "state",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "summary_input_digest": {
+          "name": "summary_input_digest",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "work_unit_id": {
+          "name": "work_unit_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "gh_work_unit_summary_input_unique": {
+          "name": "gh_work_unit_summary_input_unique",
+          "columns": [
+            {
+              "expression": "work_unit_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "summary_input_digest",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "recipe",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "gh_work_unit_summary_claim_idx": {
+          "name": "gh_work_unit_summary_claim_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "debounce_until",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "gh_work_unit_summary_attempts_identity_idx": {
+          "name": "gh_work_unit_summary_attempts_identity_idx",
+          "columns": [
+            {
+              "expression": "identity_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "gh_work_unit_summary_attempts_pk": {
+          "name": "gh_work_unit_summary_attempts_pk",
+          "columns": ["work_unit_id", "revision"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "gh_work_unit_summary_state": {
+          "name": "gh_work_unit_summary_state",
+          "value": "\"github_work_unit_summary_attempts\".\"state\" IN ('pending', 'processing', 'retryable', 'accepted', 'terminal')"
+        },
+        "gh_work_unit_summary_digests": {
+          "name": "gh_work_unit_summary_digests",
+          "value": "\"github_work_unit_summary_attempts\".\"outcome_digest\" ~ '^[a-f0-9]{64}$' AND \"github_work_unit_summary_attempts\".\"summary_input_digest\" ~ '^[a-f0-9]{64}$'"
+        },
+        "gh_work_unit_summary_attribution": {
+          "name": "gh_work_unit_summary_attribution",
+          "value": "\"github_work_unit_summary_attempts\".\"attribution_mode\" IN ('tracked_authored_pr', 'foreign_pr_contribution', 'canonical_owned_composite', 'branch_owned_composite')"
+        },
+        "gh_work_unit_summary_revisions": {
+          "name": "gh_work_unit_summary_revisions",
+          "value": "\"github_work_unit_summary_attempts\".\"revision\" > 0 AND \"github_work_unit_summary_attempts\".\"started_requests\" BETWEEN 0 AND 2"
+        },
+        "gh_work_unit_summary_lease": {
+          "name": "gh_work_unit_summary_lease",
+          "value": "(\"github_work_unit_summary_attempts\".\"lease_token\" IS NULL) = (\"github_work_unit_summary_attempts\".\"lease_until\" IS NULL) AND (\"github_work_unit_summary_attempts\".\"state\" = 'processing') = (\"github_work_unit_summary_attempts\".\"lease_token\" IS NOT NULL) AND (\"github_work_unit_summary_attempts\".\"state\" <> 'processing' OR (\"github_work_unit_summary_attempts\".\"started_requests\" > 0 AND \"github_work_unit_summary_attempts\".\"request_payload\" IS NOT NULL))"
+        },
+        "gh_work_unit_summary_terminal_payload": {
+          "name": "gh_work_unit_summary_terminal_payload",
+          "value": "\"github_work_unit_summary_attempts\".\"state\" NOT IN ('accepted', 'terminal') OR \"github_work_unit_summary_attempts\".\"request_payload\" IS NULL"
+        },
+        "gh_work_unit_summary_accepted_output": {
+          "name": "gh_work_unit_summary_accepted_output",
+          "value": "(\"github_work_unit_summary_attempts\".\"state\" = 'accepted' AND \"github_work_unit_summary_attempts\".\"outcome\" IS NOT NULL AND \"github_work_unit_summary_attempts\".\"accepted_at\" IS NOT NULL AND \"github_work_unit_summary_attempts\".\"completed_at\" IS NOT NULL) OR (\"github_work_unit_summary_attempts\".\"state\" <> 'accepted' AND \"github_work_unit_summary_attempts\".\"outcome\" IS NULL AND \"github_work_unit_summary_attempts\".\"accepted_at\" IS NULL AND (\"github_work_unit_summary_attempts\".\"state\" <> 'terminal' OR \"github_work_unit_summary_attempts\".\"completed_at\" IS NOT NULL))"
+        },
+        "gh_work_unit_summary_started": {
+          "name": "gh_work_unit_summary_started",
+          "value": "(\"github_work_unit_summary_attempts\".\"started_requests\" = 0) = (\"github_work_unit_summary_attempts\".\"last_started_at\" IS NULL) AND (\"github_work_unit_summary_attempts\".\"state\" <> 'pending' OR \"github_work_unit_summary_attempts\".\"request_payload\" IS NOT NULL)"
+        },
+        "gh_work_unit_summary_request_cap": {
+          "name": "gh_work_unit_summary_request_cap",
+          "value": "\"github_work_unit_summary_attempts\".\"request_payload\" IS NULL OR octet_length(\"github_work_unit_summary_attempts\".\"request_payload\") <= 393216"
+        },
+        "gh_work_unit_summary_request_times": {
+          "name": "gh_work_unit_summary_request_times",
+          "value": "cardinality(\"github_work_unit_summary_attempts\".\"request_started_at\") = \"github_work_unit_summary_attempts\".\"started_requests\""
+        },
+        "gh_work_unit_summary_metrics": {
+          "name": "gh_work_unit_summary_metrics",
+          "value": "(\"github_work_unit_summary_attempts\".\"input_tokens\" IS NULL OR \"github_work_unit_summary_attempts\".\"input_tokens\" >= 0) AND (\"github_work_unit_summary_attempts\".\"output_tokens\" IS NULL OR \"github_work_unit_summary_attempts\".\"output_tokens\" >= 0) AND (\"github_work_unit_summary_attempts\".\"latency_ms\" IS NULL OR \"github_work_unit_summary_attempts\".\"latency_ms\" >= 0)"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.github_work_unit_summary_daily_usage": {
+      "name": "github_work_unit_summary_daily_usage",
+      "schema": "",
+      "columns": {
+        "day": {
+          "name": "day",
+          "type": "date",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "started_requests": {
+          "name": "started_requests",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.github_work_units": {
+      "name": "github_work_units",
+      "schema": "",
+      "columns": {
+        "activity_anchor_at": {
+          "name": "activity_anchor_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activity_at": {
+          "name": "activity_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activity_day": {
+          "name": "activity_day",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "additions": {
+          "name": "additions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attribution_mode": {
+          "name": "attribution_mode",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "branch_lineage_id": {
+          "name": "branch_lineage_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_observed_at": {
+          "name": "content_observed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deletions": {
+          "name": "deletions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "facts_digest": {
+          "name": "facts_digest",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_count": {
+          "name": "file_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_activity_at": {
+          "name": "first_activity_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "identity_key": {
+          "name": "identity_key",
+          "type": "varchar(180)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "languages": {
+          "name": "languages",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_activity_at": {
+          "name": "last_activity_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "member_count": {
+          "name": "member_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "membership_digest": {
+          "name": "membership_digest",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "newest_commit_repository_id": {
+          "name": "newest_commit_repository_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "newest_commit_sha": {
+          "name": "newest_commit_sha",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "outcome_digest": {
+          "name": "outcome_digest",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pull_request_node_id": {
+          "name": "pull_request_node_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revision": {
+          "name": "revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "summary_evaluation_digest": {
+          "name": "summary_evaluation_digest",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary_evaluated_digest": {
+          "name": "summary_evaluated_digest",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary_input_digest": {
+          "name": "summary_input_digest",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "gh_work_units_identity_unique": {
+          "name": "gh_work_units_identity_unique",
+          "columns": [
+            {
+              "expression": "identity_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "gh_work_units_pr_unique": {
+          "name": "gh_work_units_pr_unique",
+          "columns": [
+            {
+              "expression": "pull_request_node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"github_work_units\".\"kind\" = 'pull_request'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "gh_work_units_canonical_day_unique": {
+          "name": "gh_work_units_canonical_day_unique",
+          "columns": [
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "activity_day",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"github_work_units\".\"kind\" = 'canonical_day'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "gh_work_units_branch_unique": {
+          "name": "gh_work_units_branch_unique",
+          "columns": [
+            {
+              "expression": "branch_lineage_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"github_work_units\".\"kind\" = 'branch'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "gh_work_units_feed_idx": {
+          "name": "gh_work_units_feed_idx",
+          "columns": [
+            {
+              "expression": "visibility",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "activity_day",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "activity_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gh_work_units_repository_fk": {
+          "name": "gh_work_units_repository_fk",
+          "tableFrom": "github_work_units",
+          "tableTo": "github_repositories",
+          "columnsFrom": ["repository_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gh_work_units_pull_request_fk": {
+          "name": "gh_work_units_pull_request_fk",
+          "tableFrom": "github_work_units",
+          "tableTo": "github_pull_requests",
+          "columnsFrom": ["pull_request_node_id"],
+          "columnsTo": ["node_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gh_work_units_newest_commit_fk": {
+          "name": "gh_work_units_newest_commit_fk",
+          "tableFrom": "github_work_units",
+          "tableTo": "github_commits",
+          "columnsFrom": ["newest_commit_repository_id", "newest_commit_sha"],
+          "columnsTo": ["repository_id", "sha"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "gh_work_units_kind": {
+          "name": "gh_work_units_kind",
+          "value": "\"github_work_units\".\"kind\" IN ('pull_request', 'canonical_day', 'branch')"
+        },
+        "gh_work_units_owner_shape": {
+          "name": "gh_work_units_owner_shape",
+          "value": "(\"github_work_units\".\"kind\" = 'pull_request' AND \"github_work_units\".\"pull_request_node_id\" IS NOT NULL AND \"github_work_units\".\"branch_lineage_id\" IS NULL) OR (\"github_work_units\".\"kind\" = 'canonical_day' AND \"github_work_units\".\"pull_request_node_id\" IS NULL AND \"github_work_units\".\"branch_lineage_id\" IS NULL) OR (\"github_work_units\".\"kind\" = 'branch' AND \"github_work_units\".\"pull_request_node_id\" IS NULL AND \"github_work_units\".\"branch_lineage_id\" IS NOT NULL)"
+        },
+        "gh_work_units_identity": {
+          "name": "gh_work_units_identity",
+          "value": "(\"github_work_units\".\"kind\" = 'pull_request' AND \"github_work_units\".\"identity_key\" = 'pr:' || \"github_work_units\".\"pull_request_node_id\") OR (\"github_work_units\".\"kind\" = 'canonical_day' AND \"github_work_units\".\"identity_key\" = 'canonical:' || \"github_work_units\".\"repository_id\" || ':' || \"github_work_units\".\"activity_day\"::text) OR (\"github_work_units\".\"kind\" = 'branch' AND \"github_work_units\".\"identity_key\" = 'branch:' || \"github_work_units\".\"branch_lineage_id\"::text)"
+        },
+        "gh_work_units_attribution_mode": {
+          "name": "gh_work_units_attribution_mode",
+          "value": "\"github_work_units\".\"attribution_mode\" IN ('tracked_authored_pr', 'foreign_pr_contribution', 'canonical_owned_composite', 'branch_owned_composite')"
+        },
+        "gh_work_units_kind_attribution": {
+          "name": "gh_work_units_kind_attribution",
+          "value": "(\"github_work_units\".\"kind\" = 'pull_request' AND \"github_work_units\".\"attribution_mode\" IN ('tracked_authored_pr', 'foreign_pr_contribution')) OR (\"github_work_units\".\"kind\" = 'canonical_day' AND \"github_work_units\".\"attribution_mode\" = 'canonical_owned_composite') OR (\"github_work_units\".\"kind\" = 'branch' AND \"github_work_units\".\"attribution_mode\" = 'branch_owned_composite')"
+        },
+        "gh_work_units_visibility": {
+          "name": "gh_work_units_visibility",
+          "value": "\"github_work_units\".\"visibility\" IN ('public', 'private')"
+        },
+        "gh_work_units_nonnegative_facts": {
+          "name": "gh_work_units_nonnegative_facts",
+          "value": "\"github_work_units\".\"member_count\" > 0 AND \"github_work_units\".\"file_count\" >= 0 AND \"github_work_units\".\"additions\" >= 0 AND \"github_work_units\".\"deletions\" >= 0 AND \"github_work_units\".\"revision\" > 0"
+        },
+        "gh_work_units_activity_order": {
+          "name": "gh_work_units_activity_order",
+          "value": "\"github_work_units\".\"first_activity_at\" <= \"github_work_units\".\"last_activity_at\" AND \"github_work_units\".\"activity_day\" = (\"github_work_units\".\"activity_at\" AT TIME ZONE 'UTC')::date"
+        },
+        "gh_work_units_digest_shapes": {
+          "name": "gh_work_units_digest_shapes",
+          "value": "\"github_work_units\".\"facts_digest\" ~ '^[a-f0-9]{64}$' AND \"github_work_units\".\"membership_digest\" ~ '^[a-f0-9]{64}$' AND (\"github_work_units\".\"outcome_digest\" IS NULL OR \"github_work_units\".\"outcome_digest\" ~ '^[a-f0-9]{64}$') AND (\"github_work_units\".\"summary_evaluation_digest\" IS NULL OR \"github_work_units\".\"summary_evaluation_digest\" ~ '^[a-f0-9]{64}$') AND (\"github_work_units\".\"summary_evaluated_digest\" IS NULL OR \"github_work_units\".\"summary_evaluated_digest\" ~ '^[a-f0-9]{64}$') AND (\"github_work_units\".\"summary_input_digest\" IS NULL OR \"github_work_units\".\"summary_input_digest\" ~ '^[a-f0-9]{64}$')"
+        },
+        "gh_work_units_languages_array": {
+          "name": "gh_work_units_languages_array",
+          "value": "\"github_work_units\".\"languages\" IS NULL OR jsonb_typeof(\"github_work_units\".\"languages\") = 'array'"
+        }
+      },
+      "isRLSEnabled": true
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -148,6 +148,13 @@
       "when": 1788807293156,
       "tag": "0020_lame_blindfold",
       "breakpoints": true
+    },
+    {
+      "idx": 21,
+      "version": "7",
+      "when": 1788813490378,
+      "tag": "0021_windy_midnight",
+      "breakpoints": true
     }
   ]
 }

--- a/scripts/configure-supabase-cron.ts
+++ b/scripts/configure-supabase-cron.ts
@@ -21,6 +21,7 @@ const SUMMARY_URL_NAME = "github_summary_url";
 const WORKER_URL_NAME = "github_worker_url";
 const CODEX_STATS_URL_NAME = "codex_stats_url";
 const CODEX_STATS_JOB_NAME = "codex-stats-every-fifteen-minutes";
+const LEGACY_SUMMARY_JOB_NAME = "github-summary-worker-every-five-minutes";
 const LEGACY_JOB_NAME = "github-sync-every-three-hours";
 const LEGACY_REFS_JOB_NAME = "github-refs-every-fifteen-minutes";
 const LEGACY_TAG_REFS_JOB_NAME = "github-tag-refs-every-fifteen-minutes";
@@ -205,6 +206,7 @@ export const configureSupabaseCron = async (
           ${LEGACY_JOB_NAME},
           ${LEGACY_REFS_JOB_NAME},
           ${LEGACY_TAG_REFS_JOB_NAME},
+          ${LEGACY_SUMMARY_JOB_NAME},
           ${GITHUB_EVENTS_CRON_JOB.name},
           ${GITHUB_HEAD_REFS_CRON_JOB.name},
           ${GITHUB_SUMMARY_CRON_JOB.name},

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -1329,6 +1329,8 @@ export const githubWorkUnitMemberships = pgTable(
 export const githubWorkUnitSummaryAttempts = pgTable(
   "github_work_unit_summary_attempts",
   {
+    identityKey: varchar("identity_key", { length: 180 }).notNull(),
+    repositoryId: varchar("repository_id", { length: 32 }).notNull(),
     errorCode: varchar("error_code", { length: 80 }),
     acceptedAt: timestamp("accepted_at", {
       mode: "date",
@@ -1350,6 +1352,15 @@ export const githubWorkUnitSummaryAttempts = pgTable(
       withTimezone: true,
     }).notNull(),
     inputTokens: integer("input_tokens"),
+    // At most two starts. A null entry marks an unknown pre-migration time.
+    requestStartedAt: timestamp("request_started_at", {
+      mode: "date",
+      withTimezone: true,
+    })
+      .array()
+      .$type<(Date | null)[]>()
+      .default(sql`ARRAY[]::timestamptz[]`)
+      .notNull(),
     lastStartedAt: timestamp("last_started_at", {
       mode: "date",
       withTimezone: true,
@@ -1389,11 +1400,8 @@ export const githubWorkUnitSummaryAttempts = pgTable(
       table.debounceUntil,
       table.createdAt
     ),
-    foreignKey({
-      columns: [table.workUnitId],
-      foreignColumns: [githubWorkUnits.id],
-      name: "gh_work_unit_summary_attempts_unit_fk",
-    }).onDelete("cascade"),
+    // Paid attempts outlive the current projection, including branch deletion.
+    index("gh_work_unit_summary_attempts_identity_idx").on(table.identityKey),
     check(
       "gh_work_unit_summary_state",
       sql`${table.state} IN ('pending', 'processing', 'retryable', 'accepted', 'terminal')`
@@ -1429,6 +1437,10 @@ export const githubWorkUnitSummaryAttempts = pgTable(
     check(
       "gh_work_unit_summary_request_cap",
       sql`${table.requestPayload} IS NULL OR octet_length(${table.requestPayload}) <= 393216`
+    ),
+    check(
+      "gh_work_unit_summary_request_times",
+      sql`cardinality(${table.requestStartedAt}) = ${table.startedRequests}`
     ),
     check(
       "gh_work_unit_summary_metrics",

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -1352,6 +1352,7 @@ export const githubWorkUnitSummaryAttempts = pgTable(
       withTimezone: true,
     }).notNull(),
     inputTokens: integer("input_tokens"),
+    // Recorded by the database trigger when startedRequests increases.
     // At most two starts. A null entry marks an unknown pre-migration time.
     requestStartedAt: timestamp("request_started_at", {
       mode: "date",

--- a/src/lib/github-activity-store.ts
+++ b/src/lib/github-activity-store.ts
@@ -608,10 +608,10 @@ const readPublicRows = async (
       kind,
       repository: repository.projection,
       summarizing:
-        summarizingUnits.has(row.id) ||
-        (summariesAreRunning &&
-          row.summaryEvaluationDigest !== null &&
-          row.summaryEvaluationDigest !== row.summaryEvaluatedDigest),
+        summariesAreRunning &&
+        (summarizingUnits.has(row.id) ||
+          (row.summaryEvaluationDigest !== null &&
+            row.summaryEvaluationDigest !== row.summaryEvaluatedDigest)),
       summary: summary?.summary ?? null,
     };
   });

--- a/src/lib/github-cron-config.ts
+++ b/src/lib/github-cron-config.ts
@@ -9,8 +9,8 @@ export const GITHUB_WORKER_CRON_JOB = {
 } as const;
 
 export const GITHUB_SUMMARY_CRON_JOB = {
-  name: "github-summary-worker-every-minute",
-  schedule: "* * * * *",
+  name: "github-summary-worker-every-three-minutes",
+  schedule: "*/3 * * * *",
 } as const;
 
 export const GITHUB_SUMMARY_REQUEST_BUDGET = {

--- a/src/lib/github-cron-config.ts
+++ b/src/lib/github-cron-config.ts
@@ -9,8 +9,8 @@ export const GITHUB_WORKER_CRON_JOB = {
 } as const;
 
 export const GITHUB_SUMMARY_CRON_JOB = {
-  name: "github-summary-worker-every-five-minutes",
-  schedule: "3-58/5 * * * *",
+  name: "github-summary-worker-every-minute",
+  schedule: "* * * * *",
 } as const;
 
 export const GITHUB_SUMMARY_REQUEST_BUDGET = {

--- a/src/lib/github-work-unit-store.ts
+++ b/src/lib/github-work-unit-store.ts
@@ -1504,11 +1504,19 @@ const persistProjectedUnit = async (
     projected
   );
   if (current === undefined) {
+    const [retained] = await transaction
+      .select({ workUnitId: githubWorkUnitSummaryAttempts.workUnitId })
+      .from(githubWorkUnitSummaryAttempts)
+      .where(
+        eq(githubWorkUnitSummaryAttempts.identityKey, projected.identityKey)
+      )
+      .limit(1);
     const [row] = await transaction
       .insert(githubWorkUnits)
-      .values(
-        projectedValues(projected, 1, summaryEvaluationDigest, null, null)
-      )
+      .values({
+        ...projectedValues(projected, 1, summaryEvaluationDigest, null, null),
+        id: retained?.workUnitId,
+      })
       .returning({ id: githubWorkUnits.id });
     if (row === undefined) {
       throw new Error("A GitHub work unit could not be inserted.");
@@ -1642,6 +1650,15 @@ const swapProjection = async (
       .where(inArray(githubWorkUnitMemberships.workUnitId, affectedCurrentIds));
   }
   if (deleted.length > 0) {
+    await transaction.delete(githubWorkUnitSummaryAttempts).where(
+      and(
+        inArray(
+          githubWorkUnitSummaryAttempts.workUnitId,
+          deleted.map((unit) => unit.id)
+        ),
+        eq(githubWorkUnitSummaryAttempts.startedRequests, 0)
+      )
+    );
     await transaction.delete(githubWorkUnits).where(
       inArray(
         githubWorkUnits.id,
@@ -2075,6 +2092,8 @@ const setSummaryInputs = async (
       }
       const revision = (maximumRevisionByUnit.get(current.id) ?? 0) + 1;
       await transaction.insert(githubWorkUnitSummaryAttempts).values({
+        identityKey: item.unit.projected.identityKey,
+        repositoryId: item.unit.projected.repositoryId,
         attributionMode: item.unit.projected.attributionMode,
         debounceUntil: new Date(now.getTime() + SUMMARY_DEBOUNCE_MS),
         inputTokens: eligibleBuild.inputTokens,

--- a/src/lib/github-work-unit-summary-provider.ts
+++ b/src/lib/github-work-unit-summary-provider.ts
@@ -45,8 +45,6 @@ export interface GitHubWorkUnitSummaryProviderDependencies {
 }
 
 export class GitHubWorkUnitSummaryInvalidInputError extends Error {
-  readonly retryable = false;
-
   constructor(options?: ErrorOptions) {
     super("The persisted GitHub work-unit summary input is invalid.", options);
     this.name = "GitHubWorkUnitSummaryInvalidInputError";
@@ -56,7 +54,6 @@ export class GitHubWorkUnitSummaryInvalidInputError extends Error {
 // oxlint-disable-next-line max-classes-per-file -- Input and output failures have different terminal meanings at the worker boundary.
 export class GitHubWorkUnitSummaryInvalidOutputError extends Error {
   readonly reason: GitHubWorkUnitSummaryOutputRejectionReason;
-  readonly retryable = true;
 
   constructor(
     reason: GitHubWorkUnitSummaryOutputRejectionReason,

--- a/src/lib/github-work-unit-summary-store.ts
+++ b/src/lib/github-work-unit-summary-store.ts
@@ -294,17 +294,11 @@ const reuseAcceptedSummaries = async (
 };
 
 const claimSelection = {
-  activityAt: githubWorkUnits.activityAt,
-  attributionMode: githubWorkUnitSummaryAttempts.attributionMode,
-  contentObservedAt: githubWorkUnits.contentObservedAt,
   debounceUntil: githubWorkUnitSummaryAttempts.debounceUntil,
-  outcomeDigest: githubWorkUnitSummaryAttempts.outcomeDigest,
-  recipe: githubWorkUnitSummaryAttempts.recipe,
   requestPayload: githubWorkUnitSummaryAttempts.requestPayload,
   revision: githubWorkUnitSummaryAttempts.revision,
   startedRequests: githubWorkUnitSummaryAttempts.startedRequests,
   state: githubWorkUnitSummaryAttempts.state,
-  summaryInputDigest: githubWorkUnitSummaryAttempts.summaryInputDigest,
   workUnitId: githubWorkUnitSummaryAttempts.workUnitId,
 };
 
@@ -388,9 +382,7 @@ const lockedUnit = async (
     .select({
       activityDay: githubWorkUnits.activityDay,
       attributionMode: githubWorkUnits.attributionMode,
-      identityKey: githubWorkUnits.identityKey,
       outcomeDigest: githubWorkUnits.outcomeDigest,
-      repositoryId: githubWorkUnits.repositoryId,
       summaryEvaluatedDigest: githubWorkUnits.summaryEvaluatedDigest,
       summaryEvaluationDigest: githubWorkUnits.summaryEvaluationDigest,
       summaryInputDigest: githubWorkUnits.summaryInputDigest,
@@ -552,7 +544,6 @@ const tryClaimCandidate = async (
     .update(githubWorkUnitSummaryAttempts)
     .set({
       lastStartedAt: now,
-      requestStartedAt: sql`array_append(${githubWorkUnitSummaryAttempts.requestStartedAt}, ${now.toISOString()}::timestamptz)`,
       leaseToken,
       leaseUntil: new Date(now.getTime() + leaseDurationMs),
       startedRequests,

--- a/src/lib/github-work-unit-summary-store.ts
+++ b/src/lib/github-work-unit-summary-store.ts
@@ -28,7 +28,10 @@ import { env } from "@/env";
 import { PUBLIC_GITHUB_ACTIVITY_DAY_PAGE_SIZE } from "@/lib/github-activity-store";
 import { GITHUB_SUMMARY_REQUEST_BUDGET } from "@/lib/github-cron-config";
 import { acquireGitHubWorkUnitProjectionLock } from "@/lib/github-work-unit-projection-state";
-import { GITHUB_WORK_UNIT_SUMMARY_RECIPE } from "@/lib/github-work-unit-summary";
+import {
+  decodeGitHubWorkUnitSummary,
+  GITHUB_WORK_UNIT_SUMMARY_RECIPE,
+} from "@/lib/github-work-unit-summary";
 import type { GitHubWorkUnitSummaryAttributionMode } from "@/lib/github-work-unit-summary";
 import type { GitHubWorkUnitSummaryProviderResult } from "@/lib/github-work-unit-summary-provider";
 
@@ -198,47 +201,25 @@ const currentUnitMatchesAttempt = (
 const reconcileInactiveSummaryInputs = async (
   transaction: SummaryTransaction
 ) => {
+  const inactive = sql`
+    (attempt.recipe <> ${GITHUB_WORK_UNIT_SUMMARY_RECIPE} or not exists (
+      select 1 from ${githubWorkUnits} w
+      where w.id = attempt.work_unit_id
+        and w.summary_evaluation_digest = w.summary_evaluated_digest
+        and w.outcome_digest = attempt.outcome_digest
+        and w.summary_input_digest = attempt.summary_input_digest
+        and w.attribution_mode = attempt.attribution_mode
+    ))
+  `;
   await transaction.execute(sql`
     delete from ${githubWorkUnitSummaryAttempts} as attempt
-    using ${githubWorkUnits} as work_unit
-    where attempt.work_unit_id = work_unit.id
-      and attempt.state in ('pending', 'retryable')
-      and (
-        attempt.recipe <> ${GITHUB_WORK_UNIT_SUMMARY_RECIPE}
-        or (
-          attempt.started_requests = 0
-          and (
-            work_unit.summary_evaluation_digest is null
-            or work_unit.summary_evaluation_digest
-              is distinct from work_unit.summary_evaluated_digest
-            or work_unit.outcome_digest is distinct from attempt.outcome_digest
-            or work_unit.summary_input_digest
-              is distinct from attempt.summary_input_digest
-            or work_unit.attribution_mode
-              is distinct from attempt.attribution_mode
-          )
-        )
-      )
+    where attempt.state in ('pending', 'retryable')
+      and attempt.started_requests = 0 and ${inactive}
   `);
   await transaction.execute(sql`
-    update ${githubWorkUnitSummaryAttempts} as attempt
-    set request_payload = null
-    from ${githubWorkUnits} as work_unit
-    where attempt.work_unit_id = work_unit.id
-      and attempt.state = 'retryable'
-      and attempt.started_requests > 0
-      and attempt.request_payload is not null
-      and attempt.recipe = ${GITHUB_WORK_UNIT_SUMMARY_RECIPE}
-      and (
-        work_unit.summary_evaluation_digest is null
-        or work_unit.summary_evaluation_digest
-          is distinct from work_unit.summary_evaluated_digest
-        or work_unit.outcome_digest is distinct from attempt.outcome_digest
-        or work_unit.summary_input_digest
-          is distinct from attempt.summary_input_digest
-        or work_unit.attribution_mode
-          is distinct from attempt.attribution_mode
-      )
+    update ${githubWorkUnitSummaryAttempts} as attempt set request_payload = null
+    where attempt.state = 'retryable' and attempt.started_requests > 0
+      and attempt.request_payload is not null and ${inactive}
   `);
 };
 
@@ -246,66 +227,70 @@ const recoverExpiredClaims = async (
   transaction: SummaryTransaction,
   now: Date
 ) => {
-  const expiredUnits = await transaction
-    .select({ id: githubWorkUnits.id })
-    .from(githubWorkUnits)
-    .innerJoin(
-      githubWorkUnitSummaryAttempts,
-      eq(githubWorkUnitSummaryAttempts.workUnitId, githubWorkUnits.id)
-    )
-    .where(
-      and(
-        eq(githubWorkUnitSummaryAttempts.state, "processing"),
-        lte(githubWorkUnitSummaryAttempts.leaseUntil, now)
-      )
-    )
-    .orderBy(githubWorkUnits.identityKey)
-    .for("update", { of: githubWorkUnits });
-  const expiredWorkUnitIds = [...new Set(expiredUnits.map(({ id }) => id))];
-  if (expiredWorkUnitIds.length > 0) {
-    await transaction
-      .update(githubWorkUnitSummaryAttempts)
-      .set({
-        acceptedAt: null,
-        completedAt: now,
-        leaseToken: null,
-        leaseUntil: null,
-        outcome: null,
-        requestPayload: null,
-        state: "terminal",
-      })
-      .where(
-        and(
-          inArray(githubWorkUnitSummaryAttempts.workUnitId, expiredWorkUnitIds),
-          eq(githubWorkUnitSummaryAttempts.state, "processing"),
-          lte(githubWorkUnitSummaryAttempts.leaseUntil, now),
-          gte(
-            githubWorkUnitSummaryAttempts.startedRequests,
-            MAXIMUM_STARTED_REQUESTS
-          )
-        )
-      );
-    await transaction
-      .update(githubWorkUnitSummaryAttempts)
-      .set({
-        debounceUntil: now,
-        leaseToken: null,
-        leaseUntil: null,
-        state: "retryable",
-      })
-      .where(
-        and(
-          inArray(githubWorkUnitSummaryAttempts.workUnitId, expiredWorkUnitIds),
-          eq(githubWorkUnitSummaryAttempts.state, "processing"),
-          lte(githubWorkUnitSummaryAttempts.leaseUntil, now),
-          lt(
-            githubWorkUnitSummaryAttempts.startedRequests,
-            MAXIMUM_STARTED_REQUESTS
-          )
-        )
-      );
-  }
+  // Both workers hold the summary/projection locks; expired orphaned attempts
+  // need the same settlement as attempts still attached to visible work.
+  await transaction.execute(sql`
+    update ${githubWorkUnitSummaryAttempts}
+    set accepted_at = null, lease_token = null, lease_until = null,
+        error_code = 'lease_expired',
+        state = case when started_requests >= ${MAXIMUM_STARTED_REQUESTS} then 'terminal' else 'retryable' end,
+        completed_at = case when started_requests >= ${MAXIMUM_STARTED_REQUESTS} then ${now.toISOString()}::timestamptz else null end,
+        request_payload = case when started_requests >= ${MAXIMUM_STARTED_REQUESTS} then null else request_payload end
+    where state = 'processing' and lease_until <= ${now.toISOString()}::timestamptz
+  `);
   await reconcileInactiveSummaryInputs(transaction);
+};
+
+// Reuse only the same outcome and attribution. Prompt/transport revisions do
+// not turn unchanged work into another paid request; the recipe can opt out.
+const reuseAcceptedSummaries = async (
+  transaction: SummaryTransaction,
+  now: Date
+) => {
+  const rows = await transaction.execute<{
+    work_unit_id: string;
+    revision: number;
+    outcome: string;
+    accepted_at: string;
+    activity_day: string;
+  }>(sql`
+    select distinct on (a.work_unit_id, a.revision)
+      a.work_unit_id, a.revision, s.outcome, s.accepted_at, to_char(w.activity_day, 'YYYY-MM-DD') as activity_day
+    from ${githubWorkUnitSummaryAttempts} a
+    join ${githubWorkUnits} w on w.id = a.work_unit_id
+    join ${githubWorkUnitAcceptedSummaries} s
+      on s.repository_id = w.repository_id
+      and (s.identity_key = w.identity_key or w.attribution_mode = 'branch_owned_composite')
+      and s.attribution_mode = a.attribution_mode
+      and s.outcome_digest = a.outcome_digest and s.recipe = a.recipe
+    where a.state in ('pending', 'retryable')
+      and a.recipe = ${GITHUB_WORK_UNIT_SUMMARY_RECIPE}
+      and w.summary_evaluation_digest = w.summary_evaluated_digest
+      and w.summary_input_digest = a.summary_input_digest
+      and w.outcome_digest = a.outcome_digest and w.attribution_mode = a.attribution_mode
+    order by a.work_unit_id, a.revision, s.accepted_at desc
+  `);
+  const reusable = rows.filter(
+    (row) => decodeGitHubWorkUnitSummary(row.outcome) !== null
+  );
+  if (reusable.length === 0) {
+    return new Set<string>();
+  }
+  await transaction.execute(sql`
+    update ${githubWorkUnitSummaryAttempts} a
+    set state = 'accepted', outcome = reused.outcome, accepted_at = reused.accepted_at,
+        completed_at = ${now.toISOString()}::timestamptz, request_payload = null
+    from (values ${sql.join(
+      reusable.map(
+        (row) => sql`(
+      ${row.work_unit_id}::uuid, ${row.revision}::integer, ${row.outcome}::text, ${new Date(row.accepted_at).toISOString()}::timestamptz
+    )`
+      ),
+      sql`, `
+    )}) as reused(work_unit_id, revision, outcome, accepted_at)
+    where a.work_unit_id = reused.work_unit_id and a.revision = reused.revision
+  `);
+  return new Set(reusable.map((row) => row.activity_day));
 };
 
 const claimSelection = {
@@ -327,8 +312,16 @@ type ClaimCandidate = Awaited<ReturnType<typeof selectClaimCandidate>>;
 
 async function selectClaimCandidate(
   transaction: SummaryTransaction,
-  now: Date
+  now: Date,
+  usage: SummaryUsage
 ) {
+  // Older work may consume only the elapsed share of today's budget. Recent
+  // work can use the remainder immediately instead of waiting behind a backfill.
+  const dayMs = 24 * 60 * 60 * 1000;
+  const elapsed = now.getTime() - Date.parse(`${usage.day}T00:00:00.000Z`);
+  const historicalCapacity =
+    usage.dailyStartedRequests <
+    Math.floor((MAXIMUM_DAILY_STARTED_REQUESTS * elapsed) / dayMs);
   const [candidate] = await transaction
     .select(claimSelection)
     .from(githubWorkUnitSummaryAttempts)
@@ -338,6 +331,10 @@ async function selectClaimCandidate(
     )
     .where(
       and(
+        or(
+          gte(githubWorkUnits.activityAt, new Date(now.getTime() - dayMs)),
+          sql`${historicalCapacity}`
+        ),
         inArray(githubWorkUnitSummaryAttempts.state, ["pending", "retryable"]),
         lte(githubWorkUnitSummaryAttempts.debounceUntil, now),
         lt(
@@ -368,6 +365,12 @@ async function selectClaimCandidate(
       )
     )
     .orderBy(
+      sql`exists (
+        select 1 from ${githubWorkUnitAcceptedSummaries} s
+        where s.identity_key = ${githubWorkUnits.identityKey}
+          and s.repository_id = ${githubWorkUnits.repositoryId}
+          and s.attribution_mode = ${githubWorkUnits.attributionMode}
+      )`,
       desc(githubWorkUnits.activityAt),
       desc(githubWorkUnits.contentObservedAt),
       githubWorkUnitSummaryAttempts.createdAt,
@@ -406,6 +409,8 @@ const lockedAttempt = async (
   const [attempt] = await transaction
     .select({
       attributionMode: githubWorkUnitSummaryAttempts.attributionMode,
+      identityKey: githubWorkUnitSummaryAttempts.identityKey,
+      repositoryId: githubWorkUnitSummaryAttempts.repositoryId,
       inputTokens: githubWorkUnitSummaryAttempts.inputTokens,
       leaseToken: githubWorkUnitSummaryAttempts.leaseToken,
       outcomeDigest: githubWorkUnitSummaryAttempts.outcomeDigest,
@@ -547,6 +552,7 @@ const tryClaimCandidate = async (
     .update(githubWorkUnitSummaryAttempts)
     .set({
       lastStartedAt: now,
+      requestStartedAt: sql`array_append(${githubWorkUnitSummaryAttempts.requestStartedAt}, ${now.toISOString()}::timestamptz)`,
       leaseToken,
       leaseUntil: new Date(now.getTime() + leaseDurationMs),
       startedRequests,
@@ -675,6 +681,7 @@ async function hasCurrentInitialPageSummaryWork(
   ) {
     return false;
   }
+  const canStart = hasRequestCapacity(await readSummaryUsage(transaction, now));
   const [active] = await transaction
     .select({ revision: githubWorkUnitSummaryAttempts.revision })
     .from(githubWorkUnits)
@@ -703,6 +710,7 @@ async function hasCurrentInitialPageSummaryWork(
         inArray(githubWorkUnits.activityDay, [...initialPageDays]),
         or(
           and(
+            sql`${canStart}`,
             isNotNull(githubWorkUnits.summaryEvaluationDigest),
             sql`${githubWorkUnits.summaryEvaluationDigest} IS DISTINCT FROM ${githubWorkUnits.summaryEvaluatedDigest}`
           ),
@@ -726,6 +734,7 @@ async function hasCurrentInitialPageSummaryWork(
             isNotNull(githubWorkUnitSummaryAttempts.requestPayload),
             or(
               and(
+                sql`${canStart}`,
                 inArray(githubWorkUnitSummaryAttempts.state, [
                   "pending",
                   "retryable",
@@ -813,10 +822,11 @@ export const claimGitHubWorkUnitSummary = async (
   return await getDatabase().transaction(async (transaction) => {
     await acquireSummaryStateLocks(transaction);
     await recoverExpiredClaims(transaction, now);
+    const reused = await reuseAcceptedSummaries(transaction, now);
     const usage = await readSummaryUsage(transaction, now);
     let claim: GitHubWorkUnitSummaryClaim | null = null;
     if (hasRequestCapacity(usage)) {
-      const candidate = await selectClaimCandidate(transaction, now);
+      const candidate = await selectClaimCandidate(transaction, now, usage);
       if (candidate !== null) {
         claim = await tryClaimCandidate(
           transaction,
@@ -828,7 +838,14 @@ export const claimGitHubWorkUnitSummary = async (
       }
     }
     const initialPageDays = await readInitialPageDays(transaction);
-    await revisePublicSummaryHead(transaction, now, initialPageDays);
+    await revisePublicSummaryHead(
+      transaction,
+      now,
+      initialPageDays,
+      [...reused].some((day) => initialPageDays.has(day))
+        ? { feedRevisionChanged: true, initialPageContentChanged: true }
+        : undefined
+    );
     return claim;
   });
 };
@@ -854,10 +871,6 @@ export const completeGitHubWorkUnitSummary = async (
         mutation
       );
     const unit = await lockedUnit(transaction, claim.workUnitId);
-    if (unit === null) {
-      await settleHead();
-      return { accepted: false };
-    }
     const attempt = await lockedAttempt(
       transaction,
       claim.workUnitId,
@@ -867,9 +880,10 @@ export const completeGitHubWorkUnitSummary = async (
       await settleHead();
       return { accepted: false };
     }
-    const currentlyVisible = unitMatchesAttempt(unit, attempt);
     const initialPageChanged =
-      currentlyVisible && initialPageDays.has(unit.activityDay);
+      unit !== null &&
+      unitMatchesAttempt(unit, attempt) &&
+      initialPageDays.has(unit.activityDay);
     const [accepted] = await transaction
       .update(githubWorkUnitSummaryAttempts)
       .set({
@@ -903,11 +917,11 @@ export const completeGitHubWorkUnitSummary = async (
       .values({
         acceptedAt: now,
         attributionMode: attempt.attributionMode,
-        identityKey: unit.identityKey,
+        identityKey: attempt.identityKey,
         outcome: result.outcome,
         outcomeDigest: attempt.outcomeDigest,
         recipe: attempt.recipe,
-        repositoryId: unit.repositoryId,
+        repositoryId: attempt.repositoryId,
         summaryInputDigest: attempt.summaryInputDigest,
       })
       .onConflictDoNothing();
@@ -945,10 +959,6 @@ export const deferGitHubWorkUnitSummary = async (
     const settleHead = async () =>
       await revisePublicSummaryHead(transaction, now, initialPageDays);
     const unit = await lockedUnit(transaction, claim.workUnitId);
-    if (unit === null) {
-      await settleHead();
-      return "stale";
-    }
     const attempt = await lockedAttempt(
       transaction,
       claim.workUnitId,
@@ -963,7 +973,8 @@ export const deferGitHubWorkUnitSummary = async (
       await settleHead();
       return "terminal";
     }
-    const remainsCurrent = currentUnitMatchesAttempt(unit, attempt);
+    const remainsCurrent =
+      unit !== null && currentUnitMatchesAttempt(unit, attempt);
     const [deferred] = await transaction
       .update(githubWorkUnitSummaryAttempts)
       .set({
@@ -1022,7 +1033,15 @@ export const reconcileGitHubWorkUnitSummaryStatus = async (
   return await getDatabase().transaction(async (transaction) => {
     await acquireSummaryStateLocks(transaction);
     await recoverExpiredClaims(transaction, now);
+    const reused = await reuseAcceptedSummaries(transaction, now);
     const initialPageDays = await readInitialPageDays(transaction);
-    return await revisePublicSummaryHead(transaction, now, initialPageDays);
+    return await revisePublicSummaryHead(
+      transaction,
+      now,
+      initialPageDays,
+      [...reused].some((day) => initialPageDays.has(day))
+        ? { feedRevisionChanged: true, initialPageContentChanged: true }
+        : undefined
+    );
   });
 };

--- a/tests/github-activity-feed-postgres.test.ts
+++ b/tests/github-activity-feed-postgres.test.ts
@@ -260,7 +260,7 @@ describe.skipIf(!dockerAvailable)("GitHub work-unit feed projection", () => {
       insert into github_work_unit_summary_attempts (
         accepted_at, attribution_mode, completed_at, debounce_until,
         outcome, outcome_digest, recipe, revision, state,
-        summary_input_digest, work_unit_id
+        summary_input_digest, work_unit_id, identity_key, repository_id
       ) values
         (
           '2026-08-30T12:02:00Z', 'tracked_authored_pr',
@@ -270,28 +270,28 @@ describe.skipIf(!dockerAvailable)("GitHub work-unit feed projection", () => {
             summary: "The expanded summary explains the complete outcome.",
           })}, ${digest("a")},
           ${GITHUB_WORK_UNIT_SUMMARY_RECIPE}, 1, 'accepted', ${digest("1")},
-          '00000000-0000-4000-8000-000000000101'
+          '00000000-0000-4000-8000-000000000101', 'pr:PR_public_feed_1', '101'
         ),
         (
           '2026-08-30T12:03:00Z', 'tracked_authored_pr',
           '2026-08-30T12:03:00Z', '2026-08-30T12:00:00Z',
           'Earlier summary stays available.', ${digest("b")},
           ${GITHUB_WORK_UNIT_SUMMARY_RECIPE}, 2, 'accepted', ${digest("2")},
-          '00000000-0000-4000-8000-000000000101'
+          '00000000-0000-4000-8000-000000000101', 'pr:PR_public_feed_1', '101'
         ),
         (
           '2026-08-30T12:04:00Z', 'tracked_authored_pr',
           '2026-08-30T12:04:00Z', '2026-08-30T12:00:00Z',
           'Previous summary stays visible.', ${digest("a")},
           'github-work-unit-outcome-v1', 3, 'accepted', ${digest("3")},
-          '00000000-0000-4000-8000-000000000101'
+          '00000000-0000-4000-8000-000000000101', 'pr:PR_public_feed_1', '101'
         ),
         (
           '2026-08-30T12:05:00Z', 'branch_owned_composite',
           '2026-08-30T12:05:00Z', '2026-08-30T12:00:00Z',
           'Wrong attribution must remain hidden.', ${digest("a")},
           'corrupt-mode-test', 4, 'accepted', ${digest("1")},
-          '00000000-0000-4000-8000-000000000101'
+          '00000000-0000-4000-8000-000000000101', 'pr:PR_public_feed_1', '101'
         ),
         (
           '2026-08-30T12:06:00Z', 'branch_owned_composite',
@@ -302,7 +302,7 @@ describe.skipIf(!dockerAvailable)("GitHub work-unit feed projection", () => {
               "The private work summary remains useful without exposing repository identity.",
           })}, ${digest("c")},
           ${GITHUB_WORK_UNIT_SUMMARY_RECIPE}, 1, 'accepted', ${digest("9")},
-          '00000000-0000-4000-8000-000000000105'
+          '00000000-0000-4000-8000-000000000105', 'branch:10000000-0000-4000-8000-000000000201', '201'
         )
     `;
     await admin`
@@ -423,6 +423,7 @@ describe.skipIf(!dockerAvailable)("GitHub work-unit feed projection", () => {
   });
 
   test("reuses a stale summary while the current one is pending", async () => {
+    await admin`update github_public_feed_head set summarizing = true where id`;
     await admin`
       update github_work_units set
         summary_evaluated_digest = ${digest("4")},
@@ -433,11 +434,11 @@ describe.skipIf(!dockerAvailable)("GitHub work-unit feed projection", () => {
     await admin`
       insert into github_work_unit_summary_attempts (
         attribution_mode, debounce_until, outcome_digest, recipe,
-        request_payload, revision, state, summary_input_digest, work_unit_id
+        request_payload, revision, state, summary_input_digest, work_unit_id, identity_key, repository_id
       ) values (
         'tracked_authored_pr', '2026-08-30T12:07:00Z', ${digest("a")},
         ${GITHUB_WORK_UNIT_SUMMARY_RECIPE}, '{}', 5, 'pending', ${digest("4")},
-        '00000000-0000-4000-8000-000000000101'
+        '00000000-0000-4000-8000-000000000101', 'pr:PR_public_feed_1', '101'
       )
     `;
 
@@ -450,6 +451,16 @@ describe.skipIf(!dockerAvailable)("GitHub work-unit feed projection", () => {
       headline: "Previous summary stays visible.",
       summarizing: true,
       summary: null,
+    });
+    await admin`update github_public_feed_head set summarizing = false where id`;
+    const paused = await readPublicGitHubActivityPage(null, 2);
+    expect(
+      paused.days[0]?.repositories[0]?.items.find(
+        ({ kind }) => kind === "pull-request"
+      )
+    ).toMatchObject({
+      headline: "Previous summary stays visible.",
+      summarizing: false,
     });
   });
 

--- a/tests/github-cron-config.test.ts
+++ b/tests/github-cron-config.test.ts
@@ -26,8 +26,8 @@ import vercelConfig from "../vercel.json";
 
 const minutesFrom = (schedule: string) => {
   const [minute] = schedule.split(" ", 1);
-  if (minute === "*") {
-    return Array.from({ length: 60 }, (_, index) => index);
+  if (minute === "*/3") {
+    return Array.from({ length: 20 }, (_, index) => index * 3);
   }
   if (minute === "*/5") {
     return Array.from({ length: 12 }, (_, index) => index * 5);
@@ -45,7 +45,7 @@ const minutesFrom = (schedule: string) => {
 };
 
 describe("GitHub cron configuration", () => {
-  test("factual jobs stay staggered while summaries can run every minute", () => {
+  test("factual jobs stay staggered while summaries run 20 times per hour", () => {
     const jobs = [
       GITHUB_EVENTS_CRON_JOB,
       GITHUB_WORKER_CRON_JOB,
@@ -56,7 +56,7 @@ describe("GitHub cron configuration", () => {
     expect(new Set(allMinutes).size).toBe(allMinutes.length);
 
     expect(minutesFrom(GITHUB_SUMMARY_CRON_JOB.schedule)).toEqual(
-      Array.from({ length: 60 }, (_, index) => index)
+      Array.from({ length: 20 }, (_, index) => index * 3)
     );
   });
 

--- a/tests/github-cron-config.test.ts
+++ b/tests/github-cron-config.test.ts
@@ -26,6 +26,9 @@ import vercelConfig from "../vercel.json";
 
 const minutesFrom = (schedule: string) => {
   const [minute] = schedule.split(" ", 1);
+  if (minute === "*") {
+    return Array.from({ length: 60 }, (_, index) => index);
+  }
   if (minute === "*/5") {
     return Array.from({ length: 12 }, (_, index) => index * 5);
   }
@@ -42,23 +45,19 @@ const minutesFrom = (schedule: string) => {
 };
 
 describe("GitHub cron configuration", () => {
-  test("staggered routine jobs never start in the same minute", () => {
+  test("factual jobs stay staggered while summaries can run every minute", () => {
     const jobs = [
       GITHUB_EVENTS_CRON_JOB,
       GITHUB_WORKER_CRON_JOB,
-      GITHUB_SUMMARY_CRON_JOB,
       GITHUB_HEAD_REFS_CRON_JOB,
     ];
     const allMinutes = jobs.flatMap((job) => minutesFrom(job.schedule));
     expect(new Set(jobs.map((job) => job.name)).size).toBe(jobs.length);
     expect(new Set(allMinutes).size).toBe(allMinutes.length);
 
-    const factualMinutes = new Set(
-      minutesFrom(GITHUB_WORKER_CRON_JOB.schedule)
+    expect(minutesFrom(GITHUB_SUMMARY_CRON_JOB.schedule)).toEqual(
+      Array.from({ length: 60 }, (_, index) => index)
     );
-    for (const summaryMinute of minutesFrom(GITHUB_SUMMARY_CRON_JOB.schedule)) {
-      expect(factualMinutes.has((summaryMinute + 59) % 60)).toBe(true);
-    }
   });
 
   test("bounds scheduled repository reconciliation", () => {

--- a/tests/github-work-unit-store-postgres.test.ts
+++ b/tests/github-work-unit-store-postgres.test.ts
@@ -609,7 +609,7 @@ describe.skipIf(!dockerAvailable)("GitHub work-unit projection store", () => {
     });
   });
 
-  test("reactivates an exact cached summary and revises the public head", async () => {
+  test("reuses unchanged outcomes across context changes without another request", async () => {
     const firstClaim = await claimGitHubWorkUnitSummary({
       now: new Date("2026-08-30T12:06:00.000Z"),
     });
@@ -631,13 +631,11 @@ describe.skipIf(!dockerAvailable)("GitHub work-unit projection store", () => {
     const secondClaim = await claimGitHubWorkUnitSummary({
       now: new Date("2026-08-30T12:13:00.000Z"),
     });
-    expect(secondClaim).not.toBeNull();
-    assert.ok(secondClaim);
-    await completeGitHubWorkUnitSummary(
-      secondClaim,
-      summaryResult("Current outcome B."),
-      new Date("2026-08-30T12:13:01.000Z")
-    );
+    expect(secondClaim).toBeNull();
+    const [usage] = await database
+      .select()
+      .from(schema.githubWorkUnitSummaryDailyUsage);
+    expect(usage.startedRequests).toBe(1);
 
     await database
       .update(schema.githubRepositories)
@@ -657,13 +655,13 @@ describe.skipIf(!dockerAvailable)("GitHub work-unit projection store", () => {
     const [publicUnit] = page.days[0].repositories[0].items;
 
     expect(reverted).toMatchObject({
-      feedRevisionChanged: true,
+      feedRevisionChanged: false,
       summaryAttemptsQueued: 0,
     });
     expect(revertedUnit.summaryInputDigest).toBe(inputA);
-    expect(afterReversion.feedRevision).toBe(beforeReversion.feedRevision + 1);
+    expect(afterReversion.feedRevision).toBe(beforeReversion.feedRevision);
     expect(afterReversion.headContentRevision).toBe(
-      beforeReversion.headContentRevision + 1
+      beforeReversion.headContentRevision
     );
     expect(publicUnit).toMatchObject({
       headline: "Cached outcome A.",
@@ -672,6 +670,7 @@ describe.skipIf(!dockerAvailable)("GitHub work-unit projection store", () => {
   });
 
   test("reuses a superseded paid input without resetting its request budget", async () => {
+    await database.delete(schema.githubWorkUnitAcceptedSummaries);
     await database
       .update(schema.githubRepositories)
       .set({ description: "Retryable context C." })
@@ -713,6 +712,9 @@ describe.skipIf(!dockerAvailable)("GitHub work-unit projection store", () => {
       state: "retryable",
     });
 
+    await database
+      .delete(schema.githubWorkUnits)
+      .where(eq(schema.githubWorkUnits.id, firstClaim.workUnitId));
     await database
       .update(schema.githubRepositories)
       .set({ description: "Retryable context C." })

--- a/tests/github-work-unit-summary-provider.test.ts
+++ b/tests/github-work-unit-summary-provider.test.ts
@@ -168,7 +168,6 @@ describe("GitHub work-unit summary provider", () => {
     expect(semanticFailure).rejects.toMatchObject({
       name: "GitHubWorkUnitSummaryInvalidOutputError",
       reason: "url",
-      retryable: true,
     });
     expect(semanticCalls).toBe(1);
 
@@ -180,7 +179,6 @@ describe("GitHub work-unit summary provider", () => {
     expect(structuredFailure).rejects.toMatchObject({
       name: "GitHubWorkUnitSummaryInvalidOutputError",
       reason: "invalid_shape",
-      retryable: true,
     });
 
     const schemaFailure = generateGitHubWorkUnitSummary(request(), {
@@ -204,7 +202,6 @@ describe("GitHub work-unit summary provider", () => {
     expect(schemaFailure).rejects.toMatchObject({
       name: "GitHubWorkUnitSummaryInvalidOutputError",
       reason: "invalid_shape",
-      retryable: true,
     });
   });
 
@@ -260,7 +257,6 @@ describe("GitHub work-unit summary provider", () => {
       );
       expect(receivedError).toMatchObject({
         name: "GitHubWorkUnitSummaryInvalidInputError",
-        retryable: false,
       });
     }
     expect(calls).toBe(0);

--- a/tests/github-work-unit-summary-store.test.ts
+++ b/tests/github-work-unit-summary-store.test.ts
@@ -407,6 +407,117 @@ describe.skipIf(!dockerAvailable)("GitHub work-unit summary store", () => {
     expect(await claimGitHubWorkUnitSummary({ now })).toBeNull();
   });
 
+  test("upgrades paid attempts without inventing legacy request timestamps", async () => {
+    const now = new Date("2026-09-01T12:00:00Z");
+    for (const startedRequests of [0, 1, 2]) {
+      await seedUnit({
+        activityAt: now,
+        debounceUntil: now,
+        lastStartedAt: startedRequests === 0 ? null : now,
+        startedRequests,
+        state: startedRequests === 0 ? "pending" : "retryable",
+      });
+    }
+    const rollback = new Error("Rollback migration rehearsal");
+    try {
+      await admin.begin(async (transaction) => {
+        // Recreate the deployed table shape with real pending and paid rows.
+        await transaction`drop trigger record_github_summary_attempt on github_work_unit_summary_attempts`;
+        await transaction`drop function record_github_summary_attempt()`;
+        await transaction`
+          alter table github_work_unit_summary_attempts
+          drop column identity_key cascade, drop column repository_id,
+          drop column request_started_at cascade,
+          add constraint gh_work_unit_summary_attempts_unit_fk
+            foreign key (work_unit_id) references github_work_units(id) on delete cascade
+        `;
+        const migration = await Bun.file(
+          new URL("../drizzle/0021_windy_midnight.sql", import.meta.url)
+        ).text();
+        for (const statement of migration.split("--> statement-breakpoint")) {
+          await transaction.unsafe(statement);
+        }
+        const rows = await transaction`
+          select a.started_requests, cardinality(a.request_started_at) as recorded,
+            a.identity_key = w.identity_key and a.repository_id = w.repository_id as identity_preserved,
+            a.request_started_at[1] is null as first_unknown,
+            a.request_started_at[a.started_requests] = a.last_started_at as last_preserved
+          from github_work_unit_summary_attempts a join github_work_units w on w.id = a.work_unit_id
+          order by a.started_requests
+        `;
+        expect([...rows]).toEqual([
+          {
+            started_requests: 0,
+            recorded: 0,
+            identity_preserved: true,
+            first_unknown: true,
+            last_preserved: null,
+          },
+          {
+            started_requests: 1,
+            recorded: 1,
+            identity_preserved: true,
+            first_unknown: false,
+            last_preserved: true,
+          },
+          {
+            started_requests: 2,
+            recorded: 2,
+            identity_preserved: true,
+            first_unknown: true,
+            last_preserved: true,
+          },
+        ]);
+        throw rollback;
+      });
+    } catch (error) {
+      if (error !== rollback) {
+        throw error;
+      }
+    }
+  });
+
+  test("keeps the deployed worker's inserts and claims compatible during rollout", async () => {
+    const now = new Date("2026-09-01T12:00:00Z");
+    const unit = await seedUnit({ activityAt: now, debounceUntil: now });
+    await admin`delete from github_work_unit_summary_attempts`;
+    // These are the columns written by the worker before migration 0021.
+    await admin`
+      insert into github_work_unit_summary_attempts (
+        attribution_mode, debounce_until, outcome_digest, recipe,
+        request_payload, revision, summary_input_digest, work_unit_id
+      ) select attribution_mode, ${instant(now)}, outcome_digest, ${recipe},
+        ${unit.payload}, 1, summary_input_digest, id
+      from github_work_units where id = ${unit.workUnitId}
+    `;
+    expect(await readAttempt(unit)).toMatchObject({
+      identity_key: unit.identityKey,
+      repository_id: repositoryId,
+      started_requests: 0,
+    });
+    for (const startedAt of [now, new Date("2026-09-02T00:10:00Z")]) {
+      await admin`
+        update github_work_unit_summary_attempts
+        set state = 'processing', started_requests = started_requests + 1,
+            last_started_at = ${instant(startedAt)}, lease_token = gen_random_uuid(),
+            lease_until = ${instant(new Date(startedAt.getTime() + 90_000))}
+        where work_unit_id = ${unit.workUnitId}
+      `;
+      await admin`
+        update github_work_unit_summary_attempts
+        set state = 'retryable', lease_token = null, lease_until = null
+        where work_unit_id = ${unit.workUnitId}
+      `;
+    }
+    const [history] = await admin`
+      select started_requests, request_started_at = ARRAY[
+        '2026-09-01T12:00:00Z'::timestamptz, '2026-09-02T00:10:00Z'::timestamptz
+      ] as recorded from github_work_unit_summary_attempts
+      where work_unit_id = ${unit.workUnitId}
+    `;
+    expect(history).toEqual({ started_requests: 2, recorded: true });
+  });
+
   test("records each paid start across a UTC-day boundary", async () => {
     const first = new Date("2026-09-01T23:50:00Z");
     const second = new Date("2026-09-02T00:10:00Z");

--- a/tests/github-work-unit-summary-store.test.ts
+++ b/tests/github-work-unit-summary-store.test.ts
@@ -75,7 +75,7 @@ describe.skipIf(!dockerAvailable)("GitHub work-unit summary store", () => {
     lastStartedAt = null,
     leaseToken = null,
     leaseUntil = null,
-    outcomeDigest = digest("a"),
+    outcomeDigest,
     requestPayload,
     startedRequests = 0,
     state = "pending",
@@ -105,6 +105,7 @@ describe.skipIf(!dockerAvailable)("GitHub work-unit summary store", () => {
     const workUnitId = `00000000-0000-4000-8000-${suffix}`;
     const branchLineageId = `10000000-0000-4000-8000-${suffix}`;
     const sha = sequence.toString(16).padStart(40, "0");
+    const unitOutcomeDigest = outcomeDigest ?? sha.padStart(64, "0");
     const activityDay = activityAt.toISOString().slice(0, 10);
     const payload = requestPayload ?? JSON.stringify({ unit: sequence });
     await admin`
@@ -129,7 +130,7 @@ describe.skipIf(!dockerAvailable)("GitHub work-unit summary store", () => {
         'branch_owned_composite', ${branchLineageId}, ${instant(contentObservedAt)}, 1,
         ${digest("c")}, 1, ${instant(activityAt)}, ${workUnitId},
         ${`branch:${branchLineageId}`}, 'branch', ${instant(activityAt)}, 1,
-        ${digest("d")}, ${repositoryId}, ${sha}, ${outcomeDigest},
+        ${digest("d")}, ${repositoryId}, ${sha}, ${unitOutcomeDigest},
         ${repositoryId}, ${workUnitRevision}, ${summaryEvaluatedDigest},
         ${summaryEvaluationDigest}, ${summaryInputDigest}, 'public'
       )
@@ -137,20 +138,21 @@ describe.skipIf(!dockerAvailable)("GitHub work-unit summary store", () => {
     await admin`
       insert into github_work_unit_summary_attempts (
         attribution_mode, created_at, debounce_until, input_tokens,
-        last_started_at, lease_token, lease_until, outcome_digest, recipe,
+        last_started_at, lease_token, lease_until, outcome_digest, recipe, request_started_at,
         request_payload, revision, started_requests, state,
-        summary_input_digest, work_unit_id
+        summary_input_digest, work_unit_id, identity_key, repository_id
       ) values (
         'branch_owned_composite', ${instant(contentObservedAt)},
         ${instant(debounceUntil)}, 37, ${instant(lastStartedAt)}, ${leaseToken},
-        ${instant(leaseUntil)}, ${outcomeDigest},
-        ${recipe}, ${payload}, ${attemptRevision}, ${startedRequests}, ${state},
-        ${summaryInputDigest}, ${workUnitId}
+        ${instant(leaseUntil)}, ${unitOutcomeDigest},
+        ${recipe}, case when ${startedRequests} = 0 then ARRAY[]::timestamptz[] when ${startedRequests} = 1 then ARRAY[${instant(lastStartedAt)}::timestamptz] else ARRAY[null, ${instant(lastStartedAt)}::timestamptz] end,
+        ${payload}, ${attemptRevision}, ${startedRequests}, ${state},
+        ${summaryInputDigest}, ${workUnitId}, ${`branch:${branchLineageId}`}, ${repositoryId}
       )
     `;
     return {
       identityKey: `branch:${branchLineageId}`,
-      outcomeDigest,
+      outcomeDigest: unitOutcomeDigest,
       payload,
       revision: attemptRevision,
       workUnitId,
@@ -263,6 +265,7 @@ describe.skipIf(!dockerAvailable)("GitHub work-unit summary store", () => {
 
   beforeEach(async () => {
     await admin`delete from github_work_unit_summary_attempts`;
+    await admin`delete from github_work_unit_accepted_summaries`;
     await admin`delete from github_work_unit_summary_daily_usage`;
     await admin`delete from github_work_units`;
     await admin`delete from github_issues`;
@@ -298,6 +301,156 @@ describe.skipIf(!dockerAvailable)("GitHub work-unit summary store", () => {
         stdout: "ignore",
       });
     }
+  });
+
+  const seedAcceptedSummary = async (
+    unit: Awaited<ReturnType<typeof seedUnit>>,
+    acceptedAt: Date,
+    outcomeDigest = unit.outcomeDigest
+  ) => {
+    await admin`
+      insert into github_work_unit_accepted_summaries (
+        accepted_at, attribution_mode, identity_key, outcome, outcome_digest,
+        recipe, repository_id, summary_input_digest
+      ) values (
+        ${instant(acceptedAt)}, 'branch_owned_composite', ${unit.identityKey},
+        ${JSON.stringify({ headline: "Valid cached outcome", summary: "The accepted summary describes the same authored changes." })},
+        ${outcomeDigest}, ${recipe}, ${repositoryId}, ${digest("f")}
+      )
+    `;
+  };
+
+  test("reuses unchanged outcomes for free even when the daily budget is exhausted", async () => {
+    const now = new Date("2026-09-01T12:00:00Z");
+    const unit = await seedUnit({
+      activityAt: now,
+      debounceUntil: new Date("2026-09-01T13:00:00Z"),
+    });
+    await seedAcceptedSummary(unit, new Date("2026-08-31T12:00:00Z"));
+    await seedUsage([{ day: "2026-09-01", startedRequests: 100 }]);
+    expect(await claimGitHubWorkUnitSummary({ now })).toBeNull();
+    expect(await readAttempt(unit)).toMatchObject({
+      state: "accepted",
+      started_requests: 0,
+      request_payload: null,
+      lease_token: null,
+    });
+    expect([...(await readUsage())]).toEqual([
+      { day: "2026-09-01", started_requests: 100 },
+    ]);
+    expect(await readHead()).toMatchObject({ summarizing: false });
+  });
+
+  test("serves missing summaries newest first before refreshing existing prose", async () => {
+    const now = new Date("2026-09-01T12:00:00Z");
+    const refresh = await seedUnit({
+      activityAt: new Date("2026-09-01T11:00:00Z"),
+      debounceUntil: now,
+    });
+    await seedAcceptedSummary(
+      refresh,
+      new Date("2026-08-31T12:00:00Z"),
+      digest("c")
+    );
+    const newer = await seedUnit({
+      activityAt: new Date("2026-09-01T10:00:00Z"),
+      debounceUntil: now,
+    });
+    const older = await seedUnit({
+      activityAt: new Date("2026-08-31T10:00:00Z"),
+      debounceUntil: now,
+    });
+    for (const expected of [newer, older, refresh]) {
+      const claim = await claimGitHubWorkUnitSummary({ now });
+      assert.ok(claim);
+      expect(claim.workUnitId).toBe(expected.workUnitId);
+      await terminalGitHubWorkUnitSummary(claim, now);
+    }
+  });
+
+  test("retains paid history and accepts an in-flight result after projection deletion", async () => {
+    const now = new Date("2026-09-01T12:00:00Z");
+    const unit = await seedUnit({ activityAt: now, debounceUntil: now });
+    const claim = await claimGitHubWorkUnitSummary({ now });
+    assert.ok(claim);
+    await admin`delete from github_work_units where id = ${unit.workUnitId}`;
+    expect(
+      await completeGitHubWorkUnitSummary(
+        claim,
+        providerResult("Retained authored work."),
+        now
+      )
+    ).toEqual({ accepted: true });
+    expect(await readAttempt(unit)).toMatchObject({
+      state: "accepted",
+      started_requests: 1,
+      identity_key: unit.identityKey,
+    });
+    const [cached] =
+      await admin`select identity_key from github_work_unit_accepted_summaries where identity_key = ${unit.identityKey}`;
+    expect(cached.identity_key).toBe(unit.identityKey);
+    expect([...(await readUsage())]).toEqual([
+      { day: "2026-09-01", started_requests: 1 },
+    ]);
+  });
+
+  test("shows active work at the cap only while a provider claim is still running", async () => {
+    const now = new Date("2026-09-01T12:00:00Z");
+    await seedUnit({ activityAt: now, debounceUntil: now });
+    await seedUnit({ activityAt: now, debounceUntil: now });
+    await seedUsage([{ day: "2026-09-01", startedRequests: 99 }]);
+    const claim = await claimGitHubWorkUnitSummary({ now });
+    assert.ok(claim);
+    expect(await readHead()).toMatchObject({ summarizing: true });
+    await terminalGitHubWorkUnitSummary(claim, now);
+    expect(await readHead()).toMatchObject({ summarizing: false });
+    expect(await claimGitHubWorkUnitSummary({ now })).toBeNull();
+  });
+
+  test("records each paid start across a UTC-day boundary", async () => {
+    const first = new Date("2026-09-01T23:50:00Z");
+    const second = new Date("2026-09-02T00:10:00Z");
+    const unit = await seedUnit({ activityAt: first, debounceUntil: first });
+    const claim = await claimGitHubWorkUnitSummary({ now: first });
+    assert.ok(claim);
+    await deferGitHubWorkUnitSummary(claim, second, first, "TimeoutError");
+    const retry = await claimGitHubWorkUnitSummary({ now: second });
+    assert.ok(retry);
+    await terminalGitHubWorkUnitSummary(retry, second, "output_html");
+    await admin`delete from github_work_units where id = ${unit.workUnitId}`;
+    const starts =
+      await admin`select started::date::text as day, count(*)::integer as started_requests from github_work_unit_summary_attempts, unnest(request_started_at) started group by started::date order by day`;
+    expect([...starts]).toEqual([...(await readUsage())]);
+    expect([...starts]).toEqual([
+      { day: "2026-09-01", started_requests: 1 },
+      { day: "2026-09-02", started_requests: 1 },
+    ]);
+  });
+
+  test("paces historical work while keeping remaining daily capacity available to recent work", async () => {
+    const midnight = new Date("2026-09-01T00:00:00Z");
+    await seedUnit({
+      activityAt: new Date("2026-08-28T12:00:00Z"),
+      debounceUntil: midnight,
+    });
+    await seedUnit({
+      activityAt: new Date("2026-08-29T12:00:00Z"),
+      debounceUntil: midnight,
+    });
+    expect(await claimGitHubWorkUnitSummary({ now: midnight })).toBeNull();
+    await seedUsage([{ day: "2026-09-01", startedRequests: 49 }]);
+    const noon = new Date("2026-09-01T12:00:00Z");
+    const historical = await claimGitHubWorkUnitSummary({ now: noon });
+    assert.ok(historical);
+    await terminalGitHubWorkUnitSummary(historical, noon);
+    expect(await claimGitHubWorkUnitSummary({ now: noon })).toBeNull();
+    const recent = await seedUnit({ activityAt: noon, debounceUntil: noon });
+    expect(await claimGitHubWorkUnitSummary({ now: noon })).toMatchObject({
+      workUnitId: recent.workUnitId,
+    });
+    expect([...(await readUsage())]).toEqual([
+      { day: "2026-09-01", started_requests: 51 },
+    ]);
   });
 
   test("claims current work by newest activity then newest content", async () => {
@@ -868,14 +1021,14 @@ describe.skipIf(!dockerAvailable)("GitHub work-unit summary store", () => {
         accepted_at, attribution_mode, completed_at, debounce_until,
         input_tokens, last_started_at, latency_ms, model, outcome,
         outcome_digest, output_tokens, recipe, revision, started_requests,
-        state, summary_input_digest, work_unit_id
+        state, summary_input_digest, work_unit_id, identity_key, repository_id, request_started_at
       ) values (
         '2026-08-31T13:00:00Z', 'branch_owned_composite',
         '2026-08-31T13:00:00Z', '2026-08-31T12:00:00Z', 40,
         '2026-08-31T13:00:00Z', 10, 'previous-model',
         'Prior prose for the same outcome.', ${rewrite.outcomeDigest}, 10,
         'github-work-unit-outcome-v0', 1, 1, 'accepted', ${digest("e")},
-        ${rewrite.workUnitId}
+        ${rewrite.workUnitId}, ${rewrite.identityKey}, ${repositoryId}, ARRAY['2026-08-31T13:00:00Z'::timestamptz]
       )
     `;
     const rewriteClaim = await claimGitHubWorkUnitSummary({ now });
@@ -955,7 +1108,10 @@ describe.skipIf(!dockerAvailable)("GitHub work-unit summary store", () => {
     await admin`
       delete from github_work_units where id = ${stale.workUnitId}
     `;
-    expect(await readAttempt(stale)).toBeUndefined();
+    expect(await readAttempt(stale)).toMatchObject({
+      started_requests: 1,
+      state: "accepted",
+    });
     const [retained] = await admin`
       select * from github_work_unit_accepted_summaries
       where identity_key = ${stale.identityKey}


### PR DESCRIPTION
Unchanged authored outcomes were sent to the model again after prompt, policy, or repository-context changes. Historical work could then exhaust the daily budget before new work arrived, and projection deletion erased the attempt history needed to explain the spend.

The timeline continues to publish factual, uniquely owned work independently of prose. Summary reconciliation now uses the existing accepted-output cache before any paid claim, including when the daily budget is exhausted. Reuse requires matching repository, outcome, attribution, and recipe, with the existing identity/branch-lineage boundaries and output validation. Missing summaries run newest first before refreshes of existing prose. Work older than 24 hours is limited to the elapsed share of the daily allowance; recent work can use the remaining allowance immediately.

The existing worker runs every three minutes (20 opportunities/hour), with the same 100/day, 3,000/month, and two-start-per-input caps. Budget-exhausted queues no longer appear actively summarizing. Lease recovery and obsolete-input cleanup are simplified and cover orphaned attempts.

The migration removes the attempt-to-projection cascade and records stable identity, repository, and up to two request-start timestamps on existing attempts. Deleted/recreated identities keep their retry count; in-flight results remain cacheable after deletion. Legacy unknown timestamps remain explicitly unknown. A database trigger records starts and fills omitted identity fields for the previous worker version, keeping the migration compatible with workers still running during deployment. Unused claim fields and provider retry flags are removed. No new queue, accounting table, dependency, or committed repair script is introduced.

Validation:
- 304 tests passed, including PostgreSQL projection, feed, concurrent budget, cache reuse, cross-day retry accounting, deletion/recreation, a populated migration rehearsal, and writes from the previous worker version; typecheck, lint, and formatting passed.
- The live crosswalk for September 3–7 passed all ownership/coverage invariants for the stored evidence: 256 eligible changes, no enrichment backlog, visibility gaps, or verified-merge ownership violations.
- A local cache-only reconciliation of live data reduced 93 queued inputs to 11 with zero model calls; daily usage remained 100.

Deployment applies the migration and persistent scheduling/lifecycle changes. The cache-only reconciliation has already run locally; it did not reset usage or erase paid history. Deleted historical attempt records cannot be reconstructed by this migration.
