### PR TITLE
fix(seo): revalidate share images and link the author profile

### DIFF
--- a/src/app/(blog)/writing/[slug]/page.tsx
+++ b/src/app/(blog)/writing/[slug]/page.tsx
@@ -58,7 +58,7 @@ export async function generateMetadata({
     description: metadata.summary,
     keywords: metadata.tags,
     openGraph: {
-      authors: [metadata.author],
+      authors: [publicUrl("/journey")],
       description: metadata.summary,
       locale: siteConfig.locale,
       images: [{ alt: metadata.title, url: shareImageUrl }],

--- a/src/lib/blog-metadata-images.ts
+++ b/src/lib/blog-metadata-images.ts
@@ -82,7 +82,7 @@ export const resolveMetadataImageResponse = async (
   const buffer = await fs.readFile(asset.filePath);
   return new Response(buffer, {
     headers: {
-      "Cache-Control": "public, max-age=31536000, immutable",
+      "Cache-Control": "public, max-age=0, must-revalidate",
       "Content-Type": asset.contentType ?? "application/octet-stream",
     },
   });


### PR DESCRIPTION
Unversioned share-image URLs previously advertised a year of immutable caching, allowing replaced artwork to remain stale. Static share-image responses now use `public, max-age=0, must-revalidate`.

Article Open Graph authors now reference the canonical profile URL, `https://f0rr0.dev/journey`, instead of the author's display name.

Based on fresh `origin/next` at `ee3a073`. Validation: three focused SEO/Markdown tests and production Next build pass; running-server checks confirm the rendered `article:author` URL and share-image cache header. Lint and typecheck pass. Existing build filesystem-tracing and GitHub embed fallback warnings remain. Previously cached third-party copies may still require a refresh by the sharing service.
