### PR TITLE
feat: add home page links to all work and writing

### DIFF
--- a/src/app/(portfolio)/page.tsx
+++ b/src/app/(portfolio)/page.tsx
@@ -138,7 +138,7 @@ export default async function Home() {
         <h1 className="sr-only">{resumeData.person.name}</h1>
         <p>{homeIntroduction}</p>
 
-        <SiteSection id="writing" title="Writing">
+        <SiteSection href="/writing" id="writing" title="Writing">
           <WritingList posts={posts.slice(0, 3)} />
         </SiteSection>
 

--- a/src/components/site-page.tsx
+++ b/src/components/site-page.tsx
@@ -1,3 +1,4 @@
+import { ArrowRight } from "lucide-react";
 import Link from "next/link";
 import type { ReactNode } from "react";
 
@@ -41,25 +42,27 @@ export function SiteSection({
 }>) {
   return (
     <section aria-labelledby={`${id}-title`} className={className} id={id}>
-      <Heading
-        className={cn(
-          "section-title mb-4 font-serif text-2xl font-normal text-foreground",
-          headingClassName
-        )}
-        id={`${id}-title`}
-      >
-        {href === undefined ? (
-          title
-        ) : (
+      <div className="mb-4 flex items-baseline justify-between gap-4">
+        <Heading
+          className={cn(
+            "section-title font-serif text-2xl font-normal text-foreground",
+            headingClassName
+          )}
+          id={`${id}-title`}
+        >
+          {title}
+        </Heading>
+        {href === undefined ? null : (
           <Link
-            className="section-title-link rounded-sm hover:underline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-ring"
+            className="inline-flex min-h-11 shrink-0 items-center gap-1.5 rounded-sm font-ui text-sm text-muted-foreground hover:text-foreground hover:underline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-ring"
             href={href}
             prefetch={false}
           >
-            {title}
+            All {title.toLowerCase()}
+            <ArrowRight aria-hidden="true" className="size-3.5" />
           </Link>
         )}
-      </Heading>
+      </div>
       {children}
     </section>
   );

--- a/tests/site-section.test.tsx
+++ b/tests/site-section.test.tsx
@@ -1,0 +1,25 @@
+import { expect, test } from "bun:test";
+
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { SiteSection } from "../src/components/site-page";
+
+test("section archive links use the internal work and writing pages", () => {
+  for (const title of ["Work", "Writing"]) {
+    const path = `/${title.toLowerCase()}`;
+    const html = renderToStaticMarkup(
+      <SiteSection href={path} id={title.toLowerCase()} title={title}>
+        <p>Preview</p>
+      </SiteSection>
+    );
+    expect(html).toContain(`href="${path}"`);
+    expect(html).toContain(`All ${title.toLowerCase()}`);
+    expect(html).not.toContain('target="_blank"');
+  }
+  const html = renderToStaticMarkup(
+    <SiteSection id="open-source" title="Open source">
+      <p>Projects</p>
+    </SiteSection>
+  );
+  expect(html).not.toContain("<a ");
+});


### PR DESCRIPTION
Adds right-aligned All writing and All work links beside the home page section headings, opening the existing /writing and /work pages. Uses a right arrow to distinguish page navigation from expandable work entries.

Validation: section link test, TypeScript, lint, and formatting checks pass. Local home page returned HTTP 200.
